### PR TITLE
Define all include directories not belonging to FairShip (e.g. root, boo...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include(WriteConfigFile)
 include(CTest)
 include(CheckCompiler)
 
+
 #Check the compiler and set the compile and link flags
 If(NOT CMAKE_BUILD_TYPE)
   Message("Set BuildType DEBUG")
@@ -143,6 +144,17 @@ find_package(HEPMC)
 # set a variable which should be used in all CMakeLists.txt
 # Defines all basic include directories from fairbase
 SetBasicVariables()
+
+# Add the FairRoot include directories to the list of libraries which are
+# external to the Ship project. For include directories in this list the
+# compiler will not generate any warnings. This is usefull since one is only
+# interested about warnings from the own project. SYSTEM_INCLUDE_DIRECTORIES
+# is defined in FairMacros.cmake. In the moment the defined directories are
+# the root and boost include directories. 
+Set(SYSTEM_INCLUDE_DIRECTORIES 
+  ${SYSTEM_INCLUDE_DIRECTORIES}
+  ${BASE_INCLUDE_DIRECTORIES}
+)
 
 # Set the library version in the main CMakeLists.txt
 SET(FAIRROOT_MAJOR_VERSION 0)

--- a/TauSensitive/CMakeLists.txt
+++ b/TauSensitive/CMakeLists.txt
@@ -3,14 +3,12 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${BASE_INCLUDE_DIRECTORIES}
 ${CMAKE_SOURCE_DIR}/shipdata
 ${CMAKE_SOURCE_DIR}/TauSensitive
-${ROOT_INCLUDE_DIR} 
-
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/ecal/CMakeLists.txt
+++ b/ecal/CMakeLists.txt
@@ -3,14 +3,13 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${ROOT_INCLUDE_DIR} 
-${BASE_INCLUDE_DIRECTORIES}
 #put here all directories where header files are located
 ${CMAKE_SOURCE_DIR}/shipdata
 ${CMAKE_SOURCE_DIR}/ecal
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/field/CMakeLists.txt
+++ b/field/CMakeLists.txt
@@ -3,12 +3,11 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${BASE_INCLUDE_DIRECTORIES} 
-${ROOT_INCLUDE_DIR}
 ${CMAKE_SOURCE_DIR}/field 
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/hcal/CMakeLists.txt
+++ b/hcal/CMakeLists.txt
@@ -3,14 +3,12 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${ROOT_INCLUDE_DIR} 
-${BASE_INCLUDE_DIRECTORIES}
-#put here all directories where header files are located
 ${CMAKE_SOURCE_DIR}/shipdata
 ${CMAKE_SOURCE_DIR}/hcal
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/muon/CMakeLists.txt
+++ b/muon/CMakeLists.txt
@@ -3,15 +3,12 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${ROOT_INCLUDE_DIR} 
-${BASE_INCLUDE_DIRECTORIES} 
-
-#put here all directories where header files are located
 ${CMAKE_SOURCE_DIR}/shipdata
 ${CMAKE_SOURCE_DIR}/muon
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/passive/CMakeLists.txt
+++ b/passive/CMakeLists.txt
@@ -3,13 +3,11 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${BASE_INCLUDE_DIRECTORIES}
 ${CMAKE_SOURCE_DIR}/passive
-${ROOT_INCLUDE_DIR} 
-
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/shipdata/CMakeLists.txt
+++ b/shipdata/CMakeLists.txt
@@ -3,12 +3,11 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${ROOT_INCLUDE_DIR} 
-${BASE_INCLUDE_DIRECTORIES}
 ${CMAKE_SOURCE_DIR}/shipdata
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/shipgen/CMakeLists.txt
+++ b/shipgen/CMakeLists.txt
@@ -3,16 +3,18 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${ROOT_INCLUDE_DIR} 
-${PYTHIA8_INCLUDE_DIR}
-${SIMPATH}/include
-${BASE_INCLUDE_DIRECTORIES} 
 ${CMAKE_SOURCE_DIR}/shipgen
 ${CMAKE_SOURCE_DIR}/generators
+)
 
+set(SYSTEM_INCLUDE_DIRECTORIES
+${SYSTEM_INCLUDE_DIRECTORIES}
+${PYTHIA8_INCLUDE_DIR}
+${SIMPATH}/include
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/strawtubes/CMakeLists.txt
+++ b/strawtubes/CMakeLists.txt
@@ -3,15 +3,12 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${ROOT_INCLUDE_DIR} 
-${BASE_INCLUDE_DIRECTORIES} 
-
-#put here all directories where header files are located
 ${CMAKE_SOURCE_DIR}/shipdata
 ${CMAKE_SOURCE_DIR}/strawtubes
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}

--- a/veto/CMakeLists.txt
+++ b/veto/CMakeLists.txt
@@ -3,15 +3,12 @@
 # The extension is already found.  Any number of sources could be listed here.
 
 set(INCLUDE_DIRECTORIES
-${ROOT_INCLUDE_DIR} 
-${BASE_INCLUDE_DIRECTORIES} 
-
-#put here all directories where header files are located
 ${CMAKE_SOURCE_DIR}/shipdata
 ${CMAKE_SOURCE_DIR}/veto
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}


### PR DESCRIPTION
...st, and fairroot include directories) as system include directories. For header files from these directories the compiler will not generate warnings. This avoid that the compiler output is flooded by warnings which doesn't belong to our project.