### PR TITLE
Replace eoslhcb addresses with full urls

### DIFF
--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -45,7 +45,7 @@ else:
  inputFile = 'ship.'+str(dy)+'.Pythia8-TGeant4_rec.root'
 
 if inputFile[0:4] == "/eos":
-  eospath = "root://eoslhcb/"+inputFile
+  eospath = "root://eoslhcb.cern.ch/"+inputFile
   f = ROOT.TFile.Open(eospath)
   sTree = f.cbmsim
 elif not inputFile.find(',')<0 :  
@@ -60,7 +60,7 @@ else:
 if not geoFile:
  geoFile = inputFile.replace('ship.','geofile_full.').replace('_rec.','.')
 if geoFile[0:4] == "/eos":
-  eospath = "root://eoslhcb/"+geoFile
+  eospath = "root://eoslhcb.cern.ch/"+geoFile
   fgeo = ROOT.TFile.Open(eospath)
 else:  
   fgeo = ROOT.TFile(geoFile)

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -640,7 +640,7 @@ fRun = ROOT.FairRunAna()
 if geoFile: fRun.SetGeomFile(geoFile)
 if os.path.islink(InputFile): 
   rfn = os.path.realpath(InputFile).split('eos')[1]
-  InputFile  = 'root://eoslhcb//eos/'+rfn
+  InputFile  = 'root://eoslhcb.cern.ch//eos/'+rfn
 
 if hasattr(fRun,'SetSource'):
  inFile = ROOT.FairFileSource(InputFile)

--- a/macro/mergeMbias.py
+++ b/macro/mergeMbias.py
@@ -10,7 +10,7 @@ Mmu  = mu.Mass()
 Mmu2 = Mmu * Mmu 
 rnr  = ROOT.TRandom()
 
-#eospath = "root://eoslhcb//eos/ship/data/"
+#eospath = "root://eoslhcb.cern.ch//eos/ship/data/"
 eospath = "/media/Data/HNL/ShipSoft/data/"
 ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_config.py", Yheight = 10.)
 endOfHadronAbsorber = (ship_geo['hadronAbsorber'].z + ship_geo['hadronAbsorber'].length/2.) /100.

--- a/muonShieldOptimization/ana_ShipMuon.py
+++ b/muonShieldOptimization/ana_ShipMuon.py
@@ -549,7 +549,7 @@ def BigEventLoop():
  for fn in fchain: 
   if os.path.islink(fn): 
     rfn = os.path.realpath(fn).split('eos')[1]
-    fn  = 'root://eoslhcb//eos/'+rfn
+    fn  = 'root://eoslhcb.cern.ch//eos/'+rfn
   elif not os.path.isfile(fn): 
     print "Don't know what to do with",fn
     1/0 

--- a/python/rootUtils.py
+++ b/python/rootUtils.py
@@ -12,7 +12,7 @@ import os,sys
 
 def readHists(h,fname):
   if fname[0:4] == "/eos":
-    eospath = "root://eoslhcb/"+fname
+    eospath = "root://eoslhcb.cern.ch/"+fname
     f = ROOT.TFile.Open(eospath)
   else:  
     f = TFile(fname)

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -32,7 +32,7 @@ Bool_t GenieGenerator::Init(const char* fileName, const int firstEvent) {
   fLogger = FairLogger::GetLogger();
   if (0 == strncmp("/eos",fileName,4) ) {
    char stupidCpp[100];
-   strcpy(stupidCpp,"root://eoslhcb/");
+   strcpy(stupidCpp,"root://eoslhcb.cern.ch/");
    strcat(stupidCpp,fileName);
    fInputFile  = TFile::Open(stupidCpp); 
    fLogger->Info(MESSAGE_ORIGIN,"Opening input file on eos %s",stupidCpp);

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -39,7 +39,7 @@ Bool_t HNLPythia8Generator::Init()
   if (fextFile != ""){
     if (0 == strncmp("/eos",fextFile,4) ) {
      char stupidCpp[100];
-     strcpy(stupidCpp,"root://eoslhcb/");
+     strcpy(stupidCpp,"root://eoslhcb.cern.ch/");
      strcat(stupidCpp,fextFile);
      fLogger->Info(MESSAGE_ORIGIN,"Open external file with charm or beauty hadrons on eos: %s",stupidCpp);
      fInputFile  = TFile::Open(stupidCpp); 

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -36,7 +36,7 @@ Bool_t MuDISGenerator::Init(const char* fileName, const int firstEvent) {
   dPart = 0; 
   if (0 == strncmp("/eos",fileName,4) ) {
     char stupidCpp[100];
-    strcpy(stupidCpp,"root://eoslhcb/");
+    strcpy(stupidCpp,"root://eoslhcb.cern.ch/");
     strcat(stupidCpp,fileName);
     fInputFile  = TFile::Open(stupidCpp); 
     fLogger->Info(MESSAGE_ORIGIN,"Open external file on eos: %s",stupidCpp);

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -22,7 +22,7 @@ Bool_t MuonBackGenerator::Init(const char* fileName, const int firstEvent, const
   fLogger->Info(MESSAGE_ORIGIN,"Opening input file %s",fileName);
   if (0 == strncmp("/eos",fileName,4) ) {
      char stupidCpp[100];
-     strcpy(stupidCpp,"root://eoslhcb/");
+     strcpy(stupidCpp,"root://eoslhcb.cern.ch/");
      strcat(stupidCpp,fileName);
      fInputFile  = TFile::Open(stupidCpp); 
   }else{


### PR DESCRIPTION
Dear Thomas,

Outside of the CERN network eos seems to be only accessible if we use the full address using the cern.ch domain (see the email thread with Jacques and Francois on the ship-software list).

This patch is a simple search-and-replace which will hopefully fix most of the related issues. It should be automatically merge-able. 

For machines within the CERN network the change should not change anything.

All the best,

Oliver