### PR TITLE
Fix of possible bug in ShipReco.hit2wire

### DIFF
--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -219,15 +219,11 @@ class ShipReco:
      top = ROOT.TVector3()
      bot = ROOT.TVector3()
      modules["Strawtubes"].StrawEndPoints(detID,bot,top)
-     ex = ahit.GetX()
-     ey = ahit.GetY()
-     ez = ahit.GetZ()
    #distance to wire, and smear it.
      dw  = ahit.dist2Wire()
      smear = dw
      if not no_amb: smear = abs(self.random.Gaus(dw,ShipGeo.straw.resol))
      smearedHit = {'mcHit':ahit,'xtop':top.x(),'ytop':top.y(),'z':top.z(),'xbot':bot.x(),'ybot':bot.y(),'z':bot.z(),'dist':smear}
-     # print 'smeared hit:',top.x(),top.y(),top.z(),bot.x(),bot.y(),bot.z(),"dist",smear,ex,ey,ez,ox,oy,oz
      if abs(top.y())==abs(bot.y()): h['disty'].Fill(dw)
      if abs(top.y())>abs(bot.y()): h['distu'].Fill(dw)
      if abs(top.y())<abs(bot.y()): h['distv'].Fill(dw)

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -223,7 +223,8 @@ class ShipReco:
      dw  = ahit.dist2Wire()
      smear = dw
      if not no_amb: smear = abs(self.random.Gaus(dw,ShipGeo.straw.resol))
-     smearedHit = {'mcHit':ahit,'xtop':top.x(),'ytop':top.y(),'z':top.z(),'xbot':bot.x(),'ybot':bot.y(),'z':bot.z(),'dist':smear}
+     smearedHit = {'mcHit':ahit,'xtop':top.x(),'ytop':top.y(),'z':top.z(),'xbot':bot.x(),'ybot':bot.y(),'dist':smear}
+     # Note: top.z()==bot.z() unless misaligned, so only add key 'z' to smearedHit
      if abs(top.y())==abs(bot.y()): h['disty'].Fill(dw)
      if abs(top.y())>abs(bot.y()): h['distu'].Fill(dw)
      if abs(top.y())<abs(bot.y()): h['distv'].Fill(dw)


### PR DESCRIPTION
I stumbled across some duplicated dictionary keys that are later accessed. In my analysis I can't tell whether it affects any results negatively, but that may not be generally true.

If this is indeed intentional, maybe we could add a comment and remove the earlier, overwritten assignment?

I also removed some variables only referenced in a commented out piece of code.

-- Oliver

