### PR TITLE
Fix lcg.sh not being found on lxplus/lxbatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,7 @@ If(${distribution} MATCHES "ScientificCERNSLC")
  file(APPEND ${CMAKE_BINARY_DIR}/config.sh  "perl -i -ne 'print if ! \$a{\$_}++' lcg.sh\n")
  file(APPEND ${CMAKE_BINARY_DIR}/config.csh "perl -i -ne 'print if ! \$a{\$_}++' lcg.csh\n")
  file(APPEND ${CMAKE_BINARY_DIR}/config.csh "source lcg.csh\n")
- file(APPEND ${CMAKE_BINARY_DIR}/config.sh  "source lcg.sh\n")
+ file(APPEND ${CMAKE_BINARY_DIR}/config.sh  "source ./lcg.sh\n")
  file(APPEND ${CMAKE_BINARY_DIR}/config.csh "rm lcg.csh\n")
  file(APPEND ${CMAKE_BINARY_DIR}/config.sh  "rm lcg.sh\n")
  


### PR DESCRIPTION
When sourcing FairShipRun/config.sh lcg.sh is not found on line 64 of the original script. It seems explicitly giving the relative location with ./ fixes this on both lxplus and lxbatch.

Maybe something similar needs to be done for the .csh script as well.