### PR TITLE
Correct magnet length

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -186,9 +186,9 @@ with ConfigRegistry.register_config("basic") as c:
     c.muShield       =  AttrDict(z=0*u.cm)
     c.muShieldDesign = muShieldDesign
     # design 4,5,6
-    c.muShield.LE  = 10*u.m     #- 0.5 m air - Goliath: 4.5 m - 0.5 m air - nu-tau mu-det: 3 m - 0.5 m air. finally 10m asked by Giovanni
+    c.muShield.LE  = 10*u.m     # - 0.5 m air - Goliath: 4.5 m - 0.5 m air - nu-tau mu-det: 3 m - 0.5 m air. finally 10m asked by Giovanni
     if muShieldDesign == 6: c.muShield.dZ0 = 2.5*u.m 
-    else:                   c.muShield.dZ0 = 1*u.m      #  extra hadron absorber
+    else:                   c.muShield.dZ0 = 1*u.m      # extra hadron absorber
     c.muShield.dZ1 = 3.5*u.m
     c.muShield.dZ2 = 6.*u.m
     c.muShield.dZ3 = 2.5*u.m
@@ -202,19 +202,18 @@ with ConfigRegistry.register_config("basic") as c:
     if muShieldDesign == 7:
         c.muShield.dZ1 = 0.7*u.m
         c.muShield.dZ2 = 1.7*u.m
-        c.muShield.dZ3 = 4.*u.m
-        c.muShield.dZ4 = 2.75*u.m
-        c.muShield.dZ5 = 2.4*u.m 
-        c.muShield.dZ6 = 3.*u.m
-        c.muShield.dZ7 = 2.35*u.m
+        c.muShield.dZ3 = 4.05*u.m
+        c.muShield.dZ4 = 2.80*u.m
+        c.muShield.dZ5 = 2.45*u.m
+        c.muShield.dZ6 = 3.05*u.m
+        c.muShield.dZ7 = 2.40*u.m
         c.muShield.dZ8 = 0.*u.m
         c.muShield.dXgap = 0.*u.m
         c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
                          +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 
         c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2.
 
-    if muShieldDesign == 3: 
-     c.muShield.LE  = 10*u.m     #- 0.5 m air - Goliath: 4.5 m - 0.5 m air - nu-tau mu-det: 3 m - 0.5 m air. finally 10m asked by Giovanni
+    if muShieldDesign == 3:
      c.muShield.dZ0 = 1*u.m      #  extra hadron absorber
      c.muShield.dZ1 = 3.5*u.m
      c.muShield.dZ2 = 5.*u.m
@@ -226,7 +225,7 @@ with ConfigRegistry.register_config("basic") as c:
      c.muShield.dZ8 = 3.*u.m
      c.muShield.dXgap = 0.2*u.m
 
-    if muShieldDesign == 2: 
+    if muShieldDesign == 2:
      c.muShield.dZ0 = 0*u.m      #  extra hadron absorber
      c.muShield.dZ1 = 2.5*u.m
      c.muShield.dZ2 = 3.5*u.m
@@ -237,7 +236,7 @@ with ConfigRegistry.register_config("basic") as c:
      c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+
                          c.muShield.dZ5+c.muShield.dZ6) + c.muShield.LE  # leave some space for nu-tau detector   
     # for passive design, fDesign==1
-    if muShieldDesign == 1: 
+    if muShieldDesign == 1:
         c.muShield.length =  70*u.m 
         c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2. - c.muShield.LE  # leave some space for nu-tau 
     if muShieldDesign == 3 or muShieldDesign == 4 or muShieldDesign == 5 : 

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -216,7 +216,6 @@ with ConfigRegistry.register_config("basic") as c:
         c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2.
 
     if muShieldDesign == 3:
-     c.muShield.dZ0 = 1*u.m      #  extra hadron absorber
      c.muShield.dZ1 = 3.5*u.m
      c.muShield.dZ2 = 5.*u.m
      c.muShield.dZ3 = 3.5*u.m

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -167,11 +167,11 @@ with ConfigRegistry.register_config("basic") as c:
     c.MuonStation1 = AttrDict(z=c.MuonStation0.z+1*u.m)
     c.MuonStation2 = AttrDict(z=c.MuonStation0.z+2*u.m)
     c.MuonStation3 = AttrDict(z=c.MuonStation0.z+3*u.m)
-    
+
     c.MuonFilter0 = AttrDict(z=c.MuonStation0.z+50.*u.cm)
     c.MuonFilter1 = AttrDict(z=c.MuonStation0.z+150.*u.cm)
     c.MuonFilter2 = AttrDict(z=c.MuonStation0.z+250.*u.cm)
-     
+
     c.Muon = AttrDict(z=0)
     c.Muon.XMax    =  300.*u.cm
     c.Muon.YMax    =  600.*u.cm * c.Yheight / (10.*u.m)
@@ -187,8 +187,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.muShieldDesign = muShieldDesign
     # design 4,5,6
     c.muShield.LE  = 10*u.m     # - 0.5 m air - Goliath: 4.5 m - 0.5 m air - nu-tau mu-det: 3 m - 0.5 m air. finally 10m asked by Giovanni
-    if muShieldDesign == 6: c.muShield.dZ0 = 2.5*u.m 
-    else:                   c.muShield.dZ0 = 1*u.m      # extra hadron absorber
+    c.muShield.dZ0 = 2.5*u.m if muShieldDesign == 6 else 1*u.m
     c.muShield.dZ1 = 3.5*u.m
     c.muShield.dZ2 = 6.*u.m
     c.muShield.dZ3 = 2.5*u.m
@@ -198,15 +197,18 @@ with ConfigRegistry.register_config("basic") as c:
     c.muShield.dZ7 = 3.*u.m
     c.muShield.dZ8 = 3.*u.m
     c.muShield.dXgap = 0.2*u.m
+    c.muShield.dZgap = 0.1*u.m
 
+    # zGap to compensate automatic shortening of magnets
+    zGap = 0.5 * c.muShield.dZgap  # halflengh of gap
     if muShieldDesign == 7:
         c.muShield.dZ1 = 0.7*u.m
         c.muShield.dZ2 = 1.7*u.m
-        c.muShield.dZ3 = 4.05*u.m
-        c.muShield.dZ4 = 2.80*u.m
-        c.muShield.dZ5 = 2.45*u.m
-        c.muShield.dZ6 = 3.05*u.m
-        c.muShield.dZ7 = 2.40*u.m
+        c.muShield.dZ3 = 4.0*u.m + zGap
+        c.muShield.dZ4 = 2.75*u.m + zGap
+        c.muShield.dZ5 = 2.4*u.m + zGap
+        c.muShield.dZ6 = 3.0*u.m + zGap
+        c.muShield.dZ7 = 2.35*u.m + zGap
         c.muShield.dZ8 = 0.*u.m
         c.muShield.dXgap = 0.*u.m
         c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
@@ -239,11 +241,11 @@ with ConfigRegistry.register_config("basic") as c:
     if muShieldDesign == 1:
         c.muShield.length =  70*u.m 
         c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2. - c.muShield.LE  # leave some space for nu-tau 
-    if muShieldDesign == 3 or muShieldDesign == 4 or muShieldDesign == 5 : 
+    if muShieldDesign == 3 or muShieldDesign == 4 or muShieldDesign == 5: 
      c.muShield.length = 2*(c.muShield.dZ0+c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
                          +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 
      c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2.
-    if muShieldDesign == 6 : 
+    if muShieldDesign == 6: 
      c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
                          +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 
      c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2.


### PR DESCRIPTION
Hi Thomas,

Here the fixed magnet lengths. I will split magnet `dZ3` in a separate pull request, probably by using `dZ8` in the muonshield config 7. So far I've only corrected config 7, but I can also fix the gaps for configuration 6 if required.

Also some minor cosmetic changes, deleted duplicate assignments and superfluous whitespace. I've only touched the muon shield section though.

Let me know if you'd like me to make any changes. I can also rebase to combine all changes into a single commit if you prefer that.

Cheers,
    Oliver

### Background for those who don't know about the gaps:

The muon shield `C++` code automatically shortens magnets to add gaps, i.e. the lengths given in `geometry_config.py` should be the lengths including gaps. But the current lengths did not account for that and as a result every magnet is 10cm shorter than it should be. By now accounting for the gaps automatically in `geometry_config.py` this is fixed.