### PR TITLE
Add supports and elevated floor for the muon shield

### DIFF
--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -140,7 +140,7 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
 				  Double_t gap,Double_t gap2, Double_t Z, Bool_t NotMagnet)
   {
     Double_t Clgap,Clgap2;
-    int color[4];
+    int color[4] = {30,31,38,45};
 
     if (NotMagnet) {
       Clgap = gap;
@@ -152,7 +152,6 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
       gap2 = std::max(2., gap2);
     }
 
-    color[0] = 30; color[1] = 31; color[2] = 38; color[3] = 45;
 
     Int_t testGap = 0.1;   // gap between fields in the corners for mitred joints (Geant goes crazy when they touch each other)
 				 

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -152,8 +152,8 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
       gap2 = std::max(2., gap2);
     }
 
+    Double_t testGap = 0.1;   // gap between fields in the corners for mitred joints (Geant goes crazy when they touch each other)
 
-    Int_t testGap = 0.1;   // gap between fields in the corners for mitred joints (Geant goes crazy when they touch each other)
 				 
     Double_t cornerMainL[16] = {-dX/2+middleGap+dX/2,-dY-dX+testGap , -dX/2+middleGap+dX/2,dY+dX-testGap , dX/2+middleGap+dX/2,dY-testGap , dX/2+middleGap+dX/2,-dY+testGap ,
                                -dX2/2+middleGap2+dX2/2,-dY2-dX2+testGap , -dX2/2+middleGap2+dX2/2,dY2+dX2-testGap , dX2/2+middleGap2+dX2/2,dY2-testGap , dX2/2+middleGap2+dX2/2,-dY2+testGap };

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -141,15 +141,16 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
   {
     Double_t Clgap,Clgap2;
     int color[4];
-    
-    if (gap<20&&NotMagnet==0){
-      Clgap =20;
-      if(gap<2.){gap=2.;}
-    }else{Clgap=gap;}
-    if (gap2<20&&NotMagnet==0){
-      Clgap2 =20;
-      if(gap2<2.){gap2=2.;}
-    }else{Clgap2=gap2;}
+
+    if (NotMagnet) {
+      Clgap = gap;
+      Clgap2 = gap2;
+    } else {
+      Clgap = std::max(20., gap);
+      Clgap2 = std::max(20., gap2);
+      gap = std::max(2., gap);
+      gap2 = std::max(2., gap2);
+    }
 
     color[0] = 30; color[1] = 31; color[2] = 38; color[3] = 45;
 

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -409,17 +409,33 @@ void ShipMuonShield::ConstructGeometry()
       mag1->RegisterYourself();
       mag2->RegisterYourself();
 
-      TGeoTube *abs = new TGeoTube("absorber",0,400,(dZ1+dZ2-15));
- // TODO: names should be picked up automatically - work in progress :D
-       TString holl = "MagnAbsorb1_MiddleMagL:mag1-MagnAbsorb1_MiddleMagR:mag1-MagnAbsorb1_MagRetL:mag1-MagnAbsorb1_MagRetR:mag1-MagnAbsorb1_MagCLB:mag1-MagnAbsorb1_MagCLT:mag1-MagnAbsorb1_MagCRT:mag1-MagnAbsorb1_MagCRB:mag1\
-   -MagnAbsorb1_MagTopLeft:mag1-MagnAbsorb1_MagTopRight:mag1-MagnAbsorb1_MagBotLeft:mag1-MagnAbsorb1_MagBotRight:mag1\
-   -MagnAbsorb2_MiddleMagL:mag2-MagnAbsorb2_MiddleMagR:mag2-MagnAbsorb2_MagRetL:mag2-MagnAbsorb2_MagRetR:mag2-MagnAbsorb2_MagCLB:mag2-MagnAbsorb2_MagCLT:mag2-MagnAbsorb2_MagCRT:mag2-MagnAbsorb2_MagCRB:mag2\
-   -MagnAbsorb2_MagTopLeft:mag2-MagnAbsorb2_MagTopRight:mag2-MagnAbsorb2_MagBotLeft:mag2-MagnAbsorb2_MagBotRight:mag2";
-   TGeoCompositeShape *absorberShape = new TGeoCompositeShape("Absorber","absorber-"+holl); // cutting out magnet parts from absorber 
-     TGeoVolume *absorber = new TGeoVolume("AbsorberVol",absorberShape,iron);
-    absorber->SetLineColor(42); // brown / light red
-    tShield->AddNode(absorber, 1, new TGeoTranslation(0, 0, zEndOfAbsorb + (dZ1+dZ2)));
-         
+      TGeoTube *abs = new TGeoTube("absorber", 0, 400, (dZ1 + dZ2 - 15));
+      const std::vector<TString> absorber_magnets = {"MagnAbsorb1",
+						     "MagnAbsorb2"};
+      const std::vector<TString> magnet_components = {
+	  "_MiddleMagL", "_MiddleMagR",  "_MagRetL",    "_MagRetR",
+	  "_MagCLB",     "_MagCLT",      "_MagCRT",     "_MagCRB",
+	  "_MagTopLeft", "_MagTopRight", "_MagBotLeft", "_MagBotRight",
+      };
+      TString absorber_magnet_components;
+      for (auto &&magnet_component : magnet_components) {
+	// format: "-<magnetName>_<magnet_component>:<translation>"
+	absorber_magnet_components +=
+	    ("-" + absorber_magnets[0] + magnet_component + ":" +
+	     mag1->GetName());
+	absorber_magnet_components +=
+	    ("-" + absorber_magnets[1] + magnet_component + ":" +
+	     mag2->GetName());
+      }
+      TGeoCompositeShape *absorberShape = new TGeoCompositeShape(
+	  "Absorber", "absorber" + absorber_magnet_components); // cutting out
+								// magnet parts
+								// from absorber
+      TGeoVolume *absorber = new TGeoVolume("AbsorberVol", absorberShape, iron);
+      absorber->SetLineColor(42); // brown / light red
+      tShield->AddNode(absorber, 1,
+		       new TGeoTranslation(0, 0, zEndOfAbsorb + (dZ1 + dZ2)));
+
       for(int nM=2;nM<7;nM++)
       {
 	  CreateMagnet(magnetName[nM],iron,tShield,fields,fieldDirection[nM],


### PR DESCRIPTION
Hi Thomas,

Attached my changes to the ShipMuonShield.cxx for the supports and floor.

The logic for the supports is fully contained in commit  660e70d .

The other commits are small cosmetic changes (mostly in an attempt to make the code easier to understand). There's also a bugfix for an incorrect type (`Int_t testGap = 0.1;` results in `testGap == 1`), which is not the intention, but C++ automatically converts this.

As usual, if you'd like me to change anything, remove commits, or merge into a single commit, let me know.

Cheers,
    Oliver

PS: Do we have a convention whether to use `double/int` or `Double_t/Int_t`?