### PR TITLE
Restore overlap gap to 0 for TP for backwards compability

### DIFF
--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -152,9 +152,11 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
       gap2 = std::max(2., gap2);
     }
 
-    Double_t testGap = 0.1;   // gap between fields in the corners for mitred joints (Geant goes crazy when they touch each other)
+    Double_t testGap = (fDesign == 5) ? 0.0 : 0.1; // gap between fields in the
+						   // corners for mitred joints
+						   // (Geant goes crazy when
+						   // they touch each other)
 
-				 
     Double_t cornerMainL[16] = {-dX/2+middleGap+dX/2,-dY-dX+testGap , -dX/2+middleGap+dX/2,dY+dX-testGap , dX/2+middleGap+dX/2,dY-testGap , dX/2+middleGap+dX/2,-dY+testGap ,
                                -dX2/2+middleGap2+dX2/2,-dY2-dX2+testGap , -dX2/2+middleGap2+dX2/2,dY2+dX2-testGap , dX2/2+middleGap2+dX2/2,dY2-testGap , dX2/2+middleGap2+dX2/2,-dY2+testGap };
     Double_t cornerMainR[16] = {-dX/2-middleGap-dX/2,-dY+testGap , -dX/2-middleGap-dX/2,dY-testGap , dX/2-middleGap-dX/2,dY+dX-testGap , dX/2-middleGap-dX/2,-dY-dX+testGap ,


### PR DESCRIPTION
Hi Thomas,

This pull request restores the testGap to 0 for the TP design. Having non-zero testGap introduces a bug in the TP design and changes its behaviour. This bug was introduces in 0083604c539601117815b9183eaea03f5c16dc56 where the automatic casting to int was fixed and testGap was changed to the value it was intended to have.

I will investigate why this does not seem to affect the new design and fix the testGap logic if necessary in a separate pull request.

Cheers,
Oliver