### PR TITLE
Split largest magnet for engineering reasons

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -210,12 +210,12 @@ with ConfigRegistry.register_config("basic") as c:
     if muShieldDesign == 7:
         c.muShield.dZ1 = 0.7*u.m
         c.muShield.dZ2 = 1.7*u.m
-        c.muShield.dZ3 = 4.0*u.m + zGap
-        c.muShield.dZ4 = 2.75*u.m + zGap
-        c.muShield.dZ5 = 2.4*u.m + zGap
-        c.muShield.dZ6 = 3.0*u.m + zGap
-        c.muShield.dZ7 = 2.35*u.m + zGap
-        c.muShield.dZ8 = 0.*u.m
+        c.muShield.dZ3 = 2.0*u.m + zGap
+        c.muShield.dZ4 = 2.0*u.m + zGap
+        c.muShield.dZ5 = 2.75*u.m + zGap
+        c.muShield.dZ6 = 2.4*u.m + zGap
+        c.muShield.dZ7 = 3.0*u.m + zGap
+        c.muShield.dZ8 = 2.35*u.m + zGap
         c.muShield.dXgap = 0.*u.m
         c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
                          +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -72,7 +72,9 @@ ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char*
      dZ5 = L5;
      dZ6 = L6;
      dZ7 = L7;
-     fMuonShieldLength = 2*(dZ1+dZ2+dZ3+dZ4+dZ5+dZ6+dZ7) + LE ;
+     dZ8 = L8;
+     fMuonShieldLength =
+	 2 * (dZ1 + dZ2 + dZ3 + dZ4 + dZ5 + dZ6 + dZ7 + dZ8) + LE;
    }
     
  fFloor = (fDesign == 7) ? floor : 0;
@@ -235,9 +237,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[8],const char* (&fiel
 				  Double_t (&HmainSideMagIn)[8], Double_t (&HmainSideMagOut)[8],
 				  Double_t (&gapIn)[8],Double_t (&gapOut)[8], Double_t (&Z)[8])
 {
-  Double_t zgap;
-  if(fDesign>6){zgap = 10;}
-  else{zgap = 0;}               // fixed distance between magnets in Z-axis 
+  Double_t zgap = (fDesign > 6) ? 10 : 0;  // fixed distance between magnets in Z-axis
   Double_t dYEnd = fY;
   if(fDesign==7){
       
@@ -259,44 +259,51 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[8],const char* (&fiel
     
   magnetName[2] = "Magn1";		fieldDirection[2] = "up";
   dXIn[2]  = 0.87*m;			dYIn[2]	= 0.35*m;
-  dXOut[2] = 0.43*m;			dYOut[2]= 2.07*m;
+  dXOut[2] = 0.65*m;			dYOut[2]= 1.21*m;
   midGapIn[2] = 0; 			midGapOut[2] = 0;
   HmainSideMagIn[2] = dYIn[2]/2;  	HmainSideMagOut[2] = dYOut[2]/2;
   gapIn[2] = 0.11*m;				gapOut[2] = 0.02*m;
   dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
 
   magnetName[3] = "Magn2";		fieldDirection[3] = "up";
-  dXIn[3]  = 0.06*m;			dYIn[3]	= 0.32*m;
-  dXOut[3] = 0.33*m;			dYOut[3]= 0.13*m;
+  dXIn[3]  = 0.65*m;			dYIn[3]	= 1.21*m;
+  dXOut[3] = 0.43*m;			dYOut[3]= 2.07*m;
   midGapIn[3] = 0; 			midGapOut[3] = 0;
   HmainSideMagIn[3] = dYIn[3]/2;  	HmainSideMagOut[3] = dYOut[3]/2;
-  gapIn[3] = 0.7*m;			gapOut[3] = 0.11*m;
+  gapIn[3] = 0.11*m;				gapOut[3] = 0.02*m;
   dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
-  
-  magnetName[4] = "Magn3";		fieldDirection[4] = "down";
-  dXIn[4]  = 0.05*m;			dYIn[4]	= 1.12*m;
-  dXOut[4] =0.16*m;			dYOut[4]= 0.05*m;
+
+  magnetName[4] = "Magn3";		fieldDirection[4] = "up";
+  dXIn[4]  = 0.06*m;			dYIn[4]	= 0.32*m;
+  dXOut[4] = 0.33*m;			dYOut[4]= 0.13*m;
   midGapIn[4] = 0; 			midGapOut[4] = 0;
   HmainSideMagIn[4] = dYIn[4]/2;  	HmainSideMagOut[4] = dYOut[4]/2;
-  gapIn[4] = 0.04*m;			gapOut[4] = 0.02*m;
+  gapIn[4] = 0.7*m;			gapOut[4] = 0.11*m;
   dZ[4] = dZ5-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
   
   magnetName[5] = "Magn4";		fieldDirection[5] = "down";
-  dXIn[5]  = 0.15*m;			dYIn[5]	= 2.35*m;
-  dXOut[5] = 0.34*m;			dYOut[5]= 0.32*m;
-  midGapIn[5] = 0; 		        midGapOut[5] = 0;
+  dXIn[5]  = 0.05*m;			dYIn[5]	= 1.12*m;
+  dXOut[5] =0.16*m;			dYOut[5]= 0.05*m;
+  midGapIn[5] = 0; 			midGapOut[5] = 0;
   HmainSideMagIn[5] = dYIn[5]/2;  	HmainSideMagOut[5] = dYOut[5]/2;
-  gapIn[5] = 0.05*m;			gapOut[5] = 0.08*m;
+  gapIn[5] = 0.04*m;			gapOut[5] = 0.02*m;
   dZ[5] = dZ6-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
   
-  
   magnetName[6] = "Magn5";		fieldDirection[6] = "down";
-  dXIn[6]  = 0.31*m;			dYIn[6]	= 1.86*m;
-  dXOut[6] = 0.9*m;			dYOut[6]= 3.1*m;
+  dXIn[6]  = 0.15*m;			dYIn[6]	= 2.35*m;
+  dXOut[6] = 0.34*m;			dYOut[6]= 0.32*m;
   midGapIn[6] = 0; 		        midGapOut[6] = 0;
   HmainSideMagIn[6] = dYIn[6]/2;  	HmainSideMagOut[6] = dYOut[6]/2;
-  gapIn[6] = 0.02*m;			gapOut[6] = 0.55*m;
+  gapIn[6] = 0.05*m;			gapOut[6] = 0.08*m;
   dZ[6] = dZ7-zgap/2;			Z[6] = Z[5] + dZ[5] + dZ[6]+zgap;
+  
+  magnetName[7] = "Magn6";		fieldDirection[7] = "down";
+  dXIn[7]  = 0.31*m;			dYIn[7]	= 1.86*m;
+  dXOut[7] = 0.9*m;			dYOut[7]= 3.1*m;
+  midGapIn[7] = 0; 		        midGapOut[7] = 0;
+  HmainSideMagIn[7] = dYIn[7]/2;  	HmainSideMagOut[7] = dYOut[7]/2;
+  gapIn[7] = 0.02*m;			gapOut[7] = 0.55*m;
+  dZ[7] = dZ8-zgap/2;			Z[7] = Z[6] + dZ[6] + dZ[7]+zgap;
       
     }
   else{
@@ -383,9 +390,15 @@ void ShipMuonShield::ConstructGeometry()
       if(fDesign==7){
             TGeoUniformMagField *fieldsTarget[4] = {new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.)};
       }
-      
-      const char* magnetName[8]; const char* fieldDirection[8];
-      Double_t dXIn[8],dYIn[8],dXOut[8],dYOut[8],dZf[8],midGapIn[8],midGapOut[8],HmainSideMagIn[8],HmainSideMagOut[8],gapIn[8],gapOut[8],Z[8];
+      Int_t nMagnets = (fDesign == 7) ? 9 : 8;
+
+      // need to use literal 8 here as initialisation function's signature requires it.
+      // TODO use nMagnets, std::vector and TString!
+      const char *magnetName[8];
+      const char *fieldDirection[8];
+      Double_t dXIn[8], dYIn[8], dXOut[8], dYOut[8], dZf[8], midGapIn[8],
+	  midGapOut[8], HmainSideMagIn[8], HmainSideMagOut[8], gapIn[8],
+	  gapOut[8], Z[8];
       Initialize (magnetName,fieldDirection,dXIn,dYIn,dXOut,dYOut,dZf,midGapIn,midGapOut,HmainSideMagIn,HmainSideMagOut,gapIn,gapOut,Z);
       
       if (fDesign==6){
@@ -442,8 +455,7 @@ void ShipMuonShield::ConstructGeometry()
       tShield->AddNode(absorber, 1,
 		       new TGeoTranslation(0, 0, zEndOfAbsorb + (dZ1 + dZ2)));
 
-      for(Int_t nM=2;nM<7;nM++)
-      {
+      for (Int_t nM = 2; nM < (nMagnets - 1); nM++) {
 	CreateMagnet(magnetName[nM], iron, tShield, fields, fieldDirection[nM],
 		     dXIn[nM], dYIn[nM], dXOut[nM], dYOut[nM], dZf[nM],
 		     midGapIn[nM], midGapOut[nM], HmainSideMagIn[nM],
@@ -499,14 +511,13 @@ void ShipMuonShield::ConstructGeometry()
 	CreateTube("AbsorberAdd", iron, 15, 400, dZ0, 43, tShield, 1, 0, 0, zEndOfAbsorb - dZ0);
 	CreateTube("AbsorberAddCore", iron, 0, 15, dZ0, 38, tShield, 1, 0, 0, zEndOfAbsorb - dZ0);
 
-	for (Int_t nM = 0; nM < 7; nM++) {
+	for (Int_t nM = 0; nM < (nMagnets - 1); nM++) {
 	  CreateMagnet(magnetName[nM],iron,tShield,fields,fieldDirection[nM],
 		   dXIn[nM],dYIn[nM],dXOut[nM],dYOut[nM],dZf[nM],
 		   midGapIn[nM],midGapOut[nM],HmainSideMagIn[nM],HmainSideMagOut[nM],
 		   gapIn[nM],gapOut[nM],Z[nM],0);
+	}
       }
-      }
-      Double_t ZGmid=Z[7]+dZf[7]+2.25*m+0.2*m;
       Double_t dX1 = dXIn[0];
       Double_t dY = dYIn[0];
 


### PR DESCRIPTION
Hi Thomas,

Next pull request: Split the first, too long, magnet in two for design 7. As is is the first magnet all other magnets unfortunately need to be shifted in the magnet array.

The unused length dZ8 is used now, so the constructor does not need to be changed, but some logic needed to be changed to allow using the correct number of magnets,  as this number now depends on the magnet design. 

This change also prepares the clipped corners of the last wing and the move to vectors.

Cheers,
Oliver