### PR TITLE
Define floor using geometry_config.py

### DIFF
--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -39,11 +39,11 @@ ShipMuonShield::ShipMuonShield()
 
 ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char* Title, 
                                Double_t Z, Double_t L0, Double_t L1, Double_t L2, Double_t L3, Double_t L4, Double_t L5, Double_t L6,
-                               Double_t L7, Double_t L8, Double_t gap, Double_t LE, Double_t y, Double_t fl)
+                               Double_t L7, Double_t L8, Double_t gap, Double_t LE, Double_t y, Double_t floor, Double_t field)
   : FairModule(name ,Title)
 {
  fDesign = Design;
- fField  = fl;
+ fField  = field;
  if (fDesign==1){
      fMuonShieldLength = L1;   
     }
@@ -77,6 +77,8 @@ ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char*
 	 2 * (dZ1 + dZ2 + dZ3 + dZ4 + dZ5 + dZ6 + dZ7 + dZ8) + LE;
    }
     
+ fFloor = (fDesign == 7) ? floor : 0;
+
  zEndOfAbsorb = Z + dZ0 - fMuonShieldLength/2.;   
  if(fDesign==6||fDesign==7){zEndOfAbsorb = Z - fMuonShieldLength/2.;}
  fY = y;
@@ -475,14 +477,13 @@ void ShipMuonShield::ConstructGeometry()
 	// TODO split out into function/method?
 	Double_t dymax = std::max(dYIn[nM] + dXIn[nM], dYOut[nM] + dXOut[nM]);
 	Double_t dymin = std::min(dYIn[nM] + dXIn[nM], dYOut[nM] + dXOut[nM]);
-	Double_t floor = -5. * m; // TODO use same variable for floor definition
 	Double_t slope =
 	    (dYIn[nM] + dXIn[nM] - dYOut[nM] - dXOut[nM]) / (2 * dZf[nM]);
 	Double_t w1 = 2 * dXIn[nM] + std::max(20., gapIn[nM]);
 	Double_t w2 = 2 * dXOut[nM] + std::max(20., gapOut[nM]);
 	Double_t anti_overlap = 0.1;
-	Double_t h1 = 0.5 * (floor + dYIn[nM] + dXIn[nM] + anti_overlap);
-	Double_t h2 = 0.5 * (floor + dYOut[nM] + dXOut[nM] + anti_overlap);
+	Double_t h1 = 0.5 * (dYIn[nM] + dXIn[nM] + anti_overlap - fFloor);
+	Double_t h2 = 0.5 * (dYOut[nM] + dXOut[nM] + anti_overlap - fFloor);
 	std::vector<Double_t> verticesIn = {
 	    -w1, -h1,
 	    +w1, -h1,
@@ -512,10 +513,10 @@ void ShipMuonShield::ConstructGeometry()
 	pillar1->SetLineColor(kGreen-5);
 	pillar2->SetLineColor(kGreen-5);
 	tShield->AddNode(pillar1, 1, new TGeoTranslation(
-				     0, -0.5 * (dYIn[nM] + dXIn[nM] - floor),
+				     0, -0.5 * (dYIn[nM] + dXIn[nM] + fFloor),
 				     Z[nM] - dZf[nM] + 0.5 * m));
 	tShield->AddNode(pillar2, 1, new TGeoTranslation(
-				     0, -0.5 * (dYOut[nM] + dXOut[nM] - floor),
+				     0, -0.5 * (dYOut[nM] + dXOut[nM] + fFloor),
 				     Z[nM] + dZf[nM] - 0.5 * m));
       }
           
@@ -552,15 +553,16 @@ void ShipMuonShield::ConstructGeometry()
       Double_t dZD =  100*m + fMuonShieldLength;
       TGeoBBox *box3    = new TGeoBBox("box3", 15*m, 15*m,dZD/2.);
       TGeoBBox *box4    = new TGeoBBox("box4", 10*m, 10*m,dZD/2.);
-// cover also Tau nu area
+
       if (fDesign == 7) {
-	TGeoBBox *box5 = new TGeoBBox("shield_floor", 10 * m, 2.5 * m,
+	// Only add floor for new shield
+	TGeoBBox *box5 = new TGeoBBox("shield_floor", 10 * m, fFloor / 2.,
 				      fMuonShieldLength / 2.);
 	TGeoVolume *floor = new TGeoVolume("floorM", box5, concrete);
 	floor->SetLineColor(11); // grey
-	top->AddNode(floor, 1,
-		     new TGeoTranslation(
-			 0, -7.5 * m, zEndOfAbsorb + fMuonShieldLength / 2.));
+	top->AddNode(floor, 1, new TGeoTranslation(0, -10 * m + fFloor / 2.,
+						   zEndOfAbsorb +
+						       fMuonShieldLength / 2.));
       }
       TGeoCompositeShape *compRockD =
 	  new TGeoCompositeShape("compRockD", "(box3-box4)");

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -17,16 +17,18 @@ class ShipMuonShield : public FairModule
   public:
    ShipMuonShield(const char* name, const Int_t Design=1,  const char* Title="ShipMuonShield",
                                Double_t Z=0, Double_t L0=0, Double_t L1=0, Double_t L2=0, Double_t L3=0, Double_t L4=0, Double_t L5=0, Double_t L6=0, 
-                               Double_t L7=0, Double_t L8=0,Double_t gap=0,Double_t LE=0,Double_t y=400,Double_t fl=1.8);
+                               Double_t L7=0, Double_t L8=0,Double_t gap=0,Double_t LE=0,Double_t y=400, Double_t floor=500, Double_t field=1.8);
+
    ShipMuonShield();
    virtual ~ShipMuonShield();
    void ConstructGeometry();
-   ClassDef(ShipMuonShield,3)
+   ClassDef(ShipMuonShield,4)
     
  protected:
   
   Int_t  fDesign;       // design of muon shield, 1=passive, active = ...
-  Double_t  fMuonShieldLength,fY,fField ;
+  Double_t  fMuonShieldLength,fY,fField;
+  Double_t fFloor;
   Double_t  dZ0,dZ1,dZ2,dZ3,dZ4,dZ5,dZ6,dZ7,dZ8,dXgap,zEndOfAbsorb,mag4Gap,midGapOut7,midGapOut8;
   Int_t InitMedium(const char* name);
   

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -76,6 +76,7 @@ def configure(run,ship_geo):
  if not hasattr(ship_geo.Bfield,'x') :  ship_geo.Bfield.x   = 3.*u.m
  if not hasattr(ship_geo,'cave') :       
    ship_geo.cave = AttrDict(z=0*u.cm)
+   ship_geo.cave.floorHeightMuonShield = 5*u.m
    ship_geo.cave.floorHeightTankA   = 4.5*u.m
    ship_geo.cave.floorHeightTankB   = 2.*u.m
  latestShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_config.py",Yheight = ship_geo.Yheight/u.m, tankDesign = ship_geo.tankDesign, muShieldDesign = ship_geo.muShieldDesign)
@@ -114,7 +115,7 @@ def configure(run,ship_geo):
  elif ship_geo.muShieldDesign==3 or ship_geo.muShieldDesign==4 or ship_geo.muShieldDesign==5 or ship_geo.muShieldDesign==6 or ship_geo.muShieldDesign==7 :
   MuonShield = ROOT.ShipMuonShield("MuonShield",ship_geo.muShieldDesign,"ShipMuonShield",ship_geo.muShield.z,ship_geo.muShield.dZ0,ship_geo.muShield.dZ1,\
                ship_geo.muShield.dZ2,ship_geo.muShield.dZ3,ship_geo.muShield.dZ4,ship_geo.muShield.dZ5,ship_geo.muShield.dZ6,\
-               ship_geo.muShield.dZ7,ship_geo.muShield.dZ8,ship_geo.muShield.dXgap,ship_geo.muShield.LE,ship_geo.Yheight*4./10.) 
+               ship_geo.muShield.dZ7,ship_geo.muShield.dZ8,ship_geo.muShield.dXgap,ship_geo.muShield.LE,ship_geo.Yheight*4./10., ship_geo.cave.floorHeightMuonShield) 
 
  detectorList.append(MuonShield)
 


### PR DESCRIPTION
Hi Thomas,

Here the rewrite of the earlier commit to define the floor height via the `geometry_config`
but without accidentally changing the field anymore (I've checked to make sure).

Sorry for the mistake in the first place, it is something I should have spotted.
No constructor calls of the `ShipMuonShield` explicitly set the field strength,
so I've decided to just swap the `floor` and `field` parameters.

The geometry itself remains unchanged. 

Cheers,
	Oliver