### PR TITLE
Fix exact same typos in definition of emulsion pillar dimensions again

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -378,8 +378,8 @@ with ConfigRegistry.register_config("basic") as c:
           c.EmuMagnet.ColZ = 0*u.m
           c.EmuMagnet.Y = 2*c.EmuMagnet.BaseY+c.EmuMagnet.Height1+c.EmuMagnet.Height2+c.EmuMagnet.Distance
           c.EmuMagnet.PillarX = 0 *u.m
-          c.EmuMagnetPillarZ = 0*u.m
-          c.EmuMagnetPillarY = 0* u.m
+          c.EmuMagnet.PillarZ = 0 * u.m
+          c.EmuMagnet.PillarY = 0 * u.m
        
         
 


### PR DESCRIPTION
The typos fixed in 85f045cd918092d3d0b90ee4755a6821f63eae78 were reintroduced in the Tau neutrino geometry update.
This fixes them hopefully for the last time.

Cheers,
	Oliver