### PR TITLE
Actually set the mass + fix misleading indentation in `run_simScript.py`.

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -63,7 +63,7 @@ except getopt.GetoptError:
         print '       --SusyBench to specify which of the preset benchmarks to generate (default 2)'
         print '       --mass or -m to set HNL or New Particle mass'
         print '       --couplings \'U2e,U2mu,U2tau\' or -c \'U2e,U2mu,U2tau\' to set list of HNL couplings'
-	print '       --epsilon value or -e value to set mixing parameter epsilon' 
+        print '       --epsilon value or -e value to set mixing parameter epsilon' 
         print '                   Note that for RPVSUSY the third entry of the couplings is the stop mass'
         sys.exit()
 for o, a in opts:
@@ -121,7 +121,7 @@ for o, a in opts:
             dv = int(a)
         if o in ("--muShieldDesign",):
             ds = int(a)
-	if o in ("--nuTauTargetDesign",):
+        if o in ("--nuTauTargetDesign",):
             nud = int(a)
         if o in ("--charm",):
             charm = int(a)
@@ -133,12 +133,12 @@ for o, a in opts:
         if o in ("--SusyBench",):
             RPVSUSYbench = int(a)
         if o in ("-m", "--mass",):
-		if HNL: theHNLmass = float(a)
-		if DarkPhoton: theDPmass = float(a)
+            if HNL or RPVSUSY: theMass = float(a)
+            if DarkPhoton: theDPmass = float(a)
         if o in ("-c", "--couplings", "--coupling",):
             theCouplings = [float(c) for c in a.split(",")]
-	if o in ("-e", "--epsilon",):
-		theDPepsilon = float(a)
+        if o in ("-e", "--epsilon",):
+            theDPepsilon = float(a)
 
 #sanity check
 if (HNL and RPVSUSY) or (HNL and DarkPhoton) or (DarkPhoton and RPVSUSY): 


### PR DESCRIPTION
Hi,

I noticed that specifying a custom mass using the `-m`/`--mass` command-line parameter of `run_simScript.py` currently does not make Pythia use the requested value (for HNLs and RPVSUSY) due to a trivial error. Instead it keeps using the default value of 1 GeV.

This PR fixes this behaviour. The following notebooks allow you to compare the results [before](https://github.com/Element-126/My-notebooks/blob/master/HNL_mass_before.ipynb) / [after](https://github.com/Element-126/My-notebooks/blob/master/HNL_mass_after.ipynb) when setting `--mass '1.5'` (look at the first histogram).

Note that the recorded mass is still wrong (it remains fixed at 1 GeV), but this is a minor error and does not affect the physics.

In addition, I replaced a few raw tabs by spaces, since they were messing up the indentation, resulting in hard to find errors.

This is the squash of 2 commits:
1. Fix misleading indentation due to rogue tabs.
2. Actually set the mass in the HNL/RPVSUSY case, when the `-m`/`--mass` command-line parameter is used.

Feel free to edit this PR or request the unsquashed version if you prefer.