### PR TITLE
Fix seeding issue

### DIFF
--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -33,7 +33,7 @@ Bool_t MuonBackGenerator::Init(const char* fileName, const int firstEvent, const
   }
   fn = firstEvent;
   fPhiRandomize = fl;
-  fSameSeed = -1;
+  fSameSeed = 0;
   fsmearBeam = 0; // default no beam smearing, use SetSmearBeam(sb) if different, sb [cm]
   fTree = (TTree *)fInputFile->Get("pythia8-Geant4");
   fNevents = fTree->GetEntries();
@@ -82,9 +82,10 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
   Double_t mass = pdgBase->GetParticle(id)->Mass();
   Double_t    e = TMath::Sqrt( px*px+py*py+pz*pz+mass*mass );
   Double_t tof = 0;
-  if (!fSameSeed<0){
-   Int_t theSeed = fn + fSameSeed*fNevents;
-   gRandom->SetSeed(theSeed);
+  if (fSameSeed) {
+    Int_t theSeed = fn + fSameSeed * fNevents;
+    fLogger->Debug(MESSAGE_ORIGIN, TString::Format("Seed: %d", theSeed));
+    gRandom->SetSeed(theSeed);
   }
   if (fPhiRandomize){
       Double_t pt  = TMath::Sqrt( px*px+py*py );

--- a/shipgen/MuonBackGenerator.h
+++ b/shipgen/MuonBackGenerator.h
@@ -26,9 +26,13 @@ class MuonBackGenerator : public FairGenerator
   void CloseFile();//!
   void SetPhiRandom(Bool_t fl) { fPhiRandomize = fl; };
   void SetSmearBeam(Double_t sb) { fsmearBeam = sb; };
-  void SetSameSeed(Double_t s) { fSameSeed = s; };
- private:  
- protected:
+  void SetSameSeed(Int_t s) {
+    fLogger->Info(MESSAGE_ORIGIN, TString::Format("Seed: %d", s));
+    fSameSeed = s;
+  };
+
+private:
+protected:
   Float_t id,parentid,pythiaid,w,px,py,pz,vx,vy,vz,ecut;
   TFile* fInputFile;    //! 
   FairLogger*  fLogger; //!   don't make it persistent, magic ROOT command


### PR DESCRIPTION
Hi Thomas,

I discovered an issue in the `sameSeed` implementation:
`!fSameSeed<0` always evaluates to `false`, for any `Int_t` `fSameSeed`, as `!` has higher precedence than `<`. `!` returns a `bool`, which is always not `<0`, i.e. `false`.

To fix and simplify we can just use the truthyness of `fSameSeed` directly and change the default accordingly.

Cheers,
Oliver  