### PR TITLE
Implement the new beam smearing scheme

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -387,7 +387,7 @@ if simEngine == "MuonBack":
  primGen.SetTarget(ship_geo.target.z0+50*u.m,0.)
  MuonBackgen = ROOT.MuonBackGenerator()
  MuonBackgen.Init(inputFile,firstEvent,phiRandom)
- MuonBackgen.SetSmearBeam(3*u.cm) # beam size mimicking spiral
+ MuonBackgen.SetSmearBeam(5 * u.cm) # radius of ring, thickness 8mm
  if sameSeed: MuonBackgen.SetSameSeed(sameSeed)
  primGen.AddGenerator(MuonBackgen)
  nEvents = min(nEvents,MuonBackgen.GetNevents())

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -121,10 +121,10 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
   }
   if (fPhiRandomize){phi = gRandom->Uniform(0.,2.) * TMath::Pi();}
   if (fsmearBeam > 0) {
-     do {
-        dx = gRandom->Uniform(-1., 1.) * fsmearBeam;
-        dy = gRandom->Uniform(-1., 1.) * fsmearBeam;
-     } while ((dx * dx + dy * dy) > fsmearBeam * fsmearBeam);
+     Double_t r = fsmearBeam + 0.8 * gRandom->Gaus();
+     phi = gRandom->Uniform(0., 2.) * TMath::Pi();
+     dx = r * TMath::Cos(phi);
+     dy = r * TMath::Sin(phi);
   } else {
      dx = 0;
      dy = 0;
@@ -172,8 +172,8 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
        cpg->AddTrack(track->GetPdgCode(),px,py,pz,vx,vy,vz,-1.,wanttracking,e,tof,track->GetWeight(),(TMCProcess)track->GetProcID());
      } 
   }else{
-    vx = vx + dx/100.;  
-    vy = vy + dy/100.; 
+    vx += dx/100.;
+    vy += dy/100.;
     if (fPhiRandomize){
      Double_t pt  = TMath::Sqrt( px*px+py*py );
      px = pt*TMath::Cos(phi);

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -120,15 +120,15 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
     gRandom->SetSeed(theSeed);
   }
   if (fPhiRandomize){phi = gRandom->Uniform(0.,2.) * TMath::Pi();}
-  if (fsmearBeam>0){
-    Double_t test = fsmearBeam*fsmearBeam;
-    Double_t Rsq  = test + 1.;
-    while(Rsq>test){
-     dx = gRandom->Uniform(-1.,1.) * fsmearBeam;
-     dy = gRandom->Uniform(-1.,1.) * fsmearBeam;
-     Rsq = dx*dx+dy*dy;
-    }
-   }
+  if (fsmearBeam > 0) {
+     do {
+        dx = gRandom->Uniform(-1., 1.) * fsmearBeam;
+        dy = gRandom->Uniform(-1., 1.) * fsmearBeam;
+     } while ((dx * dx + dy * dy) > fsmearBeam * fsmearBeam);
+  } else {
+     dx = 0;
+     dy = 0;
+  }
   if (id==-1){
      std::vector<int> partList;
      for (int k = 0; k < vetoPoints->GetEntries(); k++) {

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -85,7 +85,8 @@ MuonBackGenerator::~MuonBackGenerator()
 Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
 {
   TDatabasePDG* pdgBase = TDatabasePDG::Instance();
-  Double_t mass,e,tof,phi,dx,dy;
+  Double_t mass,e,tof,phi;
+  Double_t dx = 0, dy = 0;
   std::vector<int> muList;
 
   while (fn<fNevents) {
@@ -125,9 +126,6 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
      phi = gRandom->Uniform(0., 2.) * TMath::Pi();
      dx = r * TMath::Cos(phi);
      dy = r * TMath::Sin(phi);
-  } else {
-     dx = 0;
-     dy = 0;
   }
   if (id==-1){
      std::vector<int> partList;


### PR DESCRIPTION
At the muon flux meeting and the last collaboration meeting [Marco Calviani presented a new beam smearing scheme](https://indico.cern.ch/event/638036/contributions/2593440/attachments/1471589/2277517/mc__BDF_TTC_SHiP_CM_June2017_v1.3.pdf#page=12):

* 8mm beam size (1σ)
* 50mm radius of ring

This pull-request implements this scheme, but there are still some issues I would like feedback on:

* Currently this just replaces the old scheme. We probably want to keep the old scheme as an option
* Instead of just one parameter of the scheme (the radius), we now have two (radius and width of the ring). How do we handle this?
* Needs some more testing.

PS: I suggest [WiP] (work in progress) as a tag for pull-requests that are not ready for merging yet.