### PR TITLE
Allow field maps to work as local B fields in volumes.

### DIFF
--- a/field/README.md
+++ b/field/README.md
@@ -58,15 +58,15 @@ The syntax for each of the above options are:
 1) [FieldMap](ShipBFieldMap.h)
 
 ```
-FieldMap MapLabel MapFileName x0 y0 z0 phi theta psi
+FieldMap MapLabel MapFileName [x0 y0 z0] [phi theta psi]
 ```
 
 where MapLabel is the descriptive name of the field, MapFileName is the location of
 the ROOT file containing the field map data (relative to the VMCWORKDIR directory),
 x0, y0, z0 are the offset co-ordinates in cm, and phi, theta and psi are the Euler 
 rotation angles in degrees about the z axis, the new x axis, and then the new z axis, 
-in that order. The offsets and angles are optional parameters; offsets still need to 
-be provided (can be set to zero) if angles are required.
+in that order. The offsets and angles are optional parameters (denoted by the square
+brackets); offsets still need to be provided (can be set to zero) if angles are required.
 
 A field map that is local to a particular volume is assumed to be centred and aligned 
 along the local symmetry axes. For example, if there is a collection of identical magnets 
@@ -180,7 +180,7 @@ i.e. any particle inside this volume will experience the superposition of the
 9) Local
 
 ```
-Local VolName FieldLabel {FieldMapScaleFactor]
+Local VolName FieldLabel [FieldMapScaleFactor]
 ```
 
 where VolName is again the name of the TGeo volume, FieldLabel is the name 

--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -16,22 +16,31 @@ ShipBFieldMap::ShipBFieldMap(const std::string& label,
 			     const std::string& mapFileName,
 			     Double_t xOffset,
 			     Double_t yOffset,
-			     Double_t zOffset) : 
+			     Double_t zOffset,
+			     Double_t phi,
+			     Double_t theta,
+			     Double_t psi,
+			     Double_t scale) : 
     TVirtualMagField(label.c_str()),
     fieldMap_(new std::vector<TVector3>()),
     mapFileName_(mapFileName),
-    initialised_(kFALSE), 
+    initialised_(kFALSE),
     isCopy_(kFALSE),
     Nx_(0), Ny_(0), Nz_(0), N_(0),
-    xMin_(0.0), xMax_(0.0), 
+    xMin_(0.0), xMax_(0.0),
     dx_(0.0), xRange_(0.0),
     yMin_(0.0), yMax_(0.0),
     dy_(0.0), yRange_(0.0),
-    zMin_(0.0), zMax_(0.0), 
+    zMin_(0.0), zMax_(0.0),
     dz_(0.0), zRange_(0.0),
-    xOffset_(xOffset), 
+    xOffset_(xOffset),
     yOffset_(yOffset),
     zOffset_(zOffset),
+    phi_(phi),
+    theta_(theta),
+    psi_(psi),
+    scale_(scale),
+    theTrans_(0),
     Tesla_(10.0)
 {
     this->initialise();
@@ -40,27 +49,47 @@ ShipBFieldMap::ShipBFieldMap(const std::string& label,
 ShipBFieldMap::~ShipBFieldMap()
 {
     // Delete the internal vector storing the field map values
-    if (fieldMap_) {delete fieldMap_;}
+    if (fieldMap_ && isCopy_ == kFALSE) {
+	delete fieldMap_; fieldMap_ = 0;
+    }
+
+    if (theTrans_) {delete theTrans_; theTrans_ = 0;}
+
 }
 
 
 ShipBFieldMap::ShipBFieldMap(const std::string& newName, const ShipBFieldMap& rhs,
-			     Double_t newXOffset, Double_t newYOffset, Double_t newZOffset) :
+			     Double_t newXOffset, Double_t newYOffset, Double_t newZOffset,
+			     Double_t newPhi, Double_t newTheta, Double_t newPsi, Double_t newScale) :
     TVirtualMagField(newName.c_str()),
     fieldMap_(rhs.fieldMap_),
     mapFileName_(rhs.GetMapFileName()),
-    initialised_(kFALSE), 
+    initialised_(kFALSE),
     isCopy_(kTRUE),
-    Nx_(0), Ny_(0), Nz_(0), N_(0),
-    xMin_(0.0), xMax_(0.0), 
-    dx_(0.0), xRange_(0.0),
-    yMin_(0.0), yMax_(0.0),
-    dy_(0.0), yRange_(0.0),
-    zMin_(0.0), zMax_(0.0), 
-    dz_(0.0), zRange_(0.0),
+    Nx_(rhs.Nx_),
+    Ny_(rhs.Ny_),
+    Nz_(rhs.Nz_),
+    N_(rhs.N_),
+    xMin_(rhs.xMin_),
+    xMax_(rhs.xMax_),
+    dx_(rhs.dx_),
+    xRange_(rhs.xRange_),
+    yMin_(rhs.yMin_),
+    yMax_(rhs.yMax_),
+    dy_(rhs.dy_),
+    yRange_(rhs.yRange_),
+    zMin_(rhs.zMin_),
+    zMax_(rhs.zMax_),
+    dz_(rhs.dz_),
+    zRange_(rhs.zRange_),
     xOffset_(newXOffset), 
     yOffset_(newYOffset),
     zOffset_(newZOffset),
+    phi_(newPhi),
+    theta_(newTheta),
+    psi_(newPsi),
+    scale_(newScale),
+    theTrans_(0),
     Tesla_(10.0)
 {
     // Copy constructor with new label and different global offset, which uses
@@ -71,15 +100,20 @@ ShipBFieldMap::ShipBFieldMap(const std::string& newName, const ShipBFieldMap& rh
 void ShipBFieldMap::Field(const Double_t* position, Double_t* B) 
 {
 
-    // Set the B field components given the position vector
+    // Set the B field components given the global position co-ordinates
 
-    // The point (global) co-ordinates, subtracting any offsets
-    Double_t x = position[0] - xOffset_;
-    Double_t y = position[1] - yOffset_;
-    Double_t z = position[2] - zOffset_;
+    // Convert the global position into a local one for the volume field.
+    // Initialise the local co-ords, which will get overwritten if the
+    // co-ordinate transformation exists. For a global field, any local
+    // volume transformation is ignored
+    Double_t localCoords[3] = {position[0], position[1], position[2]};
 
-    //std::cout<<"Offsets: "<<xOffset_<<", "<<yOffset_<<", "<<zOffset_<<std::endl;
-    //std::cout<<"Position = "<<position[0]<<", "<<position[1]<<", "<<position[2]<<std::endl;
+    if (theTrans_) {theTrans_->MasterToLocal(position, localCoords);}
+
+    // The local position co-ordinates
+    Double_t x = localCoords[0];
+    Double_t y = localCoords[1];
+    Double_t z = localCoords[2];
 
     // Initialise the B field components to zero
     B[0] = 0.0;
@@ -88,7 +122,6 @@ void ShipBFieldMap::Field(const Double_t* position, Double_t* B)
 
     // First check to see if we are inside the field map range
     Bool_t inside = this->insideRange(x, y, z);
-    //std::cout<<"x,y,z = "<<x<<", "<<y<<", "<<z<<", Inside = "<<(int) inside<<std::endl;
     if (inside == kFALSE) {return;}
 
     // Find the neighbouring bins for the given point
@@ -128,22 +161,36 @@ void ShipBFieldMap::Field(const Double_t* position, Double_t* B)
     zFrac1_ = 1.0 - zFrac_;
 
     // Finally get the magnetic field components using trilinear interpolation
-    B[0] = this->BInterCalc(ShipBFieldMap::xAxis);
-    B[1] = this->BInterCalc(ShipBFieldMap::yAxis);
-    B[2] = this->BInterCalc(ShipBFieldMap::zAxis);
-
-    //std::cout<<GetName()<<": Bins = "<<iX<<", "<<iY<<", "<<iZ
-    //         <<", B = "<<B[0]<<", "<<B[1]<<", "<<B[2]<<std::endl;
+    // and scale with the appropriate multiplication factor (default = 1.0)
+    B[0] = this->BInterCalc(ShipBFieldMap::xAxis)*scale_;
+    B[1] = this->BInterCalc(ShipBFieldMap::yAxis)*scale_;
+    B[2] = this->BInterCalc(ShipBFieldMap::zAxis)*scale_;
 
 }
 
 void ShipBFieldMap::initialise()
 {
- 
-   if (initialised_ == kFALSE) {
+    
+    if (initialised_ == kFALSE) {
+	
+	if (isCopy_ == kFALSE) {this->readMapFile();}
 
-	this->readMapFile();
-	initialised_ = kTRUE;    
+	// Set the global co-ordinate translation and rotation info
+	if (fabs(phi_) > 1e-6 && fabs(theta_) > 1e-6 && fabs(psi_) > 1e-6) {
+
+	    // We have non-zero rotation angles. Create a combined translation and rotation
+	    TGeoTranslation tr("offsets", xOffset_, yOffset_, zOffset_);
+	    TGeoRotation rot("angles", phi_, theta_, psi_);
+	    theTrans_ = new TGeoCombiTrans(tr, rot);
+
+	} else {
+
+	    // We only need a translation
+	    theTrans_ = new TGeoTranslation("offsets", xOffset_, yOffset_, zOffset_);
+
+	}
+
+	initialised_ = kTRUE;
 
     }
 
@@ -166,15 +213,24 @@ void ShipBFieldMap::readMapFile()
 
     }
 
-
 }
 
 void ShipBFieldMap::readRootFile() {
 
     TFile* theFile = TFile::Open(mapFileName_.c_str());
 
+    if (!theFile) {
+	std::cout<<"ShipBFieldMap: could not find the file "<<mapFileName_<<std::endl;
+	return;
+    }
+    
     // Coordinate ranges
     TTree* rTree = dynamic_cast<TTree*>(theFile->Get("Range"));
+    if (!rTree) {
+	std::cout<<"ShipBFieldMap: could not find Range tree in "<<mapFileName_<<std::endl;
+	return;
+    }
+
     rTree->SetBranchAddress("xMin", &xMin_);
     rTree->SetBranchAddress("xMax", &xMax_);
     rTree->SetBranchAddress("dx", &dx_);
@@ -190,6 +246,7 @@ void ShipBFieldMap::readRootFile() {
 
     this->setLimits();
 
+    // Make sure we don't have a copy
     if (isCopy_ == kFALSE) {
 
 	// The data is expected to contain Bx,By,Bz data values 
@@ -198,6 +255,11 @@ void ShipBFieldMap::readRootFile() {
 	fieldMap_->clear();
 
 	TTree* dTree = dynamic_cast<TTree*>(theFile->Get("Data"));
+	if (!dTree) {
+	    std::cout<<"ShipBFieldMap: could not find Data tree in "<<mapFileName_<<std::endl;
+	    return;
+	}
+
 	Double_t Bx, By, Bz;
 	dTree->SetBranchStatus("*", 0);
 	dTree->SetBranchStatus("Bx", 1);
@@ -292,7 +354,6 @@ Bool_t ShipBFieldMap::insideRange(Double_t x, Double_t y, Double_t z)
     if (x >= xMin_ && x <= xMax_ && y >= yMin_ &&
 	y <= yMax_ && z >= zMin_ && z <= zMax_) {inside = kTRUE;}
 	
-
     return inside;
 
 }

--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -176,7 +176,7 @@ void ShipBFieldMap::initialise()
 	if (isCopy_ == kFALSE) {this->readMapFile();}
 
 	// Set the global co-ordinate translation and rotation info
-	if (fabs(phi_) > 1e-6 && fabs(theta_) > 1e-6 && fabs(psi_) > 1e-6) {
+	if (fabs(phi_) > 1e-6 || fabs(theta_) > 1e-6 || fabs(psi_) > 1e-6) {
 
 	    // We have non-zero rotation angles. Create a combined translation and rotation
 	    TGeoTranslation tr("offsets", xOffset_, yOffset_, zOffset_);

--- a/field/ShipBFieldMap.h
+++ b/field/ShipBFieldMap.h
@@ -6,6 +6,7 @@
 #ifndef ShipBFieldMap_H
 #define ShipBFieldMap_H
 
+#include "TGeoMatrix.h"
 #include "TVirtualMagField.h"
 #include "TVector3.h"
 
@@ -25,11 +26,17 @@ class ShipBFieldMap : public TVirtualMagField
       \param [in] xOffset The x global co-ordinate shift to position the field map (cm)
       \param [in] yOffset The y global co-ordinate shift to position the field map (cm)
       \param [in] zOffset The z global co-ordinate shift to position the field map (cm)
+      \param [in] phi The first Euler rotation angle about the z axis (degrees)
+      \param [in] theta The second Euler rotation angle about the new x axis (degrees)
+      \param [in] psi The third Euler rotation angle about the new z axis (degrees)
+      \param [in] scale The field magnitude scaling factor (default = 1.0)
     */
     ShipBFieldMap(const std::string& label, const std::string& mapFileName,
-		  Double_t xOffset = 0.0, Double_t yOffset = 0.0, Double_t zOffset = 0.0);
+		  Double_t xOffset = 0.0, Double_t yOffset = 0.0, Double_t zOffset = 0.0,
+		  Double_t phi = 0.0, Double_t theta = 0.0, Double_t psi = 0.0,
+		  Double_t scale = 1.0);
 
-    //! Copy constructor with a new global positioning offset. Use this if you want
+    //! Copy constructor with a new global transformation. Use this if you want
     //! to reuse the same field map information elsewhere in the geometry
     /*! 
       \param [in] rhs The ShipBFieldMap object to be copied
@@ -37,10 +44,16 @@ class ShipBFieldMap : public TVirtualMagField
       \param [in] newXOffset The new global offset x co-ordinate (cm)
       \param [in] newYOffset The new global offset y co-ordinate (cm)
       \param [in] newZOffset The new global offset z co-ordinate (cm)
-      \returns a copy of the field map object "rhs", keeping the same fieldMap pointer
+      \param [in] newPhi The first Euler rotation angle about the z axis (degrees)
+      \param [in] newTheta The second Euler rotation angle about the new x axis (degrees)
+      \param [in] newPsi The third Euler rotation angle about the new z axis (degrees)
+      \param [in] newScale The field magnitude scaling factor (default = 1.0)
+     \returns a copy of the field map object "rhs", keeping the same fieldMap pointer
     */
     ShipBFieldMap(const std::string& newName, const ShipBFieldMap& rhs,
-		  Double_t newXOffset, Double_t newYOffset, Double_t newZOffset);
+		  Double_t newXOffset, Double_t newYOffset, Double_t newZOffset,
+		  Double_t newPhi = 0.0, Double_t newTheta = 0.0, Double_t newPsi = 0.0,
+		  Double_t newScale = 1.0);
 
     //! Destructor
     virtual ~ShipBFieldMap();
@@ -69,6 +82,30 @@ class ShipBFieldMap : public TVirtualMagField
       \param [in] zValue The value of the z global co-ordinate shift (cm)
     */
     void SetZOffset(Double_t zValue) {zOffset_ = zValue;}
+
+    //! Set the first Euler rotation angle phi about the z axis
+    /*!
+      \param [in] phi The first Euler rotation angle about the z axis (degrees)
+    */
+    void SetPhi(Double_t phi) {phi_ = phi;}
+
+    //! Set the second Euler rotation angle theta about the new x axis
+    /*!
+      \param [in] theta The second Euler rotation angle about the new x axis (degrees)
+    */
+    void SetTheta(Double_t theta) {theta_ = theta;}
+
+    //! Set the third Euler rotation angle psi about the new z axis
+    /*!
+      \param [in] psi The third Euler rotation angle about the new z axis (degrees)
+    */
+    void SetPsi(Double_t psi) {psi_ = psi;}
+
+    //! Set the field magnitude scaling factor
+    /*!
+      \param [in] scale The scaling factor for the field magnitude
+    */
+    void SetScale(Double_t scale) {scale_ = scale;}
 
     //! Get the name of the map file
     /*!
@@ -102,93 +139,117 @@ class ShipBFieldMap : public TVirtualMagField
 
     //! Get the minimum value of x for the map
     /*!
-      \returns the minimum x co-ordinate
+      \returns the minimum x co-ordinate (cm)
     */
     Double_t GetXMin() const {return xMin_;}
 
     //! Get the maximum value of x for the map
     /*!
-      \returns the maximum x co-ordinate
+      \returns the maximum x co-ordinate (cm)
     */
     Double_t GetXMax() const {return xMax_;}
 
     //! Get the bin width along x for the map
     /*!
-      \returns the bin width along x
+      \returns the bin width along x (cm)
     */
     Double_t GetdX() const {return dx_;}
 
      //! Get the x co-ordinate range for the map
     /*!
-      \returns the x co-ordinate range
+      \returns the x co-ordinate range (cm)
     */
     Double_t GetXRange() const {return xRange_;}
 
    //! Get the minimum value of y for the map
     /*!
-      \returns the minimum y co-ordinate
+      \returns the minimum y co-ordinate (cm)
     */
     Double_t GetYMin() const {return yMin_;}
 
     //! Get the maximum value of y for the map
     /*!
-      \returns the maximum y co-ordinate
+      \returns the maximum y co-ordinate (cm)
     */
     Double_t GetYMax() const {return yMax_;}
 
     //! Get the bin width along y for the map
     /*!
-      \returns the bin width along y
+      \returns the bin width along y (cm)
     */
     Double_t GetdY() const {return dy_;}
 
      //! Get the y co-ordinate range for the map
     /*!
-      \returns the y co-ordinate range
+      \returns the y co-ordinate range (cm)
     */
     Double_t GetYRange() const {return yRange_;}
 
     //! Get the minimum value of z for the map
     /*!
-      \returns the minimum z co-ordinate
+      \returns the minimum z co-ordinate (cm)
     */
     Double_t GetZMin() const {return zMin_;}
 
     //! Get the maximum value of z for the map
     /*!
-      \returns the maximum z co-ordinate
+      \returns the maximum z co-ordinate (cm)
     */
     Double_t GetZMax() const {return zMax_;}
 
     //! Get the bin width along z for the map
     /*!
-      \returns the bin width along z
+      \returns the bin width along z (cm)
     */
     Double_t GetdZ() const {return dz_;}
 
      //! Get the z co-ordinate range for the map
     /*!
-      \returns the z co-ordinate range
+      \returns the z co-ordinate range (cm)
     */
     Double_t GetZRange() const {return zRange_;}
 
     //! Get the x offset co-ordinate of the map for global positioning
     /*!
-      \returns the map's x offset co-ordinate for global positioning
+      \returns the map's x offset co-ordinate for global positioning (cm)
     */
     Double_t GetXOffset() const {return xOffset_;}
 
     //! Get the y offset co-ordinate of the map for global positioning
     /*!
-      \returns the map's y offset co-ordinate for global positioning
+      \returns the map's y offset co-ordinate for global positioning (cm)
     */
     Double_t GetYOffset() const {return yOffset_;}
 
     //! Get the z offset co-ordinate of the map for global positioning
     /*!
-      \returns the map's z offset co-ordinate for global positioning
+      \returns the map's z offset co-ordinate for global positioning (cm)
     */
     Double_t GetZOffset() const {return zOffset_;}
+
+    //! Get the first Euler rotation angle about the z axis for global positioning
+    /*!
+      \returns the map's first Euler rotation angle about the z axis (degrees)
+    */
+    Double_t GetPhi() const {return phi_;}
+
+    //! Get the second Euler rotation angle about the new x axis for global positioning
+    /*!
+      \returns the map's second Euler rotation angle about the new x axis (degrees)
+    */
+    Double_t GetTheta() const {return theta_;}
+
+    //! Get the third Euler rotation angle about the new z axis for global positioning
+    /*!
+      \returns the map's third Euler rotation angle about the new z axis (degrees)
+    */
+    Double_t GetPsi() const {return psi_;}
+
+    //! Get the field magnitude scaling factor
+    /*!
+      \returns the scaling factor for the field magnitude
+    */
+    Double_t GetScale() const {return scale_;}
 
     //! Get the boolean flag to specify if we are a "copy"
     /*!
@@ -335,6 +396,21 @@ class ShipBFieldMap : public TVirtualMagField
     //! The z value of the positional offset for the map
     Double_t zOffset_;
 
+    //! The first Euler rotation angle about the z axis
+    Double_t phi_;
+
+    //! The second Euler rotation angle about the new x axis
+    Double_t theta_;
+
+    //! The third Euler rotation angle about the new z axis
+    Double_t psi_;
+
+    //! The B field magnitude scaling factor
+    Double_t scale_;
+
+    //! The combined translation and rotation transformation
+    TGeoMatrix* theTrans_;
+
     //! Double converting Tesla to kiloGauss (for VMC/FairRoot B field units)
     Double_t Tesla_;
 
@@ -379,7 +455,6 @@ class ShipBFieldMap : public TVirtualMagField
 
     //! Complimentary fractional bin distance along z
     Double_t zFrac1_;
-
 
 };
 

--- a/field/ShipFieldMaker.h
+++ b/field/ShipFieldMaker.h
@@ -16,6 +16,10 @@
 #include <string>
 #include <vector>
 
+class TGeoMatrix;
+class TGeoNode;
+class TGeoVolume;
+
 class ShipFieldMaker
 {
 
@@ -38,61 +42,6 @@ class ShipFieldMaker
       \param [in] inputFile The file containing the information about fields and volumes
     */
     void makeFields(const std::string& inputFile);
-
-    //! Create the uniform field based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void createUniform(const stringVect& inputLine);
-
-    //! Create the constant field based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void createConstant(const stringVect& inputLine);
-
-    //! Create the Bell field based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void createBell(const stringVect& inputLine);
-
-    //! Create the field map based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void createFieldMap(const stringVect& inputLine);
-
-    //! Copy (&translate) a field map based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void copyFieldMap(const stringVect& inputLine);
-
-     //! Create the composite field based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void createComposite(const stringVect& inputLine);
-
-   //! Set the global field based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void setGlobalField(const stringVect& inputLine);
-
-    //! Set the regional (local+global) field based on the info from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void setRegionField(const stringVect& inputLine);
-
-    //! Set the local field only based on information from the inputLine
-    /*!
-      \param [in] inputLine The space separated input line
-    */
-    void setLocalField(const stringVect& inputLine);
-    
 
     //! Get the global magnetic field
     /*!
@@ -167,6 +116,101 @@ class ShipFieldMaker
  
  protected:
 
+    //! Structure to hold transformation information
+    struct transformInfo {
+
+	//! The x translation displacement
+	Double_t x0_;
+	//! The y translation displacement
+	Double_t y0_;
+	//! The z translation displacement
+	Double_t z0_;
+
+	//! The first Euler rotation angle (about Z axis)
+	Double_t phi_;
+	//! The second Euler rotation angle (about new X' axis)
+	Double_t theta_;
+	//! The third Euler rotation angle (about new Z' axis)
+	Double_t psi_;
+
+    };
+
+    //! Create the uniform field based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void createUniform(const stringVect& inputLine);
+
+    //! Create the constant field based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void createConstant(const stringVect& inputLine);
+
+    //! Create the Bell field based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void createBell(const stringVect& inputLine);
+
+    //! Create the field map based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void createFieldMap(const stringVect& inputLine);
+
+    //! Copy (&translate) a field map based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void copyFieldMap(const stringVect& inputLine);
+
+     //! Create the composite field based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void createComposite(const stringVect& inputLine);
+
+   //! Set the global field based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void setGlobalField(const stringVect& inputLine);
+
+    //! Set the regional (local+global) field based on the info from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void setRegionField(const stringVect& inputLine);
+
+    //! Set the local field only based on information from the inputLine
+    /*!
+      \param [in] inputLine The space separated input line
+    */
+    void setLocalField(const stringVect& inputLine);
+
+    //! Check if we have a local field map and store the volume global transformation
+    /*!
+      \param [in] localField The pointer (reference) to the field map (which may be updated)
+      \param [in] volName The name of the volume (which is used to find the transformation)
+      \param [in] scale The B field magnitude scaling factor
+    */
+    void checkLocalFieldMap(TVirtualMagField*& localField, const TString& volName, Double_t scale);
+
+    //! Get the transformation matrix for the volume position and orientation
+    /*!
+      \param [in] volName The name of the volume
+      \param [in] theInfo The transformation information structure
+    */
+    void getTransformation(const TString& volName, transformInfo& theInfo);
+
+    //! Update the current geometry node pointer that matches the required volume name
+    /*!
+      \param [in] aVolume The current volume, whose nodes are looked at
+      \param [in] volName The required volume name we want to find
+    */
+    void findNode(TGeoVolume* aVolume, const TString& volName);
+
 
  private:
 
@@ -181,6 +225,12 @@ class ShipFieldMaker
 
     //! Double converting Tesla to kiloGauss (for VMC/FairRoot B field units)
     Double_t Tesla_;
+
+    //! The current volume node: used for finding volume transformations
+    TGeoNode* theNode_;
+
+    //! Boolean to specify if we have found the volume node we need
+    Bool_t gotNode_;
 
     //! Split a string
     /*!


### PR DESCRIPTION
The TVirtualMagField::Field(position, B) function requires the position
to be in global co-ordinates. This means that by default B fields are not
in local co-ordinates. ShipFieldMaker has been updated to obtain the
global translation and (Euler) rotations for a given volume and use this to
find the global-to-local transformation for the position so that we can
find the local field. Here, all volumes that use the same field map
distribution have ShipBFieldMap copies that reuse the map data but only
change the global-to-local TGeoMatrix transformation information.
Other changes are made to ensure that copied field maps work as expected.
It is also possible to rescale a local field map for a given individual
volume without the need to have separate map data. All new options are
described in the field/README.md file.