### PR TITLE
Comment clang-format 5 option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BraceWrapping:
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
-  SplitEmptyFunctionBody: false
+  # SplitEmptyFunctionBody: false
 BreakBeforeBinaryOperators: false
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true


### PR DESCRIPTION
The commented option is unrecogised by earlier versions of clang-format causing
them to fail. At present not even the most recent Ubuntu or Fedora versions
have a version of clang-format in the repositories that recognises this option.

I suggest we comment it at least until next spring, when clang-format 5 should
be in the new Fedora and Ubuntu releases, as this way clang-format can be used
at least partially instead of not being able to use it at all.