### PR TITLE
Fix new code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,15 @@ Additionally for developers:
 
 Partial installation, step 1 of above :
 
-    ```bash
-    source FairShipRun/config.sh
-    ```    
+```bash
+source FairShipRun/config.sh
+```    
 
 If you have a full installation, step 3 of above:
-    ```bash
-    alibuild/alienv enter (--shellrc) FairShip/latest
-    ```    
+
+```bash
+alibuild/alienv enter (--shellrc) FairShip/latest
+```    
 
 Now you can for example simulate some events, run reconstruction and analysis:
 


### PR DESCRIPTION
This fixes the code blocks for the new instructions.

Note that if there are two ways to create code blocks:

* by indenting by 4 spaces
* by surrounding with ``` ` ```

where the first will override the second and then the ``` ` ``` will appear
(alongside the filetype indicator (e.g. `bash`)).

Note additionally, that markdown as parsed by Github expects code blocks to be
surounded by blank lines, which is why the second block didn't appear as
intended.