### PR TITLE
Remove out-dates setup script

### DIFF
--- a/shipsetup.csh
+++ b/shipsetup.csh
@@ -1,8 +1,0 @@
-# for setup at CERN lxplus
-setenv mySHIPSOFT /cvmfs/ship.cern.ch/ShipSoft  # should point to your own version 
-setenv SHIPSOFT /cvmfs/ship.cern.ch/ShipSoft
-setenv SIMPATH  ${SHIPSOFT}/FairSoftInst
-setenv FAIRROOTPATH ${SHIPSOFT}/FairRootInst
-setenv FAIRSHIP ${SHIPSOFT}/FairShip
-source ${mySHIPSOFT}/FairShipRun/config.csh
-


### PR DESCRIPTION
I think this file in FairShip also either needs updating or should be removed.
It still exports the locations of FairSoft/FairRoot.

But even if we do update, it essentially duplicates the installation
instructions in the readme, so I suggest we remove it, as implemented in this
pull-request.

I also remind you of the related SIMPATH issue, we will have to deal with.