### PR TITLE
Use named temporary file for event display file

### DIFF
--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python -i
 import ROOT,sys,getopt,os,Tkinter,atexit
+import tempfile
 from ShipGeoConfig import ConfigRegistry
 from rootpyPickler import Unpickler
 from array import array
@@ -69,7 +70,6 @@ if not dy:
  except:
    tmp = None
 
-OutFile	      = "tst."+InputFile.split('/')[-1]
 if InputFile.find('_D')>0: withGeo = True
 
 def printMCTrack(n,MCTrack):
@@ -998,7 +998,8 @@ if hasattr(fRun,'SetSource'):
  fRun.SetSource(inFile)
 else:
  fRun.SetInputFile(InputFile)
-fRun.SetOutputFile(OutFile)
+tf = tempfile.NamedTemporaryFile(suffix='.root')
+fRun.SetOutputFile(tf.name)
 
 if ParFile:
  rtdb      = fRun.GetRuntimeDb()

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -45,13 +45,13 @@ except getopt.GetoptError:
         print ' enter -f filename -g geofile (-p param file  not needed if geofile present)'  
         sys.exit()
 for o, a in opts:
-        if o in ("-Y"): 
+        if o in ("-Y",):
             dy = float(a)
         if o in ("-p", "--paramFile"):
             ParFile = a
         if o in ("-g", "--geoFile"):
             geoFile = a
-        if o in ("-f"):
+        if o in ("-f",):
             InputFile = a
 
 print "FairShip setup for",simEngine

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python -i
 import ROOT,sys,getopt,os,Tkinter,atexit
-import tempfile
 from ShipGeoConfig import ConfigRegistry
 from rootpyPickler import Unpickler
 from array import array
@@ -29,6 +28,7 @@ geoFile    = None
 mcEngine  = "TGeant4"
 simEngine = "Pythia8"
 InputFile = None 
+OutputFile = None
 withGeo   = False
 dy = str(10.)
 withMCTracks = True
@@ -54,6 +54,8 @@ for o, a in opts:
             geoFile = a
         if o in ("-f",):
             InputFile = a
+        if o in ("-o", "--outFile"):
+            OutputFile = a
 
 print "FairShip setup for",simEngine
 
@@ -998,8 +1000,9 @@ if hasattr(fRun,'SetSource'):
  fRun.SetSource(inFile)
 else:
  fRun.SetInputFile(InputFile)
-tf = tempfile.NamedTemporaryFile(suffix='.root')
-fRun.SetOutputFile(tf.name)
+if OutputFile == None:
+  OutputFile = ROOT.TMemFile('event_display_output', 'recreate')
+fRun.SetOutputFile(OutputFile)
 
 if ParFile:
  rtdb      = fRun.GetRuntimeDb()

--- a/macro/makeCascade.py
+++ b/macro/makeCascade.py
@@ -26,13 +26,13 @@ except getopt.GetoptError:
         print '       -P : store all particles produced together with charm'
         sys.exit()
 for o, a in opts:
-        if o in ("-n"):
+        if o in ("-n",):
             nevgen = int(a)
         if o in ("-E","--beam"):
             pbeamh = float(a)
         if o in ("-m","--msel"):
              mselcb = int(a)
-        if o in ("-t"):
+        if o in ("-t",):
             Fntuple = a
         if o in ("-s","--seed"):
             R = int(a)

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -25,7 +25,7 @@ except getopt.GetoptError:
         print '            : c chicc= ccbar over mbias cross section'
         sys.exit()
 for o, a in opts:
-        if o in ("-f"):
+        if o in ("-f",):
             fname = a.replace('.root','')
         if o in ("-p","--pot"):
             nrpotspill = float(a)


### PR DESCRIPTION
This solves a(n addmittedly rare) problem that occurs when the eventDisplay is
run somwhere where one cannot create files. As to my knowledge this is a file
that is only used by FairRoot and contains nothing useful otherwise I suggest
we use a temporary file (as implemented here) until a use for that file is
found.