### PR TITLE
Fix getopt options

### DIFF
--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -45,13 +45,13 @@ except getopt.GetoptError:
         print ' enter -f filename -g geofile (-p param file  not needed if geofile present)'  
         sys.exit()
 for o, a in opts:
-        if o in ("-Y"): 
+        if o in ("-Y",):
             dy = float(a)
         if o in ("-p", "--paramFile"):
             ParFile = a
         if o in ("-g", "--geoFile"):
             geoFile = a
-        if o in ("-f"):
+        if o in ("-f",):
             InputFile = a
 
 print "FairShip setup for",simEngine

--- a/macro/makeCascade.py
+++ b/macro/makeCascade.py
@@ -26,13 +26,13 @@ except getopt.GetoptError:
         print '       -P : store all particles produced together with charm'
         sys.exit()
 for o, a in opts:
-        if o in ("-n"):
+        if o in ("-n",):
             nevgen = int(a)
         if o in ("-E","--beam"):
             pbeamh = float(a)
         if o in ("-m","--msel"):
              mselcb = int(a)
-        if o in ("-t"):
+        if o in ("-t",):
             Fntuple = a
         if o in ("-s","--seed"):
             R = int(a)

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -25,7 +25,7 @@ except getopt.GetoptError:
         print '            : c chicc= ccbar over mbias cross section'
         sys.exit()
 for o, a in opts:
-        if o in ("-f"):
+        if o in ("-f",):
             fname = a.replace('.root','')
         if o in ("-p","--pot"):
             nrpotspill = float(a)


### PR DESCRIPTION
This fixes all remaining cases where `("-X")` is used (note not trailing
comma), which causes the `("-X")` to be interpreted as `["-", "X"]`, which can
lead to surprises and wrong results.

NB: I've ignored the files in [`macro/obsolete`](macro/obsolete).