### PR TITLE
Set TimeDet dimensions from the geometry config

### DIFF
--- a/TimeDet/TimeDet.h
+++ b/TimeDet/TimeDet.h
@@ -47,6 +47,14 @@ class TimeDet: public FairDetector
 
     /** Sets detector position along z */
     void SetZposition(Double_t z) {fzPos = z;}
+    void SetBarZspacing(Double_t row, Double_t column)
+    {
+       fdzBarRow = row;
+       fdzBarCol = column;
+    }
+    void SetBarZ(Double_t dz) {fzBar = dz;}
+    void SetSizeX(Double_t x) {fxSize = x;}
+    void SetSizeY(Double_t y) {fySize = y;}
 
     double GetXCol(int ic) const;
     double GetYRow(int ir) const;

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -645,5 +645,17 @@ with ConfigRegistry.register_config("basic") as c:
     c.NuTauTarget.PillarX = 0.5*u.m
     c.NuTauTarget.PillarZ = 0.5*u.m
     c.NuTauTarget.PillarY = 10*u.m - c.NuTauTarget.ydim/2 -c.NuTauTarget.BaseY- 0.1*u.mm - c.cave.floorHeightMuonShield
-        
 
+# TimeDet
+c.TimeDet = AttrDict(z=c.Chamber6.z
+                     + c.chambers.Tub6length
+                     + c.Veto.lidThickness + 15 * u.cm
+                     if c.tankDesign == 6
+                     else c.Chamber6.z
+                     + c.chambers.Tub6length + 10 * u.cm)
+c.TimeDet.dzBarRow = 1.2 * u.cm
+c.TimeDet.dzBarCol = 2.4 * u.cm
+c.TimeDet.zBar = 1 * u.cm
+c.TimeDet.DZ = (c.TimeDet.dzBarRow + c.TimeDet.dzBarCol + c.TimeDet.zBar) / 2
+c.TimeDet.DX = 250 * u.cm
+c.TimeDet.DY = 500 * u.cm

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -333,7 +333,11 @@ def configure(run,ship_geo):
  detectorList.append(Muon)
 
  timeDet = ROOT.TimeDet("TimeDet", ROOT.kTRUE)
- timeDet.SetZposition(ship_geo.Chamber6.z + ship_geo.chambers.Tub6length + ship_geo.Veto.lidThickness + 15 if ship_geo.tankDesign == 6 else ship_geo.Chamber6.z + ship_geo.chambers.Tub6length + 10)
+ timeDet.SetZposition(ship_geo.TimeDet.z)
+ timeDet.SetBarZspacing(ship_geo.TimeDet.dzBarRow, ship_geo.TimeDet.dzBarCol)
+ timeDet.SetBarZ(ship_geo.TimeDet.zBar)
+ timeDet.SetSizeX(2 * ship_geo.TimeDet.DX)
+ timeDet.SetSizeY(2 * ship_geo.TimeDet.DY)
  detectorList.append(timeDet)
 
 #-----   Magnetic field   -------------------------------------------


### PR DESCRIPTION
This exposes the main settings to control the TimeDet dimensions to the
geometry config.

Note, as the depth of the detector depends in the spacing and bar depth it
needs to be adjusted via them, but I have added a the resulting depth to the
geometry config, so that it can be taken into account for the placement of
other detectors.

Currently TimeDet and the first part of the splitCal seem to overlap. This
needs to be fixed.