### PR TITLE
[WiP] Upstream new muon shield

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -280,8 +280,8 @@ with ConfigRegistry.register_config("basic") as c:
     # zGap to compensate automatic shortening of magnets
     zGap = 0.5 * c.muShield.dZgap  # halflengh of gap
     if muShieldDesign == 7:
-        c.muShield.dZ1 = 0.7*u.m
-        c.muShield.dZ2 = 1.7*u.m
+        c.muShield.dZ1 = 0.35*u.m + zGap
+        c.muShield.dZ2 = 2.26*u.m + zGap
         c.muShield.dZ3 = 2.0*u.m + zGap
         c.muShield.dZ4 = 2.0*u.m + zGap
         c.muShield.dZ5 = 2.75*u.m + zGap
@@ -301,8 +301,8 @@ with ConfigRegistry.register_config("basic") as c:
         params = r.TVectorD()
         params.Read('params')
         f.Close()
-        c.muShield.dZ1 = params[0]
-        c.muShield.dZ2 = params[1]
+        c.muShield.dZ1 = 0.35*u.m + zGap
+        c.muShield.dZ2 = 2.26*u.m + zGap
         c.muShield.dZ3 = params[2]
         c.muShield.dZ4 = params[3]
         c.muShield.dZ5 = params[4]

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -280,8 +280,8 @@ with ConfigRegistry.register_config("basic") as c:
     # zGap to compensate automatic shortening of magnets
     zGap = 0.5 * c.muShield.dZgap  # halflengh of gap
     if muShieldDesign == 7:
-        c.muShield.dZ1 = 0.35*u.m + zGap
-        c.muShield.dZ2 = 2.26*u.m + zGap
+        c.muShield.dZ1 = 0.7 * u.m + zGap
+        c.muShield.dZ2 = 1.7 * u.m + zGap
         c.muShield.dZ3 = 2.0*u.m + zGap
         c.muShield.dZ4 = 2.0*u.m + zGap
         c.muShield.dZ5 = 2.75*u.m + zGap

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -1,4 +1,5 @@
 import shipunit as u
+import ROOT as r
 from ShipGeoConfig import AttrDict, ConfigRegistry
 # the following params should be passed through 'ConfigRegistry.loadpy' method
 # muShieldDesign = 5  # 1=passive 2=active 5=TP design 6=magnetized hadron absorber
@@ -11,6 +12,8 @@ from ShipGeoConfig import AttrDict, ConfigRegistry
 # tankDesign = 5 #  4=TP elliptical tank design, 5 = optimized conical rectangular design, 6=5 without segment-1
 if "muShieldDesign" not in globals():
     muShieldDesign = 5
+if "muShieldGeo" not in globals():
+    muShieldGeo = None
 if "nuTargetPassive" not in globals():
     nuTargetPassive = 1
 if "nuTauTargetDesign" not in globals():
@@ -285,6 +288,27 @@ with ConfigRegistry.register_config("basic") as c:
         c.muShield.dZ6 = 2.4*u.m + zGap
         c.muShield.dZ7 = 3.0*u.m + zGap
         c.muShield.dZ8 = 2.35*u.m + zGap
+        c.muShield.dXgap = 0.*u.m
+        c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
+                         +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 
+        c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2.
+
+    if muShieldDesign == 8:
+       if muShieldGeo:
+        c.muShieldGeo = muShieldGeo
+        print "Load geo"
+        f = r.TFile.Open(muShieldGeo)
+        params = r.TVectorD()
+        params.Read('params')
+        f.Close()
+        c.muShield.dZ1 = params[0]
+        c.muShield.dZ2 = params[1]
+        c.muShield.dZ3 = params[2]
+        c.muShield.dZ4 = params[3]
+        c.muShield.dZ5 = params[4]
+        c.muShield.dZ6 = params[5]
+        c.muShield.dZ7 = params[6]
+        c.muShield.dZ8 = params[7]
         c.muShield.dXgap = 0.*u.m
         c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
                          +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -18,7 +18,7 @@ if "nuTargetPassive" not in globals():
     nuTargetPassive = 1
 if "nuTauTargetDesign" not in globals():
     nuTauTargetDesign = 0
-    if muShieldDesign == 7: 
+    if muShieldDesign >= 7: 
         nuTauTargetDesign=1
 if "targetOpt" not in globals():
     targetOpt = 18

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -289,12 +289,19 @@ with ConfigRegistry.register_config("basic") as c:
         c.muShield.dZ7 = 3.0*u.m + zGap
         c.muShield.dZ8 = 2.35*u.m + zGap
         c.muShield.dXgap = 0.*u.m
-        c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
-                         +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 
-        c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2.
-
-    if muShieldDesign == 8:
-       if muShieldGeo:
+    elif muShieldDesign == 9:
+        c.muShield.Field = 1.7  # Tesla
+        c.muShield.dZ1 = 0.35 * u.m + zGap
+        c.muShield.dZ2 = 2.26 * u.m + zGap
+        c.muShield.dZ3 = 2.08 * u.m + zGap
+        c.muShield.dZ4 = 2.07 * u.m + zGap
+        c.muShield.dZ5 = 2.81 * u.m + zGap
+        c.muShield.dZ6 = 2.48 * u.m + zGap
+        c.muShield.dZ7 = 3.05 * u.m + zGap
+        c.muShield.dZ8 = 2.42 * u.m + zGap
+        c.muShield.dXgap = 0. * u.m
+    elif muShieldDesign == 8:
+        assert muShieldGeo
         c.muShieldGeo = muShieldGeo
         print "Load geo"
         f = r.TFile.Open(muShieldGeo)
@@ -310,9 +317,14 @@ with ConfigRegistry.register_config("basic") as c:
         c.muShield.dZ7 = params[6]
         c.muShield.dZ8 = params[7]
         c.muShield.dXgap = 0.*u.m
-        c.muShield.length = 2*(c.muShield.dZ1+c.muShield.dZ2+c.muShield.dZ3+c.muShield.dZ4+c.muShield.dZ5+c.muShield.dZ6
-                         +c.muShield.dZ7+c.muShield.dZ8 ) + c.muShield.LE  # leave some space for nu-tau 
-        c.muShield.z  =  -c.decayVolume.length/2.-c.muShield.length/2.
+    if muShieldDesign in range(7, 10):
+        c.muShield.length = 2 * (
+              c.muShield.dZ1 + c.muShield.dZ2 +
+              c.muShield.dZ3 + c.muShield.dZ4 +
+              c.muShield.dZ5 + c.muShield.dZ6 +
+              c.muShield.dZ7 + c.muShield.dZ8
+        ) + c.muShield.LE
+        c.muShield.z = -(c.decayVolume.length + c.muShield.length) / 2.
 
     if muShieldDesign == 3:
      c.muShield.dZ1 = 3.5*u.m

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -45,6 +45,7 @@ nud          = 1 # 0=TP, 1=new magnet option for short muon shield, 2= no magnet
 charm        = 0 # !=0 create charm detector instead of SHiP
 caloDesign   = 0 # 0=ECAL/HCAL TP  1=ECAL/HCAL TP + preshower 2=splitCal
 strawDesign  = 4 # simplistic tracker design,  4=sophisticated straw tube design, horizontal wires (default), 10=2cm straw diameter for 2018 layout
+geofile = None
 
 inactivateMuonProcesses = False   # provisionally for making studies of various muon background sources
 checking4overlaps = False
@@ -55,7 +56,7 @@ FastMuon    = False  # only transport muons for a fast muon only background esti
 nuRadiography = False # misuse GenieGenerator for neutrino radiography and geometry timing test
 Opt_high = None # switch for cosmic generator
 try:
-        opts, args = getopt.getopt(sys.argv[1:], "D:FHPu:n:i:f:c:hqv:s:l:A:Y:i:m:co:t",[\
+        opts, args = getopt.getopt(sys.argv[1:], "D:FHPu:n:i:f:c:hqv:s:l:A:Y:i:m:co:t:g",[\
                                    "PG","Pythia6","Pythia8","Genie","MuDIS","Ntuple","Nuage","MuonBack","FollowMuon","FastMuon",\
                                    "Cosmics=","nEvents=", "display", "seed=", "firstEvent=", "phiRandom", "mass=", "couplings=", "coupling=", "epsilon=",\
                                    "output=","tankDesign=","muShieldDesign=","NuRadio","test",\
@@ -126,6 +127,8 @@ for o, a in opts:
             if a.lower() == "none": inputFile = None
             else: inputFile = a
             defaultInputFile = False
+        if o in ("-g",):
+            geofile = a
         if o in ("-o", "--output",):
             outputDir = a
         if o in ("-Y",): 
@@ -189,7 +192,7 @@ shipRoot_conf.configure(DarkPhoton)      # load basic libraries, prepare atexit 
 # - targetOpt      = 5  # 0=solid   >0 sliced, 5: 5 pieces of tungsten, 4 H20 slits, 17: Mo + W +H2O (default)
 #   nuTauTargetDesign = 0 # 0 = TP, 1 = NEW with magnet, 2 = NEW without magnet, 3 = 2018 design
 if charm == 0: ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_config.py", Yheight = dy, tankDesign = dv, \
-                                                muShieldDesign = ds, nuTauTargetDesign=nud, CaloDesign=caloDesign, strawDesign=strawDesign)
+                                                muShieldDesign = ds, nuTauTargetDesign=nud, CaloDesign=caloDesign, strawDesign=strawDesign, muShieldGeo=geofile)
 else: ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py")
 
 # switch off magnetic field to measure muon flux
@@ -555,4 +558,3 @@ def checkOverlapsWithGeant4():
  mygMC.ProcessGeantCommand("/geometry/test/recursion_start 0")
  mygMC.ProcessGeantCommand("/geometry/test/recursion_depth 2")
  mygMC.ProcessGeantCommand("/geometry/test/run")
-

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -81,7 +81,7 @@ ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char*
      fMuonShieldLength = 2*(dZ1+dZ2+dZ3+dZ4+dZ5+dZ6+dZ7+dZ8) + LE ; //leave some space for nu-tau detector   
     }
     
- if (fDesign==7){
+ if (fDesign>=7){
      dZ1 = L1;
      dZ2 = L2;
      dZ3 = L3;
@@ -94,7 +94,7 @@ ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char*
 	 2 * (dZ1 + dZ2 + dZ3 + dZ4 + dZ5 + dZ6 + dZ7 + dZ8) + LE;
    }
     
- fFloor = (fDesign == 7) ? floor : 0;
+ fFloor = (fDesign >= 7) ? floor : 0;
 
  zEndOfAbsorb = Z + dZ0 - fMuonShieldLength/2.;   
  if(fDesign==6||fDesign==7){zEndOfAbsorb = Z - fMuonShieldLength/2.;}

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -101,18 +101,7 @@ void ShipMuonShield::CreateTube(const char* tubeName, TGeoMedium* medium, Double
   tShield->AddNode(absorber, numberOfItems, new TGeoTranslation(x_translation, y_translation, z_translation ));
 }
 
-
-void ShipMuonShield::CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,Double_t corners[16],Int_t color,
-				     TGeoUniformMagField *magField,TGeoVolume *tShield,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
-					Double_t z_translation)
-{
-  TGeoVolume* magF = gGeoManager->MakeArb8(arbName, medium, dZ, corners);
-  magF->SetLineColor(color);
-  magF->SetField(magField);
-  tShield->AddNode(magF, 1, new TGeoTranslation(x_translation, y_translation, z_translation ));
-}
-
-void ShipMuonShield::CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,std::vector<Double_t> corners,Int_t color,
+void ShipMuonShield::CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,std::array<Double_t,16> corners, Int_t color,
 				     TGeoUniformMagField *magField,TGeoVolume *tShield,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
 					Double_t z_translation)
 {
@@ -146,31 +135,114 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
 						   // (Geant goes crazy when
 						   // they touch each other)
 
-    Double_t cornerMainL[16] = {-dX/2+middleGap+dX/2,-dY-dX+testGap , -dX/2+middleGap+dX/2,dY+dX-testGap , dX/2+middleGap+dX/2,dY-testGap , dX/2+middleGap+dX/2,-dY+testGap ,
-                               -dX2/2+middleGap2+dX2/2,-dY2-dX2+testGap , -dX2/2+middleGap2+dX2/2,dY2+dX2-testGap , dX2/2+middleGap2+dX2/2,dY2-testGap , dX2/2+middleGap2+dX2/2,-dY2+testGap };
-    Double_t cornerMainR[16] = {-dX/2-middleGap-dX/2,-dY+testGap , -dX/2-middleGap-dX/2,dY-testGap , dX/2-middleGap-dX/2,dY+dX-testGap , dX/2-middleGap-dX/2,-dY-dX+testGap ,
-                               -dX2/2-middleGap2-dX2/2,-dY2+testGap , -dX2/2-middleGap2-dX2/2,dY2-testGap , dX2/2-middleGap2-dX2/2,dY2+dX2-testGap , dX2/2-middleGap2-dX2/2,-dY2-dX2+testGap };
-    Double_t cornerMainSideL[16] = {dX+middleGap+gap,-HmainSideMag,dX+middleGap+gap,HmainSideMag, 2*dX+middleGap+gap,HmainSideMag, 2*dX+middleGap+gap,-HmainSideMag,
-				    dX2+middleGap2+gap2,-HmainSideMag2, dX2+middleGap2+gap2,HmainSideMag2, 2*dX2+middleGap2+gap2,HmainSideMag2, 2*dX2+middleGap2+gap2,-HmainSideMag2};
-    Double_t cornerMainSideR[16] = {-dX-middleGap-gap,-HmainSideMag, -2*dX-middleGap-gap,-HmainSideMag, -2*dX-middleGap-gap,HmainSideMag,  -dX-middleGap-gap,HmainSideMag,
-				    -dX2-middleGap2-gap2,-HmainSideMag2, -2*dX2-middleGap2-gap2,-HmainSideMag2, -2*dX2-middleGap2-gap2,HmainSideMag2,-dX2-middleGap2-gap2,HmainSideMag2};			       
-    Double_t cornersCLBA[16] = {dX+middleGap+gap,-HmainSideMag,2*dX+middleGap+gap,-HmainSideMag,2*dX+middleGap+Clgap,-dY-dX+testGap ,dX+middleGap+Clgap,-dY+testGap ,
-                                dX2+middleGap2+gap2,-HmainSideMag2,2*dX2+middleGap2+gap2,-HmainSideMag2,2*dX2+middleGap2+Clgap2,-dY2-dX2+testGap ,dX2+middleGap2+Clgap2,-dY2+testGap };
-    Double_t cornersCLTA[16] = {dX+middleGap+Clgap,dY-testGap ,2*dX+middleGap+Clgap,dY+dX-testGap ,2*dX+middleGap+gap,HmainSideMag,dX+middleGap+gap,HmainSideMag, 
-                                dX2+middleGap2+Clgap2,dY2-testGap ,2*dX2+middleGap2+Clgap2,dY2+dX2-testGap ,2*dX2+middleGap2+gap2,HmainSideMag2, dX2+middleGap2+gap2,HmainSideMag2};
-    Double_t cornersCRBA[16] = {-dX-middleGap-Clgap,-dY+testGap ,-2*dX-middleGap-Clgap,-dY-dX+testGap , -2*dX-middleGap-gap,-HmainSideMag,-dX-middleGap-gap,-HmainSideMag,
-                                -dX2-middleGap2-Clgap2,-dY2+testGap ,-2*dX2-middleGap2-Clgap2,-dY2-dX2+testGap ,-2*dX2-middleGap2-gap2,-HmainSideMag2,-dX2-middleGap2-gap2,-HmainSideMag2}; 
-    Double_t cornersCRTA[16] = {-dX-middleGap-gap,HmainSideMag, -2*dX-middleGap-gap,HmainSideMag, -2*dX-middleGap-Clgap,dY+dX-testGap , -dX-middleGap-Clgap,dY-testGap ,
-                                -dX2-middleGap2-gap2,HmainSideMag2,-2*dX2-middleGap2-gap2,HmainSideMag2,-2*dX2-middleGap2-Clgap2,dY2+dX2-testGap ,-dX2-middleGap2-Clgap2,dY2-testGap };
-    Double_t cornersTL[16] = {middleGap+dX,dY,middleGap,dY+dX, 2*dX+middleGap+Clgap,dY+dX, dX+middleGap+Clgap,dY, 
-                             middleGap2+dX2,dY2, middleGap2,dY2+dX2, 2*dX2+middleGap2+Clgap2,dY2+dX2, dX2+middleGap2+Clgap2,dY2}; 
-    Double_t cornersTR[16] = {-dX-middleGap-Clgap,dY,-2*dX-middleGap-Clgap,dY+dX,-middleGap,dY+dX,-middleGap-dX,dY, 
-                             -dX2-middleGap2-Clgap2,dY2,-2*dX2-middleGap2-Clgap2,dY2+dX2, -middleGap2,dY2+dX2, -middleGap2-dX2,dY2};
-    Double_t cornersBL[16] = {dX+middleGap+Clgap,-dY,2*dX+middleGap+Clgap,-dY-dX,middleGap,-dY-dX,middleGap+dX,-dY, 
-                               dX2+middleGap2+Clgap2,-dY2, 2*dX2+middleGap2+Clgap2,-dY2-dX2,middleGap2,-dY2-dX2, middleGap2+dX2,-dY2}; 
-    Double_t cornersBR[16] = {-middleGap-dX,-dY, -middleGap,-dY-dX, -2*dX-middleGap-Clgap,-dY-dX, -dX-middleGap-Clgap,-dY, 
-                              -middleGap2-dX2,-dY2, -middleGap2,-dY2-dX2, -2*dX2-middleGap2-Clgap2,-dY2-dX2, -dX2-middleGap2-Clgap2,-dY2};
-				 
+    std::array<Double_t,16> cornersMainL = {
+	middleGap,	-dY - dX + testGap,
+	middleGap,	dY + dX - testGap,
+	dX + middleGap,   dY - testGap,
+	dX + middleGap,   -dY + testGap,
+	middleGap2,       -dY2 - dX2 + testGap,
+	middleGap2,       dY2 + dX2 - testGap,
+	dX2 + middleGap2, dY2 - testGap,
+	dX2 + middleGap2, -dY2 + testGap};
+    std::array<Double_t,16> cornersMainR = {
+	-dX - middleGap,    -dY + testGap,
+	-dX - middleGap,    dY - testGap,
+	- middleGap,     dY + dX - testGap,
+	- middleGap,     -dY - dX + testGap,
+	-dX2 - middleGap2, -dY2 + testGap,
+	-dX2 - middleGap2, dY2 - testGap,
+	- middleGap2,  dY2 + dX2 - testGap,
+	- middleGap2,  -dY2 - dX2 + testGap};
+    std::array<Double_t,16> cornersMainSideL = {
+	dX + middleGap + gap,	-HmainSideMag,
+	dX + middleGap + gap,	HmainSideMag,
+	2 * dX + middleGap + gap,    HmainSideMag,
+	2 * dX + middleGap + gap,    -HmainSideMag,
+	dX2 + middleGap2 + gap2,     -HmainSideMag2,
+	dX2 + middleGap2 + gap2,     HmainSideMag2,
+	2 * dX2 + middleGap2 + gap2, HmainSideMag2,
+	2 * dX2 + middleGap2 + gap2, -HmainSideMag2};
+    std::array<Double_t,16> cornersMainSideR = {
+	-dX - middleGap - gap,	-HmainSideMag,
+	-2 * dX - middleGap - gap,    -HmainSideMag,
+	-2 * dX - middleGap - gap,    HmainSideMag,
+	-dX - middleGap - gap,	HmainSideMag,
+	-dX2 - middleGap2 - gap2,     -HmainSideMag2,
+	-2 * dX2 - middleGap2 - gap2, -HmainSideMag2,
+	-2 * dX2 - middleGap2 - gap2, HmainSideMag2,
+	-dX2 - middleGap2 - gap2,     HmainSideMag2};
+    std::array<Double_t,16> cornersCLBA = {
+	dX + middleGap + gap,	  -HmainSideMag,
+	2 * dX + middleGap + gap,      -HmainSideMag,
+	2 * dX + middleGap + Clgap,    -dY - dX + testGap,
+	dX + middleGap + Clgap,	-dY + testGap,
+	dX2 + middleGap2 + gap2,       -HmainSideMag2,
+	2 * dX2 + middleGap2 + gap2,   -HmainSideMag2,
+	2 * dX2 + middleGap2 + Clgap2, -dY2 - dX2 + testGap,
+	dX2 + middleGap2 + Clgap2,     -dY2 + testGap};
+    std::array<Double_t,16> cornersCLTA = {
+	dX + middleGap + Clgap,	dY - testGap,
+	2 * dX + middleGap + Clgap,    dY + dX - testGap,
+	2 * dX + middleGap + gap,      HmainSideMag,
+	dX + middleGap + gap,	  HmainSideMag,
+	dX2 + middleGap2 + Clgap2,     dY2 - testGap,
+	2 * dX2 + middleGap2 + Clgap2, dY2 + dX2 - testGap,
+	2 * dX2 + middleGap2 + gap2,   HmainSideMag2,
+	dX2 + middleGap2 + gap2,       HmainSideMag2};
+    std::array<Double_t,16> cornersCRBA = {
+	-dX - middleGap - Clgap,	-dY + testGap,
+	-2 * dX - middleGap - Clgap,    -dY - dX + testGap,
+	-2 * dX - middleGap - gap,      -HmainSideMag,
+	-dX - middleGap - gap,		-HmainSideMag,
+	-dX2 - middleGap2 - Clgap2,     -dY2 + testGap,
+	-2 * dX2 - middleGap2 - Clgap2, -dY2 - dX2 + testGap,
+	-2 * dX2 - middleGap2 - gap2,   -HmainSideMag2,
+	-dX2 - middleGap2 - gap2,       -HmainSideMag2};
+    std::array<Double_t,16> cornersCRTA = {
+	-dX - middleGap - gap,		HmainSideMag,
+	-2 * dX - middleGap - gap,      HmainSideMag,
+	-2 * dX - middleGap - Clgap,    dY + dX - testGap,
+	-dX - middleGap - Clgap,	dY - testGap,
+	-dX2 - middleGap2 - gap2,       HmainSideMag2,
+	-2 * dX2 - middleGap2 - gap2,   HmainSideMag2,
+	-2 * dX2 - middleGap2 - Clgap2, dY2 + dX2 - testGap,
+	-dX2 - middleGap2 - Clgap2,     dY2 - testGap};
+    std::array<Double_t,16> cornersTL = {
+	middleGap + dX, dY,
+	middleGap, dY + dX,
+	2 * dX + middleGap + Clgap, dY + dX,
+	dX + middleGap + Clgap, dY,
+	middleGap2 + dX2, dY2,
+	middleGap2, dY2 + dX2,
+	2 * dX2 + middleGap2 + Clgap2, dY2 + dX2,
+	dX2 + middleGap2 + Clgap2, dY2};
+    std::array<Double_t,16> cornersTR = {
+	-dX - middleGap - Clgap, dY,
+	-2 * dX - middleGap - Clgap, dY + dX,
+	-middleGap, dY + dX,
+	-middleGap - dX, dY,
+	-dX2 - middleGap2 - Clgap2, dY2,
+	-2 * dX2 - middleGap2 - Clgap2, dY2 + dX2,
+	-middleGap2, dY2 + dX2,
+	-middleGap2 - dX2, dY2};
+    std::array<Double_t,16> cornersBL = {
+	dX + middleGap + Clgap, -dY,
+	2 * dX + middleGap + Clgap, -dY - dX,
+	middleGap, -dY - dX,
+	middleGap + dX, -dY,
+	dX2 + middleGap2 + Clgap2, -dY2,
+	2 * dX2 + middleGap2 + Clgap2, -dY2 - dX2,
+	middleGap2, -dY2 - dX2,
+	middleGap2 + dX2, -dY2};
+    std::array<Double_t,16> cornersBR = {
+	-middleGap - dX, -dY,
+	-middleGap, -dY - dX,
+	-2 * dX - middleGap - Clgap, -dY - dX,
+	-dX - middleGap - Clgap, -dY,
+	-middleGap2 - dX2, -dY2,
+	-middleGap2, -dY2 - dX2,
+	-2 * dX2 - middleGap2 - Clgap2, -dY2 - dX2,
+	-dX2 - middleGap2 - Clgap2, -dY2};
 				 
     char magnetId[100];
     const char* str1L ="_MiddleMagL";
@@ -190,10 +262,10 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
     switch (fieldDirection){
 
     case FieldDirection::up: 
-      CreateArb8(strcat(magnetId,str1L), medium, dZ, cornerMainL,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str1R), medium, dZ, cornerMainR,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str2), medium, dZ, cornerMainSideL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str3), medium, dZ, cornerMainSideR,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
+      CreateArb8(strcat(magnetId,str1L), medium, dZ, cornersMainL,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
+      CreateArb8(strcat(magnetId,str1R), medium, dZ, cornersMainR,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
+      CreateArb8(strcat(magnetId,str2), medium, dZ, cornersMainSideL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
+      CreateArb8(strcat(magnetId,str3), medium, dZ, cornersMainSideR,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
       CreateArb8(strcat(magnetId,str4), medium, dZ, cornersCLBA,color[1],fields[1],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
       CreateArb8(strcat(magnetId,str5), medium, dZ, cornersCLTA,color[1],fields[1],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
       CreateArb8(strcat(magnetId,str6), medium, dZ, cornersCRTA,color[1],fields[1],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
@@ -204,10 +276,10 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
       CreateArb8(strcat(magnetId,str11), medium, dZ, cornersBR,color[2],fields[3],tShield,1,0, 0, Z);
       break;
     case FieldDirection::down:
-	CreateArb8(strcat(magnetId,str1L), medium, dZ, cornerMainL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str1R), medium, dZ, cornerMainR,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str2), medium, dZ, cornerMainSideL,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str3), medium, dZ, cornerMainSideR,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
+	CreateArb8(strcat(magnetId,str1L), medium, dZ, cornersMainL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
+	CreateArb8(strcat(magnetId,str1R), medium, dZ, cornersMainR,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
+	CreateArb8(strcat(magnetId,str2), medium, dZ, cornersMainSideL,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
+	CreateArb8(strcat(magnetId,str3), medium, dZ, cornersMainSideR,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
 	CreateArb8(strcat(magnetId,str4), medium, dZ, cornersCLBA,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
 	CreateArb8(strcat(magnetId,str5), medium, dZ, cornersCLTA,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
 	CreateArb8(strcat(magnetId,str6), medium, dZ, cornersCRTA,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -555,7 +555,7 @@ void ShipMuonShield::ConstructGeometry()
 	Double_t anti_overlap = 0.1;
 	Double_t h1 = 0.5 * (dYIn[nM] + dXIn[nM] + anti_overlap - fFloor);
 	Double_t h2 = 0.5 * (dYOut[nM] + dXOut[nM] + anti_overlap - fFloor);
-	std::vector<Double_t> verticesIn = {
+	std::array<Double_t, 16> verticesIn = {
 	    -w1, -h1,
 	    +w1, -h1,
 	    +w1, +h1,
@@ -565,7 +565,7 @@ void ShipMuonShield::ConstructGeometry()
 	    +w1, +h1,
 	    -w1, +h1,
 	};
-	std::vector<Double_t> verticesOut = {
+	std::array<Double_t, 16> verticesOut = {
 	    -w2, -h2 - slope * m,
 	    +w2, -h2 - slope * m,
 	    +w2, +h2,

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -125,42 +125,42 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 				  Double_t HmainSideMag, Double_t HmainSideMag2,
 				  Double_t gap,Double_t gap2, Double_t Z, Bool_t NotMagnet)
   {
-    Double_t Clgap,Clgap2;
+    Double_t coil_gap,coil_gap2;
     Int_t color[4] = {45,31,30,38};
 
     if (NotMagnet) {
-      Clgap = gap;
-      Clgap2 = gap2;
+      coil_gap = gap;
+      coil_gap2 = gap2;
     } else {
-      Clgap = std::max(20., gap);
-      Clgap2 = std::max(20., gap2);
+      coil_gap = std::max(20., gap);
+      coil_gap2 = std::max(20., gap2);
       gap = std::max(2., gap);
       gap2 = std::max(2., gap2);
     }
 
-    Double_t testGap = (fDesign == 5) ? 0.0 : 0.1; // gap between fields in the
+    Double_t anti_overlap = (fDesign == 5) ? 0.0 : 0.1; // gap between fields in the
 						   // corners for mitred joints
 						   // (Geant goes crazy when
 						   // they touch each other)
 
     std::array<Double_t,16> cornersMainL = {
-	middleGap,	-dY - dX + testGap,
-	middleGap,	dY + dX - testGap,
-	dX + middleGap,   dY - testGap,
-	dX + middleGap,   -dY + testGap,
-	middleGap2,       -dY2 - dX2 + testGap,
-	middleGap2,       dY2 + dX2 - testGap,
-	dX2 + middleGap2, dY2 - testGap,
-	dX2 + middleGap2, -dY2 + testGap};
+	middleGap,	-dY - dX + anti_overlap,
+	middleGap,	dY + dX - anti_overlap,
+	dX + middleGap,   dY - anti_overlap,
+	dX + middleGap,   -dY + anti_overlap,
+	middleGap2,       -dY2 - dX2 + anti_overlap,
+	middleGap2,       dY2 + dX2 - anti_overlap,
+	dX2 + middleGap2, dY2 - anti_overlap,
+	dX2 + middleGap2, -dY2 + anti_overlap};
     std::array<Double_t,16> cornersMainR = {
-	-dX - middleGap,    -dY + testGap,
-	-dX - middleGap,    dY - testGap,
-	- middleGap,     dY + dX - testGap,
-	- middleGap,     -dY - dX + testGap,
-	-dX2 - middleGap2, -dY2 + testGap,
-	-dX2 - middleGap2, dY2 - testGap,
-	- middleGap2,  dY2 + dX2 - testGap,
-	- middleGap2,  -dY2 - dX2 + testGap};
+	-dX - middleGap,    -dY + anti_overlap,
+	-dX - middleGap,    dY - anti_overlap,
+	- middleGap,     dY + dX - anti_overlap,
+	- middleGap,     -dY - dX + anti_overlap,
+	-dX2 - middleGap2, -dY2 + anti_overlap,
+	-dX2 - middleGap2, dY2 - anti_overlap,
+	- middleGap2,  dY2 + dX2 - anti_overlap,
+	- middleGap2,  -dY2 - dX2 + anti_overlap};
     std::array<Double_t,16> cornersMainSideL = {
 	dX + middleGap + gap,	-HmainSideMag,
 	dX + middleGap + gap,	HmainSideMag,
@@ -182,75 +182,75 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
     std::array<Double_t,16> cornersCLBA = {
 	dX + middleGap + gap,	  -HmainSideMag,
 	2 * dX + middleGap + gap,      -HmainSideMag,
-	2 * dX + middleGap + Clgap,    -dY - dX + testGap,
-	dX + middleGap + Clgap,	-dY + testGap,
+	2 * dX + middleGap + coil_gap,    -dY - dX + anti_overlap,
+	dX + middleGap + coil_gap,	-dY + anti_overlap,
 	dX2 + middleGap2 + gap2,       -HmainSideMag2,
 	2 * dX2 + middleGap2 + gap2,   -HmainSideMag2,
-	2 * dX2 + middleGap2 + Clgap2, -dY2 - dX2 + testGap,
-	dX2 + middleGap2 + Clgap2,     -dY2 + testGap};
+	2 * dX2 + middleGap2 + coil_gap2, -dY2 - dX2 + anti_overlap,
+	dX2 + middleGap2 + coil_gap2,     -dY2 + anti_overlap};
     std::array<Double_t,16> cornersCLTA = {
-	dX + middleGap + Clgap,	dY - testGap,
-	2 * dX + middleGap + Clgap,    dY + dX - testGap,
+	dX + middleGap + coil_gap,	dY - anti_overlap,
+	2 * dX + middleGap + coil_gap,    dY + dX - anti_overlap,
 	2 * dX + middleGap + gap,      HmainSideMag,
 	dX + middleGap + gap,	  HmainSideMag,
-	dX2 + middleGap2 + Clgap2,     dY2 - testGap,
-	2 * dX2 + middleGap2 + Clgap2, dY2 + dX2 - testGap,
+	dX2 + middleGap2 + coil_gap2,     dY2 - anti_overlap,
+	2 * dX2 + middleGap2 + coil_gap2, dY2 + dX2 - anti_overlap,
 	2 * dX2 + middleGap2 + gap2,   HmainSideMag2,
 	dX2 + middleGap2 + gap2,       HmainSideMag2};
     std::array<Double_t,16> cornersCRBA = {
-	-dX - middleGap - Clgap,	-dY + testGap,
-	-2 * dX - middleGap - Clgap,    -dY - dX + testGap,
+	-dX - middleGap - coil_gap,	-dY + anti_overlap,
+	-2 * dX - middleGap - coil_gap,    -dY - dX + anti_overlap,
 	-2 * dX - middleGap - gap,      -HmainSideMag,
 	-dX - middleGap - gap,		-HmainSideMag,
-	-dX2 - middleGap2 - Clgap2,     -dY2 + testGap,
-	-2 * dX2 - middleGap2 - Clgap2, -dY2 - dX2 + testGap,
+	-dX2 - middleGap2 - coil_gap2,     -dY2 + anti_overlap,
+	-2 * dX2 - middleGap2 - coil_gap2, -dY2 - dX2 + anti_overlap,
 	-2 * dX2 - middleGap2 - gap2,   -HmainSideMag2,
 	-dX2 - middleGap2 - gap2,       -HmainSideMag2};
     std::array<Double_t,16> cornersCRTA = {
 	-dX - middleGap - gap,		HmainSideMag,
 	-2 * dX - middleGap - gap,      HmainSideMag,
-	-2 * dX - middleGap - Clgap,    dY + dX - testGap,
-	-dX - middleGap - Clgap,	dY - testGap,
+	-2 * dX - middleGap - coil_gap,    dY + dX - anti_overlap,
+	-dX - middleGap - coil_gap,	dY - anti_overlap,
 	-dX2 - middleGap2 - gap2,       HmainSideMag2,
 	-2 * dX2 - middleGap2 - gap2,   HmainSideMag2,
-	-2 * dX2 - middleGap2 - Clgap2, dY2 + dX2 - testGap,
-	-dX2 - middleGap2 - Clgap2,     dY2 - testGap};
+	-2 * dX2 - middleGap2 - coil_gap2, dY2 + dX2 - anti_overlap,
+	-dX2 - middleGap2 - coil_gap2,     dY2 - anti_overlap};
     std::array<Double_t,16> cornersTL = {
 	middleGap + dX, dY,
 	middleGap, dY + dX,
-	2 * dX + middleGap + Clgap, dY + dX,
-	dX + middleGap + Clgap, dY,
+	2 * dX + middleGap + coil_gap, dY + dX,
+	dX + middleGap + coil_gap, dY,
 	middleGap2 + dX2, dY2,
 	middleGap2, dY2 + dX2,
-	2 * dX2 + middleGap2 + Clgap2, dY2 + dX2,
-	dX2 + middleGap2 + Clgap2, dY2};
+	2 * dX2 + middleGap2 + coil_gap2, dY2 + dX2,
+	dX2 + middleGap2 + coil_gap2, dY2};
     std::array<Double_t,16> cornersTR = {
-	-dX - middleGap - Clgap, dY,
-	-2 * dX - middleGap - Clgap, dY + dX,
+	-dX - middleGap - coil_gap, dY,
+	-2 * dX - middleGap - coil_gap, dY + dX,
 	-middleGap, dY + dX,
 	-middleGap - dX, dY,
-	-dX2 - middleGap2 - Clgap2, dY2,
-	-2 * dX2 - middleGap2 - Clgap2, dY2 + dX2,
+	-dX2 - middleGap2 - coil_gap2, dY2,
+	-2 * dX2 - middleGap2 - coil_gap2, dY2 + dX2,
 	-middleGap2, dY2 + dX2,
 	-middleGap2 - dX2, dY2};
     std::array<Double_t,16> cornersBL = {
-	dX + middleGap + Clgap, -dY,
-	2 * dX + middleGap + Clgap, -dY - dX,
+	dX + middleGap + coil_gap, -dY,
+	2 * dX + middleGap + coil_gap, -dY - dX,
 	middleGap, -dY - dX,
 	middleGap + dX, -dY,
-	dX2 + middleGap2 + Clgap2, -dY2,
-	2 * dX2 + middleGap2 + Clgap2, -dY2 - dX2,
+	dX2 + middleGap2 + coil_gap2, -dY2,
+	2 * dX2 + middleGap2 + coil_gap2, -dY2 - dX2,
 	middleGap2, -dY2 - dX2,
 	middleGap2 + dX2, -dY2};
     std::array<Double_t,16> cornersBR = {
 	-middleGap - dX, -dY,
 	-middleGap, -dY - dX,
-	-2 * dX - middleGap - Clgap, -dY - dX,
-	-dX - middleGap - Clgap, -dY,
+	-2 * dX - middleGap - coil_gap, -dY - dX,
+	-dX - middleGap - coil_gap, -dY,
 	-middleGap2 - dX2, -dY2,
 	-middleGap2, -dY2 - dX2,
-	-2 * dX2 - middleGap2 - Clgap2, -dY2 - dX2,
-	-dX2 - middleGap2 - Clgap2, -dY2};
+	-2 * dX2 - middleGap2 - coil_gap2, -dY2 - dX2,
+	-dX2 - middleGap2 - coil_gap2, -dY2};
 				 
     TString str1L = "_MiddleMagL";
     TString str1R = "_MiddleMagR";

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -36,7 +36,7 @@ ShipMuonShield::ShipMuonShield(TString geofile)
   params.Read("params");
   Double_t LE = 10. * m, floor = 5. * m;
   fDesign = 8;
-  fField = 1.8;
+  fField = 1.7;
   dZ0 = 1 * m;
   dZ1 = 0.4 * m;
   dZ2 = 2.31 * m;

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -152,15 +152,6 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 	middleGap2,       dY2 + dX2 - anti_overlap,
 	dX2 + middleGap2, dY2 - anti_overlap,
 	dX2 + middleGap2, -dY2 + anti_overlap};
-    std::array<Double_t,16> cornersMainR = {
-	-dX - middleGap,    -dY + anti_overlap,
-	-dX - middleGap,    dY - anti_overlap,
-	- middleGap,     dY + dX - anti_overlap,
-	- middleGap,     -dY - dX + anti_overlap,
-	-dX2 - middleGap2, -dY2 + anti_overlap,
-	-dX2 - middleGap2, dY2 - anti_overlap,
-	- middleGap2,  dY2 + dX2 - anti_overlap,
-	- middleGap2,  -dY2 - dX2 + anti_overlap};
     std::array<Double_t,16> cornersMainSideL = {
 	dX + middleGap + gap,	-HmainSideMag,
 	dX + middleGap + gap,	HmainSideMag,
@@ -170,15 +161,6 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 	dX2 + middleGap2 + gap2,     HmainSideMag2,
 	2 * dX2 + middleGap2 + gap2, HmainSideMag2,
 	2 * dX2 + middleGap2 + gap2, -HmainSideMag2};
-    std::array<Double_t,16> cornersMainSideR = {
-	-dX - middleGap - gap,	-HmainSideMag,
-	-2 * dX - middleGap - gap,    -HmainSideMag,
-	-2 * dX - middleGap - gap,    HmainSideMag,
-	-dX - middleGap - gap,	HmainSideMag,
-	-dX2 - middleGap2 - gap2,     -HmainSideMag2,
-	-2 * dX2 - middleGap2 - gap2, -HmainSideMag2,
-	-2 * dX2 - middleGap2 - gap2, HmainSideMag2,
-	-dX2 - middleGap2 - gap2,     HmainSideMag2};
     std::array<Double_t,16> cornersCLBA = {
 	dX + middleGap + gap,	  -HmainSideMag,
 	2 * dX + middleGap + gap,      -HmainSideMag,
@@ -188,33 +170,6 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 	2 * dX2 + middleGap2 + gap2,   -HmainSideMag2,
 	2 * dX2 + middleGap2 + coil_gap2, -dY2 - dX2 + anti_overlap,
 	dX2 + middleGap2 + coil_gap2,     -dY2 + anti_overlap};
-    std::array<Double_t,16> cornersCLTA = {
-	dX + middleGap + coil_gap,	dY - anti_overlap,
-	2 * dX + middleGap + coil_gap,    dY + dX - anti_overlap,
-	2 * dX + middleGap + gap,      HmainSideMag,
-	dX + middleGap + gap,	  HmainSideMag,
-	dX2 + middleGap2 + coil_gap2,     dY2 - anti_overlap,
-	2 * dX2 + middleGap2 + coil_gap2, dY2 + dX2 - anti_overlap,
-	2 * dX2 + middleGap2 + gap2,   HmainSideMag2,
-	dX2 + middleGap2 + gap2,       HmainSideMag2};
-    std::array<Double_t,16> cornersCRBA = {
-	-dX - middleGap - coil_gap,	-dY + anti_overlap,
-	-2 * dX - middleGap - coil_gap,    -dY - dX + anti_overlap,
-	-2 * dX - middleGap - gap,      -HmainSideMag,
-	-dX - middleGap - gap,		-HmainSideMag,
-	-dX2 - middleGap2 - coil_gap2,     -dY2 + anti_overlap,
-	-2 * dX2 - middleGap2 - coil_gap2, -dY2 - dX2 + anti_overlap,
-	-2 * dX2 - middleGap2 - gap2,   -HmainSideMag2,
-	-dX2 - middleGap2 - gap2,       -HmainSideMag2};
-    std::array<Double_t,16> cornersCRTA = {
-	-dX - middleGap - gap,		HmainSideMag,
-	-2 * dX - middleGap - gap,      HmainSideMag,
-	-2 * dX - middleGap - coil_gap,    dY + dX - anti_overlap,
-	-dX - middleGap - coil_gap,	dY - anti_overlap,
-	-dX2 - middleGap2 - gap2,       HmainSideMag2,
-	-2 * dX2 - middleGap2 - gap2,   HmainSideMag2,
-	-2 * dX2 - middleGap2 - coil_gap2, dY2 + dX2 - anti_overlap,
-	-dX2 - middleGap2 - coil_gap2,     dY2 - anti_overlap};
     std::array<Double_t,16> cornersTL = {
 	middleGap + dX, dY,
 	middleGap, dY + dX,
@@ -224,33 +179,28 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 	middleGap2, dY2 + dX2,
 	2 * dX2 + middleGap2 + coil_gap2, dY2 + dX2,
 	dX2 + middleGap2 + coil_gap2, dY2};
-    std::array<Double_t,16> cornersTR = {
-	-dX - middleGap - coil_gap, dY,
-	-2 * dX - middleGap - coil_gap, dY + dX,
-	-middleGap, dY + dX,
-	-middleGap - dX, dY,
-	-dX2 - middleGap2 - coil_gap2, dY2,
-	-2 * dX2 - middleGap2 - coil_gap2, dY2 + dX2,
-	-middleGap2, dY2 + dX2,
-	-middleGap2 - dX2, dY2};
-    std::array<Double_t,16> cornersBL = {
-	dX + middleGap + coil_gap, -dY,
-	2 * dX + middleGap + coil_gap, -dY - dX,
-	middleGap, -dY - dX,
-	middleGap + dX, -dY,
-	dX2 + middleGap2 + coil_gap2, -dY2,
-	2 * dX2 + middleGap2 + coil_gap2, -dY2 - dX2,
-	middleGap2, -dY2 - dX2,
-	middleGap2 + dX2, -dY2};
-    std::array<Double_t,16> cornersBR = {
-	-middleGap - dX, -dY,
-	-middleGap, -dY - dX,
-	-2 * dX - middleGap - coil_gap, -dY - dX,
-	-dX - middleGap - coil_gap, -dY,
-	-middleGap2 - dX2, -dY2,
-	-middleGap2, -dY2 - dX2,
-	-2 * dX2 - middleGap2 - coil_gap2, -dY2 - dX2,
-	-dX2 - middleGap2 - coil_gap2, -dY2};
+
+    // Use symmetries to define remaining magnets
+    std::array<Double_t, 16> cornersMainR, cornersMainSideR, cornersCLTA,
+	cornersCRBA, cornersCRTA, cornersTR, cornersBL, cornersBR;
+    for (int i = 0; i < 16; ++i) {
+      cornersMainR[i] = -cornersMainL[i];
+      cornersMainSideR[i] = -cornersMainSideL[i];
+      cornersCRTA[i] = -cornersCLBA[i];
+      cornersBR[i] = -cornersTL[i];
+    }
+    // Need to change order as corners need to be defined clockwise
+    for (int i = 0, j = 4; i < 8; ++i) {
+      j = (11 - i) % 8;
+      cornersCLTA[2 * j] = cornersCLBA[2 * i];
+      cornersCLTA[2 * j + 1] = -cornersCLBA[2 * i + 1];
+      cornersTR[2 * j] = -cornersTL[2 * i];
+      cornersTR[2 * j + 1] = cornersTL[2 * i + 1];
+    }
+    for (int i = 0; i < 16; ++i) {
+      cornersCRBA[i] = -cornersCLTA[i];
+      cornersBL[i] = -cornersTR[i];
+    }
 				 
     TString str1L = "_MiddleMagL";
     TString str1R = "_MiddleMagR";

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -296,7 +296,7 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
 				std::vector<Double_t> &gapIn, std::vector<Double_t> &gapOut,
 				std::vector<Double_t> &Z) {
 
-  const Int_t nMagnets = (fDesign == 7 || fDesign == 8) ? 9 : 8;
+  const Int_t nMagnets = (fDesign >= 7) ? 9 : 8;
   magnetName.reserve(nMagnets);
   fieldDirection.reserve(nMagnets);
   for (auto i :
@@ -370,7 +370,6 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
     gapIn[8] = gapOut[7];
     gapOut[8] = gapIn[8];
     dZ[8] = 0.1 * m;
-    // TODO better clipping?
     Z[8] = Z[7] + dZ[7] + dZ[8];
 
     for (int i = 0; i < nMagnets; ++i) {
@@ -379,6 +378,105 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
       HmainSideMagIn[i] = dYIn[i] / 2;
       HmainSideMagOut[i] = dYOut[i] / 2;
     }
+
+  } else if (fDesign == 9) {
+     magnetName = {"MagnAbsorb1", "MagnAbsorb2", "Magn1", "Magn2", "Magn3",
+       "Magn4", "Magn5", "Magn6", "Magn7"
+     };
+
+     fieldDirection = {
+        FieldDirection::up, FieldDirection::up, FieldDirection::up,
+	FieldDirection::up, FieldDirection::up, FieldDirection::down,
+	FieldDirection::down, FieldDirection::down, FieldDirection::down,
+     };
+
+     dXIn[0] = 0.4 * m;
+     dXOut[0] = 0.40 * m;
+     dYIn[0] = 1.5 * m;
+     dYOut[0] = 1.5 * m;
+     gapIn[0] = 0.1 * mm;
+     gapOut[0] = 0.1 * mm;
+     dZ[0] = dZ1 - zgap / 2;
+     Z[0] = zEndOfAbsorb + dZ[0] + zgap;
+
+     dXIn[1] = 0.5 * m;
+     dXOut[1] = 0.5 * m;
+     dYIn[1] = 1.3 * m;
+     dYOut[1] = 1.3 * m;
+     gapIn[1] = 0.02 * m;
+     gapOut[1] = 0.02 * m;
+     dZ[1] = dZ2 - zgap / 2;
+     Z[1] = Z[0] + dZ[0] + dZ[1] + zgap;
+
+     dXIn[2] = 0.72 * m;
+     dXOut[2] = 0.51 * m;
+     dYIn[2] = 0.29 * m;
+     dYOut[2] = 0.46 * m;
+     gapIn[2] = 0.10 * m;
+     gapOut[2] = 0.07 * m;
+     dZ[2] = dZ3 - zgap / 2;
+     Z[2] = Z[1] + dZ[1] + dZ[2] + 2 * zgap;
+
+     dXIn[3] = 0.54 * m;
+     dXOut[3] = 0.38 * m;
+     dYIn[3] = 0.46 * m;
+     dYOut[3] = 1.92 * m;
+     gapIn[3] = 0.14 * m;
+     gapOut[3] = 0.09 * m;
+     dZ[3] = dZ4 - zgap / 2;
+     Z[3] = Z[2] + dZ[2] + dZ[3] + zgap;
+
+     dXIn[4] = 0.10 * m;
+     dXOut[4] = 0.31 * m;
+     dYIn[4] = 0.35 * m;
+     dYOut[4] = 0.31 * m;
+     gapIn[4] = 0.51 * m;
+     gapOut[4] = 0.11 * m;
+     dZ[4] = dZ5 - zgap / 2;
+     Z[4] = Z[3] + dZ[3] + dZ[4] + zgap;
+
+     dXIn[5] = 0.03 * m;
+     dXOut[5] = 0.32 * m;
+     dYIn[5] = 0.54 * m;
+     dYOut[5] = 0.24 * m;
+     gapIn[5] = 0.08 * m;
+     gapOut[5] = 0.08 * m;
+     dZ[5] = dZ6 - zgap / 2;
+     Z[5] = Z[4] + dZ[4] + dZ[5] + zgap;
+
+     dXIn[6] = 0.22 * m;
+     dXOut[6] = 0.32 * m;
+     dYIn[6] = 2.09 * m;
+     dYOut[6] = 0.35 * m;
+     gapIn[6] = 0.08 * m;
+     gapOut[6] = 0.13 * m;
+     dZ[6] = dZ7 - zgap / 2;
+     Z[6] = Z[5] + dZ[5] + dZ[6] + zgap;
+
+     dXIn[7] = 0.33 * m;
+     dXOut[7] = 0.77 * m;
+     dYIn[7] = 0.85 * m;
+     dYOut[7] = 2.41 * m;
+     gapIn[7] = 0.09 * m;
+     gapOut[7] = 0.26 * m;
+     dZ[7] = dZ8 - zgap / 2;
+     Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
+
+     dXIn[8] = dXOut[7];
+     dYIn[8] = dYOut[7];
+     dXOut[8] = dXIn[8];
+     dYOut[8] = dYIn[8];
+     gapIn[8] = gapOut[7];
+     gapOut[8] = gapIn[8];
+     dZ[8] = 0.1 * m;
+     Z[8] = Z[7] + dZ[7] + dZ[8];
+
+     for (int i = 0; i < nMagnets; ++i) {
+        midGapIn[i] = 0.;
+        midGapOut[i] = 0.;
+        HmainSideMagIn[i] = dYIn[i] / 2;
+        HmainSideMagOut[i] = dYOut[i] / 2;
+     }
 
   } else if (fDesign == 7) {
   magnetName = {"MagnAbsorb1", "MagnAbsorb2", "Magn1", "Magn2", "Magn3",
@@ -521,7 +619,7 @@ void ShipMuonShield::ConstructGeometry()
     InitMedium("Concrete");
     TGeoMedium *concrete  =gGeoManager->GetMedium("Concrete");
     
-    if (fDesign==5||fDesign==6||fDesign==7||fDesign==8) {
+    if (fDesign >= 5 && fDesign <= 9) {
       Double_t ironField = fField*tesla;
       TGeoUniformMagField *magFieldIron = new TGeoUniformMagField(0.,ironField,0.);
       TGeoUniformMagField *RetField     = new TGeoUniformMagField(0.,-ironField,0.);
@@ -538,7 +636,7 @@ void ShipMuonShield::ConstructGeometry()
 		 gapOut, Z);
       
 
-      if (fDesign==6){
+      if (fDesign == 6){
 	Double_t dA = 3*m;
 	CreateMagnet("AbsorberStop-1",iron,tShield,fields,FieldDirection::up,
 		  dA/6.,dA/6.,dA/6.,dA/6.,dZ0/3.,0,0,dA/12.,dA/12.,0,0,zEndOfAbsorb - 5.*dZ0/3.,0);
@@ -550,7 +648,7 @@ void ShipMuonShield::ConstructGeometry()
         TGeoCompositeShape *Tc = new TGeoCompositeShape("passiveAbsorberStopSubtr", subtraction);
         TGeoVolume* passivAbsorber = new TGeoVolume("passiveAbsorberStop-1",Tc, iron);
         tShield->AddNode(passivAbsorber, 1, new TGeoTranslation(0,0,zEndOfAbsorb - 5.*dZ0/3.));
-      } else if (fDesign==7||fDesign==8) {
+      } else if (fDesign >= 7) {
 
 	TGeoUniformMagField *fieldsAbsorber[4] = {
 	    new TGeoUniformMagField(0., 1.6 * tesla, 0.),

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -144,14 +144,16 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 						   // they touch each other)
 
     std::array<Double_t,16> cornersMainL = {
-	middleGap,	-dY - dX + anti_overlap,
+	middleGap, -(dY + dX - anti_overlap),
 	middleGap,	dY + dX - anti_overlap,
 	dX + middleGap,   dY - anti_overlap,
-	dX + middleGap,   -dY + anti_overlap,
-	middleGap2,       -dY2 - dX2 + anti_overlap,
+	dX + middleGap, -(dY - anti_overlap),
+	middleGap2, -(dY2 + dX2 - anti_overlap),
 	middleGap2,       dY2 + dX2 - anti_overlap,
 	dX2 + middleGap2, dY2 - anti_overlap,
-	dX2 + middleGap2, -dY2 + anti_overlap};
+	dX2 + middleGap2, -(dY2 - anti_overlap)
+    };
+
     std::array<Double_t,16> cornersMainSideL = {
 	dX + middleGap + gap,	-HmainSideMag,
 	dX + middleGap + gap,	HmainSideMag,
@@ -160,16 +162,20 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 	dX2 + middleGap2 + gap2,     -HmainSideMag2,
 	dX2 + middleGap2 + gap2,     HmainSideMag2,
 	2 * dX2 + middleGap2 + gap2, HmainSideMag2,
-	2 * dX2 + middleGap2 + gap2, -HmainSideMag2};
+	2 * dX2 + middleGap2 + gap2, -HmainSideMag2
+    };
+
     std::array<Double_t,16> cornersCLBA = {
 	dX + middleGap + gap,	  -HmainSideMag,
 	2 * dX + middleGap + gap,      -HmainSideMag,
-	2 * dX + middleGap + coil_gap,    -dY - dX + anti_overlap,
-	dX + middleGap + coil_gap,	-dY + anti_overlap,
+	2 * dX + middleGap + coil_gap, -(dY + dX - anti_overlap),
+	dX + middleGap + coil_gap, -(dY - anti_overlap),
 	dX2 + middleGap2 + gap2,       -HmainSideMag2,
 	2 * dX2 + middleGap2 + gap2,   -HmainSideMag2,
-	2 * dX2 + middleGap2 + coil_gap2, -dY2 - dX2 + anti_overlap,
-	dX2 + middleGap2 + coil_gap2,     -dY2 + anti_overlap};
+	2 * dX2 + middleGap2 + coil_gap2, -(dY2 + dX2 - anti_overlap),
+	dX2 + middleGap2 + coil_gap2, -(dY2 - anti_overlap)
+    };
+
     std::array<Double_t,16> cornersTL = {
 	middleGap + dX, dY,
 	middleGap, dY + dX,
@@ -178,7 +184,8 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 	middleGap2 + dX2, dY2,
 	middleGap2, dY2 + dX2,
 	2 * dX2 + middleGap2 + coil_gap2, dY2 + dX2,
-	dX2 + middleGap2 + coil_gap2, dY2};
+	dX2 + middleGap2 + coil_gap2, dY2
+    };
 
     // Use symmetries to define remaining magnets
     std::array<Double_t, 16> cornersMainR, cornersMainSideR, cornersCLTA,

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -93,25 +93,33 @@ Int_t ShipMuonShield::InitMedium(TString name)
    return geoBuild->createMedium(ShipMedium);
 }
 
-void ShipMuonShield::CreateTube(const char* tubeName, TGeoMedium* medium, Double_t dX,Double_t dY,Double_t dZ,Int_t color,TGeoVolume *tShield,Int_t numberOfItems, Double_t x_translation,Double_t y_translation,
-					Double_t z_translation)
-{
+void ShipMuonShield::CreateTube(TString tubeName, TGeoMedium *medium,
+				Double_t dX, Double_t dY, Double_t dZ,
+				Int_t color, TGeoVolume *tShield,
+				Double_t x_translation, Double_t y_translation,
+				Double_t z_translation) {
   TGeoVolume* absorber = gGeoManager->MakeTube(tubeName, medium, dX, dY,dZ);
   absorber->SetLineColor(color);  
-  tShield->AddNode(absorber, numberOfItems, new TGeoTranslation(x_translation, y_translation, z_translation ));
+  tShield->AddNode(
+      absorber, 1,
+      new TGeoTranslation(x_translation, y_translation, z_translation));
 }
 
-void ShipMuonShield::CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,std::array<Double_t,16> corners, Int_t color,
-				     TGeoUniformMagField *magField,TGeoVolume *tShield,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
-					Double_t z_translation)
-{
-  TGeoVolume* magF = gGeoManager->MakeArb8(arbName, medium, dZ, corners.data());
+void ShipMuonShield::CreateArb8(TString arbName, TGeoMedium *medium,
+				Double_t dZ, std::array<Double_t, 16> corners,
+				Int_t color, TGeoUniformMagField *magField,
+				TGeoVolume *tShield, Double_t x_translation,
+				Double_t y_translation,
+				Double_t z_translation) {
+  TGeoVolume *magF =
+      gGeoManager->MakeArb8(arbName, medium, dZ, corners.data());
   magF->SetLineColor(color);
   magF->SetField(magField);
-  tShield->AddNode(magF, 1, new TGeoTranslation(x_translation, y_translation, z_translation ));
+  tShield->AddNode(magF, 1, new TGeoTranslation(x_translation, y_translation,
+						z_translation));
 }
 
-void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeoVolume *tShield,TGeoUniformMagField *fields[4],FieldDirection fieldDirection,
+void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolume *tShield,TGeoUniformMagField *fields[4],FieldDirection fieldDirection,
 				  Double_t dX, Double_t dY, Double_t dX2, Double_t dY2, Double_t dZ,
 				  Double_t middleGap,Double_t middleGap2,
 				  Double_t HmainSideMag, Double_t HmainSideMag2,
@@ -244,55 +252,53 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
 	-2 * dX2 - middleGap2 - Clgap2, -dY2 - dX2,
 	-dX2 - middleGap2 - Clgap2, -dY2};
 				 
-    char magnetId[100];
-    const char* str1L ="_MiddleMagL";
-    const char* str1R ="_MiddleMagR";
-    const char* str2 ="_MagRetL";
-    const char* str3 ="_MagRetR";
-    const char* str4 ="_MagCLB";
-    const char* str5 ="_MagCLT";
-    const char* str6 ="_MagCRT";
-    const char* str7 ="_MagCRB";
-    const char* str8 ="_MagTopLeft";
-    const char* str9 ="_MagTopRight";
-    const char* str10 ="_MagBotLeft";
-    const char* str11 ="_MagBotRight";
-    strcpy(magnetId,magnetName);
+    TString str1L = "_MiddleMagL";
+    TString str1R = "_MiddleMagR";
+    TString str2 = "_MagRetL";
+    TString str3 = "_MagRetR";
+    TString str4 = "_MagCLB";
+    TString str5 = "_MagCLT";
+    TString str6 = "_MagCRT";
+    TString str7 = "_MagCRB";
+    TString str8 = "_MagTopLeft";
+    TString str9 = "_MagTopRight";
+    TString str10 = "_MagBotLeft";
+    TString str11 = "_MagBotRight";
 
     switch (fieldDirection){
 
     case FieldDirection::up: 
-      CreateArb8(strcat(magnetId,str1L), medium, dZ, cornersMainL,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str1R), medium, dZ, cornersMainR,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str2), medium, dZ, cornersMainSideL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str3), medium, dZ, cornersMainSideR,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str4), medium, dZ, cornersCLBA,color[1],fields[1],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str5), medium, dZ, cornersCLTA,color[1],fields[1],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str6), medium, dZ, cornersCRTA,color[1],fields[1],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str7), medium, dZ, cornersCRBA,color[1],fields[1],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str8), medium, dZ, cornersTL,color[2],fields[3],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str9), medium, dZ, cornersTR,color[0],fields[2],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str10), medium, dZ, cornersBL,color[0],fields[2],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-      CreateArb8(strcat(magnetId,str11), medium, dZ, cornersBR,color[2],fields[3],tShield,1,0, 0, Z);
+      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str4, medium, dZ, cornersCLBA, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str5, medium, dZ, cornersCLTA, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str6, medium, dZ, cornersCRTA, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str7, medium, dZ, cornersCRBA, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[2], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[0], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[0], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[2], fields[3], tShield,  0, 0, Z);
       break;
     case FieldDirection::down:
-	CreateArb8(strcat(magnetId,str1L), medium, dZ, cornersMainL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str1R), medium, dZ, cornersMainR,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str2), medium, dZ, cornersMainSideL,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str3), medium, dZ, cornersMainSideR,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str4), medium, dZ, cornersCLBA,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str5), medium, dZ, cornersCLTA,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str6), medium, dZ, cornersCRTA,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str7), medium, dZ, cornersCRBA,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str8), medium, dZ, cornersTL,color[0],fields[2],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str9), medium, dZ, cornersTR,color[2],fields[3],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str10), medium, dZ, cornersBL,color[2],fields[3],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
-	CreateArb8(strcat(magnetId,str11), medium, dZ, cornersBR,color[0],fields[2],tShield,1,0, 0, Z);
+      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str4, medium, dZ, cornersCLBA, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str5, medium, dZ, cornersCLTA, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str6, medium, dZ, cornersCRTA, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str7, medium, dZ, cornersCRBA, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[0], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[2], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[2], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[0], fields[2], tShield,  0, 0, Z);
       break;
     }
   }
 
-void ShipMuonShield::Initialize (const char* (&magnetName)[9],FieldDirection (&fieldDirection)[9],
+void ShipMuonShield::Initialize (TString (&magnetName)[9],FieldDirection (&fieldDirection)[9],
 				    Double_t (&dXIn)[9], Double_t (&dYIn)[9], Double_t (&dXOut)[9], Double_t (&dYOut)[9], Double_t (&dZ)[9],
 				  Double_t (&midGapIn)[9],Double_t (&midGapOut)[9],
 				  Double_t (&HmainSideMagIn)[9], Double_t (&HmainSideMagOut)[9],
@@ -466,7 +472,7 @@ void ShipMuonShield::ConstructGeometry()
       // need to use literal 8 here as initialisation function's signature requires it.
       // TODO use nMagnets, std::vector and TString!
       const static int nMag = 9;
-      const char *magnetName[nMag];
+      TString magnetName[nMag];
       FieldDirection fieldDirection[nMag];
       Double_t dXIn[nMag], dYIn[nMag], dXOut[nMag], dYOut[nMag], dZf[nMag], midGapIn[nMag],
 	  midGapOut[nMag], HmainSideMagIn[nMag], HmainSideMagOut[nMag], gapIn[nMag],
@@ -583,8 +589,8 @@ void ShipMuonShield::ConstructGeometry()
       }
           
       } else {
-	CreateTube("AbsorberAdd", iron, 15, 400, dZ0, 43, tShield, 1, 0, 0, zEndOfAbsorb - dZ0);
-	CreateTube("AbsorberAddCore", iron, 0, 15, dZ0, 38, tShield, 1, 0, 0, zEndOfAbsorb - dZ0);
+	CreateTube("AbsorberAdd", iron, 15, 400, dZ0, 43, tShield, 0, 0, zEndOfAbsorb - dZ0);
+	CreateTube("AbsorberAddCore", iron, 0, 15, dZ0, 38, tShield, 0, 0, zEndOfAbsorb - dZ0);
 
 	for (Int_t nM = 0; nM < (nMagnets - 1); nM++) {
 	  CreateMagnet(magnetName[nM],iron,tShield,fields,fieldDirection[nM],

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -132,8 +132,7 @@ void ShipMuonShield::CreateArb8(const char* arbName, TGeoMedium* medium,Double_t
   tShield->AddNode(magF, 1, new TGeoTranslation(x_translation, y_translation, z_translation ));
 }
 
-
-void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeoVolume *tShield,TGeoUniformMagField *fields[4],const char* fieldDirection,
+void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeoVolume *tShield,TGeoUniformMagField *fields[4],FieldDirection fieldDirection,
 				  Double_t dX, Double_t dY, Double_t dX2, Double_t dY2, Double_t dZ,
 				  Double_t middleGap,Double_t middleGap2,
 				  Double_t HmainSideMag, Double_t HmainSideMag2,
@@ -197,7 +196,10 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
     const char* str10 ="_MagBotLeft";
     const char* str11 ="_MagBotRight";
     strcpy(magnetId,magnetName);
-    if (!strncmp(fieldDirection, "up", 2)) {
+
+    switch (fieldDirection){
+
+    case FieldDirection::up: 
       CreateArb8(strcat(magnetId,str1L), medium, dZ, cornerMainL,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
       CreateArb8(strcat(magnetId,str1R), medium, dZ, cornerMainR,color[3],fields[0],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
       CreateArb8(strcat(magnetId,str2), medium, dZ, cornerMainSideL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
@@ -210,8 +212,8 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
       CreateArb8(strcat(magnetId,str9), medium, dZ, cornersTR,color[0],fields[2],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
       CreateArb8(strcat(magnetId,str10), medium, dZ, cornersBL,color[0],fields[2],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
       CreateArb8(strcat(magnetId,str11), medium, dZ, cornersBR,color[2],fields[3],tShield,1,0, 0, Z);
-    } else{
-      if (!strncmp(fieldDirection, "down", 4)) {
+      break;
+    case FieldDirection::down:
 	CreateArb8(strcat(magnetId,str1L), medium, dZ, cornerMainL,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
 	CreateArb8(strcat(magnetId,str1R), medium, dZ, cornerMainR,color[1],fields[1],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
 	CreateArb8(strcat(magnetId,str2), medium, dZ, cornerMainSideL,color[3],fields[0],tShield,1,0, 0, Z);		strcpy(magnetId,magnetName);
@@ -224,10 +226,11 @@ void ShipMuonShield::CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeo
 	CreateArb8(strcat(magnetId,str9), medium, dZ, cornersTR,color[2],fields[3],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
 	CreateArb8(strcat(magnetId,str10), medium, dZ, cornersBL,color[2],fields[3],tShield,1,0, 0, Z);			strcpy(magnetId,magnetName);
 	CreateArb8(strcat(magnetId,str11), medium, dZ, cornersBR,color[0],fields[2],tShield,1,0, 0, Z);
-      } else {cout<<" Field direction has been set incorrect! Choose ""up"" or ""down"" direction "<<endl;}}
+      break;
+    }
   }
 
-void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fieldDirection)[9],
+void ShipMuonShield::Initialize (const char* (&magnetName)[9],FieldDirection (&fieldDirection)[9],
 				    Double_t (&dXIn)[9], Double_t (&dYIn)[9], Double_t (&dXOut)[9], Double_t (&dYOut)[9], Double_t (&dZ)[9],
 				  Double_t (&midGapIn)[9],Double_t (&midGapOut)[9],
 				  Double_t (&HmainSideMagIn)[9], Double_t (&HmainSideMagOut)[9],
@@ -237,7 +240,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   Double_t dYEnd = fY;
   if(fDesign==7){
       
-  magnetName[0] = "MagnAbsorb1";	fieldDirection[0] = "up";
+  magnetName[0] = "MagnAbsorb1";	fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.4*m;			dYIn[0]	= 1.5*m;
   dXOut[0] = 0.40*m;			dYOut[0]= 1.5*m;
   midGapIn[0] = 0; 			midGapOut[0] = 0;
@@ -245,7 +248,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[0] = 0.02*m;			gapOut[0] = 0.02*m;
   dZ[0] = dZ1-zgap/2;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
   
-  magnetName[1] = "MagnAbsorb2";	fieldDirection[1] = "up";
+  magnetName[1] = "MagnAbsorb2";	fieldDirection[1] = FieldDirection::up;
   dXIn[1]  = 0.8*m;			dYIn[1]	= 1.5*m;
   dXOut[1] = 0.8*m;			dYOut[1]= 1.5*m;
   midGapIn[1] = 0; 			midGapOut[1] = 0;
@@ -253,7 +256,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[1] = 0.02*m;				gapOut[1] = 0.02*m;
   dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
     
-  magnetName[2] = "Magn1";		fieldDirection[2] = "up";
+  magnetName[2] = "Magn1";		fieldDirection[2] = FieldDirection::up;
   dXIn[2]  = 0.87*m;			dYIn[2]	= 0.35*m;
   dXOut[2] = 0.65*m;			dYOut[2]= 1.21*m;
   midGapIn[2] = 0; 			midGapOut[2] = 0;
@@ -261,7 +264,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[2] = 0.11*m;				gapOut[2] = 0.02*m;
   dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
 
-  magnetName[3] = "Magn2";		fieldDirection[3] = "up";
+  magnetName[3] = "Magn2";		fieldDirection[3] = FieldDirection::up;
   dXIn[3]  = 0.65*m;			dYIn[3]	= 1.21*m;
   dXOut[3] = 0.43*m;			dYOut[3]= 2.07*m;
   midGapIn[3] = 0; 			midGapOut[3] = 0;
@@ -269,7 +272,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[3] = 0.11*m;				gapOut[3] = 0.02*m;
   dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
 
-  magnetName[4] = "Magn3";		fieldDirection[4] = "up";
+  magnetName[4] = "Magn3";		fieldDirection[4] = FieldDirection::up;
   dXIn[4]  = 0.06*m;			dYIn[4]	= 0.32*m;
   dXOut[4] = 0.33*m;			dYOut[4]= 0.13*m;
   midGapIn[4] = 0; 			midGapOut[4] = 0;
@@ -277,7 +280,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[4] = 0.7*m;			gapOut[4] = 0.11*m;
   dZ[4] = dZ5-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
   
-  magnetName[5] = "Magn4";		fieldDirection[5] = "down";
+  magnetName[5] = "Magn4";		fieldDirection[5] = FieldDirection::down;
   dXIn[5]  = 0.05*m;			dYIn[5]	= 1.12*m;
   dXOut[5] =0.16*m;			dYOut[5]= 0.05*m;
   midGapIn[5] = 0; 			midGapOut[5] = 0;
@@ -285,7 +288,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[5] = 0.04*m;			gapOut[5] = 0.02*m;
   dZ[5] = dZ6-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
   
-  magnetName[6] = "Magn5";		fieldDirection[6] = "down";
+  magnetName[6] = "Magn5";		fieldDirection[6] = FieldDirection::down;
   dXIn[6]  = 0.15*m;			dYIn[6]	= 2.35*m;
   dXOut[6] = 0.34*m;			dYOut[6]= 0.32*m;
   midGapIn[6] = 0; 		        midGapOut[6] = 0;
@@ -294,7 +297,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   dZ[6] = dZ7-zgap/2;			Z[6] = Z[5] + dZ[5] + dZ[6]+zgap;
   
   Double_t clip_width = 0.1*m; // clip field width by this width
-  magnetName[7] = "Magn6";		fieldDirection[7] = "down";
+  magnetName[7] = "Magn6";		fieldDirection[7] = FieldDirection::down;
   dXIn[7]  = 0.31*m;			dYIn[7]	= 1.86*m;
   dXOut[7] = 0.9*m - clip_width;	dYOut[7]= 3.1*m;
   midGapIn[7] = 0; 		        midGapOut[7] = 0;
@@ -304,7 +307,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[7] = 0.02*m;			gapOut[7] = 0.55*m;
   dZ[7] = dZ8 - clip_len - zgap / 2;	Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
 
-  magnetName[8] = "Magn7";		fieldDirection[8] = "down";
+  magnetName[8] = "Magn7";		fieldDirection[8] = FieldDirection::down;
   dXIn[8]  = dXOut[7];			dYIn[8]	= dYOut[7];
   dXOut[8] = dXOut[7];			dYOut[8]= dYOut[7];
   midGapIn[8] = 0; 		        midGapOut[8] = 0;
@@ -312,9 +315,8 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[8] = 0.55*m;			gapOut[8] = 0.55*m;
   dZ[8] = clip_len;			Z[8] = Z[7] + dZ[7] + dZ[8];
       
-    }
-  else{
-  magnetName[0] = "1";			fieldDirection[0] = "up";
+  } else {
+  magnetName[0] = "1";			fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.7*m;			dYIn[0]	= 1.*m; 
   dXOut[0] = 0.7*m;			dYOut[0]= 0.8158*m;
   midGapIn[0] = 0; 			midGapOut[0] = 0;
@@ -322,7 +324,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[0] = 20;			gapOut[0] = 20;
   dZ[0] = dZ1-zgap;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
     
-  magnetName[1] = "2";			fieldDirection[1] = "up";
+  magnetName[1] = "2";			fieldDirection[1] = FieldDirection::up;
   dXIn[1]  = 0.36*m;			dYIn[1]	= 0.8158*m;
   dXOut[1] = 0.19*m;			dYOut[1]= 0.499*m;
   midGapIn[1] = 0; 			midGapOut[1] = 0;
@@ -330,7 +332,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[1] = 88;			gapOut[1] = 122;
   dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
   
-  magnetName[2] = "3";			fieldDirection[2] = "down";
+  magnetName[2] = "3";			fieldDirection[2] = FieldDirection::down;
   dXIn[2]  = 0.075*m;			dYIn[2]	= 0.499*m;
   dXOut[2] = 0.25*m;			dYOut[2]= 1.10162*m;
   midGapIn[2] = 0; 			midGapOut[2] = 0;
@@ -338,7 +340,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[2] = 0;				gapOut[2] = 0;
   dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
     
-  magnetName[3] = "4";			fieldDirection[3] = "down";
+  magnetName[3] = "4";			fieldDirection[3] = FieldDirection::down;
   dXIn[3]  = 0.25*m;			dYIn[3]	= 1.10262*m;
   dXOut[3] = 0.3*m;			dYOut[3]= 1.82697*m;
   midGapIn[3] = 0; 			midGapOut[3] = 0;
@@ -346,7 +348,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[3] = 0;				gapOut[3] = 25;
   dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
 
-  magnetName[4] = "5";			fieldDirection[4] = "down";
+  magnetName[4] = "5";			fieldDirection[4] = FieldDirection::down;
   dXIn[4]  = 0.3*m;			dYIn[4]	= 1.82697*m;
   dXOut[4] = 0.4*m;			dYOut[4]= 2.55131*m;
   midGapIn[4] = 5; 			midGapOut[4] = 25;
@@ -354,7 +356,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[4] = 20;			gapOut[4] = 20;
   dZ[4] = dZ6-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
   
-  magnetName[5] = "6";			fieldDirection[5] = "down";
+  magnetName[5] = "6";			fieldDirection[5] = FieldDirection::down;
   dXIn[5]  = 0.4*m;			dYIn[5]	= 2.55131*m;
   dXOut[5] =0.4*m;			dYOut[5]= 3.27566*m;
   midGapIn[5] = 25; 			midGapOut[5] = 65;
@@ -362,7 +364,7 @@ void ShipMuonShield::Initialize (const char* (&magnetName)[9],const char* (&fiel
   gapIn[5] = 20;			gapOut[5] = 20;
   dZ[5] = dZ7-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
   
-  magnetName[6] = "7";			fieldDirection[6] = "down";
+  magnetName[6] = "7";			fieldDirection[6] = FieldDirection::down;
   dXIn[6]  = 0.4*m;			dYIn[6]	= 3.27566*m;
   dXOut[6] = 0.75*m;			dYOut[6]= 4*m;
   midGapIn[6] = 65; 		        midGapOut[6] = 75;
@@ -403,7 +405,7 @@ void ShipMuonShield::ConstructGeometry()
       // TODO use nMagnets, std::vector and TString!
       const static int nMag = 9;
       const char *magnetName[nMag];
-      const char *fieldDirection[nMag];
+      FieldDirection fieldDirection[nMag];
       Double_t dXIn[nMag], dYIn[nMag], dXOut[nMag], dYOut[nMag], dZf[nMag], midGapIn[nMag],
 	  midGapOut[nMag], HmainSideMagIn[nMag], HmainSideMagOut[nMag], gapIn[nMag],
 	  gapOut[nMag], Z[nMag];
@@ -411,9 +413,9 @@ void ShipMuonShield::ConstructGeometry()
       
       if (fDesign==6){
 	Double_t dA = 3*m;
-	CreateMagnet("AbsorberStop-1",iron,tShield,fields,"up",
+	CreateMagnet("AbsorberStop-1",iron,tShield,fields,FieldDirection::up,
 		  dA/6.,dA/6.,dA/6.,dA/6.,dZ0/3.,0,0,dA/12.,dA/12.,0,0,zEndOfAbsorb - 5.*dZ0/3.,0);
-	CreateMagnet("AbsorberStop-2",iron,tShield,fields,"up",
+	CreateMagnet("AbsorberStop-2",iron,tShield,fields,FieldDirection::up,
 		  dA/2.,dA/2.,dA/2.,dA/2.,dZ0*2./3.,0,0,dA/4.,dA/4.,0,0,zEndOfAbsorb - 2.*dZ0/3.,0);
         TGeoBBox* fullAbsorber = new TGeoBBox("fullAbsorber", dA, dA, dZ0/3.);
         TGeoBBox* cutOut = new TGeoBBox("cutout", dA/3.+20*cm, dA/3.+20*cm, dZ0/3.+0.1*mm); //no idea why to add 20cm

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -126,7 +126,7 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 				  Double_t gap,Double_t gap2, Double_t Z, Bool_t NotMagnet)
   {
     Double_t Clgap,Clgap2;
-    Int_t color[4] = {30,31,38,45};
+    Int_t color[4] = {45,31,30,38};
 
     if (NotMagnet) {
       Clgap = gap;
@@ -268,32 +268,32 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
     switch (fieldDirection){
 
     case FieldDirection::up: 
-      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[3], fields[0], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[3], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[0], fields[0], tShield,  0, 0, Z);
       CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[1], fields[1], tShield,  0, 0, Z);
       CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[1], fields[1], tShield,  0, 0, Z);
       CreateArb8(magnetName + str4, medium, dZ, cornersCLBA, color[1], fields[1], tShield,  0, 0, Z);
       CreateArb8(magnetName + str5, medium, dZ, cornersCLTA, color[1], fields[1], tShield,  0, 0, Z);
       CreateArb8(magnetName + str6, medium, dZ, cornersCRTA, color[1], fields[1], tShield,  0, 0, Z);
       CreateArb8(magnetName + str7, medium, dZ, cornersCRBA, color[1], fields[1], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[2], fields[3], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[0], fields[2], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[0], fields[2], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[2], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[3], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[2], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[2], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[3], fields[3], tShield,  0, 0, Z);
       break;
     case FieldDirection::down:
       CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[1], fields[1], tShield,  0, 0, Z);
       CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[1], fields[1], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[3], fields[0], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[3], fields[0], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str4, medium, dZ, cornersCLBA, color[3], fields[0], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str5, medium, dZ, cornersCLTA, color[3], fields[0], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str6, medium, dZ, cornersCRTA, color[3], fields[0], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str7, medium, dZ, cornersCRBA, color[3], fields[0], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[0], fields[2], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[2], fields[3], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[2], fields[3], tShield,  0, 0, Z);
-      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[0], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str4, medium, dZ, cornersCLBA, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str5, medium, dZ, cornersCLTA, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str6, medium, dZ, cornersCRTA, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str7, medium, dZ, cornersCRBA, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[2], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[3], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[3], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[2], fields[2], tShield,  0, 0, Z);
       break;
     }
   }

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -298,7 +298,7 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
     }
   }
 
-void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
+Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
 				std::vector<FieldDirection> &fieldDirection,
 				std::vector<Double_t> &dXIn, std::vector<Double_t> &dYIn,
 				std::vector<Double_t> &dXOut, std::vector<Double_t> &dYOut,
@@ -322,51 +322,53 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   Double_t dYEnd = fY;
 
   if(fDesign==7){
+  magnetName = {"MagnAbsorb1", "MagnAbsorb2", "Magn1", "Magn2", "Magn3",
+                "Magn4", "Magn5", "Magn6", "Magn7"};
       
-  magnetName[0] = "MagnAbsorb1";	fieldDirection[0] = FieldDirection::up;
+  fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.4*m;			dYIn[0]	= 1.5*m;
   dXOut[0] = 0.40*m;			dYOut[0]= 1.5*m;
   gapIn[0] = 0.02*m;			gapOut[0] = 0.02*m;
   dZ[0] = dZ1-zgap/2;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
   
-  magnetName[1] = "MagnAbsorb2";	fieldDirection[1] = FieldDirection::up;
+  fieldDirection[1] = FieldDirection::up;
   dXIn[1]  = 0.8*m;			dYIn[1]	= 1.5*m;
   dXOut[1] = 0.8*m;			dYOut[1]= 1.5*m;
   gapIn[1] = 0.02*m;				gapOut[1] = 0.02*m;
   dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
     
-  magnetName[2] = "Magn1";		fieldDirection[2] = FieldDirection::up;
+  fieldDirection[2] = FieldDirection::up;
   dXIn[2]  = 0.87*m;			dYIn[2]	= 0.35*m;
   dXOut[2] = 0.65*m;			dYOut[2]= 1.21*m;
   gapIn[2] = 0.11*m;				gapOut[2] = 0.02*m;
   dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
 
-  magnetName[3] = "Magn2";		fieldDirection[3] = FieldDirection::up;
+  fieldDirection[3] = FieldDirection::up;
   dXIn[3]  = 0.65*m;			dYIn[3]	= 1.21*m;
   dXOut[3] = 0.43*m;			dYOut[3]= 2.07*m;
   gapIn[3] = 0.11*m;				gapOut[3] = 0.02*m;
   dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
 
-  magnetName[4] = "Magn3";		fieldDirection[4] = FieldDirection::up;
+  fieldDirection[4] = FieldDirection::up;
   dXIn[4]  = 0.06*m;			dYIn[4]	= 0.32*m;
   dXOut[4] = 0.33*m;			dYOut[4]= 0.13*m;
   gapIn[4] = 0.7*m;			gapOut[4] = 0.11*m;
   dZ[4] = dZ5-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
   
-  magnetName[5] = "Magn4";		fieldDirection[5] = FieldDirection::down;
+  fieldDirection[5] = FieldDirection::down;
   dXIn[5]  = 0.05*m;			dYIn[5]	= 1.12*m;
   dXOut[5] =0.16*m;			dYOut[5]= 0.05*m;
   gapIn[5] = 0.04*m;			gapOut[5] = 0.02*m;
   dZ[5] = dZ6-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
   
-  magnetName[6] = "Magn5";		fieldDirection[6] = FieldDirection::down;
+  fieldDirection[6] = FieldDirection::down;
   dXIn[6]  = 0.15*m;			dYIn[6]	= 2.35*m;
   dXOut[6] = 0.34*m;			dYOut[6]= 0.32*m;
   gapIn[6] = 0.05*m;			gapOut[6] = 0.08*m;
   dZ[6] = dZ7-zgap/2;			Z[6] = Z[5] + dZ[5] + dZ[6]+zgap;
   
   Double_t clip_width = 0.1*m; // clip field width by this width
-  magnetName[7] = "Magn6";		fieldDirection[7] = FieldDirection::down;
+  fieldDirection[7] = FieldDirection::down;
   dXIn[7]  = 0.31*m;			dYIn[7]	= 1.86*m;
   dXOut[7] = 0.9*m - clip_width;	dYOut[7]= 3.1*m;
   Double_t clip_len =
@@ -374,13 +376,13 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[7] = 0.02*m;			gapOut[7] = 0.55*m;
   dZ[7] = dZ8 - clip_len - zgap / 2;	Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
 
-  magnetName[8] = "Magn7";		fieldDirection[8] = FieldDirection::down;
+  fieldDirection[8] = FieldDirection::down;
   dXIn[8]  = dXOut[7];			dYIn[8]	= dYOut[7];
   dXOut[8] = dXOut[7];			dYOut[8]= dYOut[7];
   gapIn[8] = 0.55*m;			gapOut[8] = 0.55*m;
   dZ[8] = clip_len;			Z[8] = Z[7] + dZ[7] + dZ[8];
       
-  for (int i = 0; i <= 8; ++i) {
+  for (int i = 0; i < nMagnets; ++i) {
     midGapIn[i] = 0.;
     midGapOut[i] = 0.;
     HmainSideMagIn[i] = dYIn[i] / 2;
@@ -388,7 +390,10 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   }
 
   } else {
-  magnetName[0] = "1";			fieldDirection[0] = FieldDirection::up;
+
+  magnetName = {"1", "2", "3", "4", "5", "6", "7"};
+
+  fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.7*m;			dYIn[0]	= 1.*m; 
   dXOut[0] = 0.7*m;			dYOut[0]= 0.8158*m;
   midGapIn[0] = 0; 			midGapOut[0] = 0;
@@ -396,7 +401,7 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[0] = 20;			gapOut[0] = 20;
   dZ[0] = dZ1-zgap;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
     
-  magnetName[1] = "2";			fieldDirection[1] = FieldDirection::up;
+  fieldDirection[1] = FieldDirection::up;
   dXIn[1]  = 0.36*m;			dYIn[1]	= 0.8158*m;
   dXOut[1] = 0.19*m;			dYOut[1]= 0.499*m;
   midGapIn[1] = 0; 			midGapOut[1] = 0;
@@ -404,7 +409,7 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[1] = 88;			gapOut[1] = 122;
   dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
   
-  magnetName[2] = "3";			fieldDirection[2] = FieldDirection::down;
+  fieldDirection[2] = FieldDirection::down;
   dXIn[2]  = 0.075*m;			dYIn[2]	= 0.499*m;
   dXOut[2] = 0.25*m;			dYOut[2]= 1.10162*m;
   midGapIn[2] = 0; 			midGapOut[2] = 0;
@@ -412,7 +417,7 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[2] = 0;				gapOut[2] = 0;
   dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
     
-  magnetName[3] = "4";			fieldDirection[3] = FieldDirection::down;
+  fieldDirection[3] = FieldDirection::down;
   dXIn[3]  = 0.25*m;			dYIn[3]	= 1.10262*m;
   dXOut[3] = 0.3*m;			dYOut[3]= 1.82697*m;
   midGapIn[3] = 0; 			midGapOut[3] = 0;
@@ -420,7 +425,7 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[3] = 0;				gapOut[3] = 25;
   dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
 
-  magnetName[4] = "5";			fieldDirection[4] = FieldDirection::down;
+  fieldDirection[4] = FieldDirection::down;
   dXIn[4]  = 0.3*m;			dYIn[4]	= 1.82697*m;
   dXOut[4] = 0.4*m;			dYOut[4]= 2.55131*m;
   midGapIn[4] = 5; 			midGapOut[4] = 25;
@@ -428,7 +433,7 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[4] = 20;			gapOut[4] = 20;
   dZ[4] = dZ6-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
   
-  magnetName[5] = "6";			fieldDirection[5] = FieldDirection::down;
+  fieldDirection[5] = FieldDirection::down;
   dXIn[5]  = 0.4*m;			dYIn[5]	= 2.55131*m;
   dXOut[5] =0.4*m;			dYOut[5]= 3.27566*m;
   midGapIn[5] = 25; 			midGapOut[5] = 65;
@@ -436,7 +441,7 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[5] = 20;			gapOut[5] = 20;
   dZ[5] = dZ7-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
   
-  magnetName[6] = "7";			fieldDirection[6] = FieldDirection::down;
+  fieldDirection[6] = FieldDirection::down;
   dXIn[6]  = 0.4*m;			dYIn[6]	= 3.27566*m;
   dXOut[6] = 0.75*m;			dYOut[6]= 4*m;
   midGapIn[6] = 65; 		        midGapOut[6] = 75;
@@ -444,25 +449,21 @@ void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   gapIn[6] = 20;			gapOut[6] = 20;
   dZ[6] = dZ8-zgap/2;			Z[6] = Z[5] + dZ[5] + dZ[6]+zgap;
   }
+  return nMagnets;
 }
 void ShipMuonShield::ConstructGeometry()
 {
     TGeoVolume *top=gGeoManager->GetTopVolume();
     TGeoVolume *tShield = new TGeoVolumeAssembly("MuonShieldArea");
-    InitMedium("tungsten");
-    TGeoMedium *tungsten =gGeoManager->GetMedium("tungsten");
     InitMedium("steel");
     TGeoMedium *steel =gGeoManager->GetMedium("steel");
     InitMedium("iron");
     TGeoMedium *iron  =gGeoManager->GetMedium("iron");
-    InitMedium("lead");
-    TGeoMedium *lead  =gGeoManager->GetMedium("lead");
     InitMedium("Concrete");
     TGeoMedium *concrete  =gGeoManager->GetMedium("Concrete");
     
     if (fDesign==4||fDesign==5||fDesign==6||fDesign==7){
       Double_t ironField = fField*tesla;
-      std::cout << "fField  " << fField << std::endl;
       TGeoUniformMagField *magFieldIron = new TGeoUniformMagField(0.,ironField,0.);
       TGeoUniformMagField *RetField     = new TGeoUniformMagField(0.,-ironField,0.);
       TGeoUniformMagField *ConRField    = new TGeoUniformMagField(-ironField,0.,0.);
@@ -472,15 +473,14 @@ void ShipMuonShield::ConstructGeometry()
             TGeoUniformMagField *fieldsTarget[4] = {new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.)};
       }
 
-      const static int nMag = 9;
       std::vector<TString> magnetName;
       std::vector<FieldDirection> fieldDirection;
       std::vector<Double_t> dXIn, dYIn, dXOut, dYOut, dZf, midGapIn, midGapOut,
 	  HmainSideMagIn, HmainSideMagOut, gapIn, gapOut, Z;
-      Initialize(magnetName, fieldDirection, dXIn, dYIn, dXOut, dYOut, dZf,
+      const Int_t nMagnets = Initialize(magnetName, fieldDirection, dXIn, dYIn, dXOut, dYOut, dZf,
 		 midGapIn, midGapOut, HmainSideMagIn, HmainSideMagOut, gapIn,
 		 gapOut, Z);
-      const Int_t nMagnets = magnetName.capacity();
+      
       
       if (fDesign==6){
 	Double_t dA = 3*m;

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -1,7 +1,6 @@
 #include "ShipMuonShield.h"
 
 #include "TGeoManager.h"
-#include "TList.h"                      // for TListIter, TList (ptr only)
 #include "TObjArray.h"                  // for TObjArray
 #include "TString.h"                    // for TString
 #include "TGeoBBox.h"
@@ -30,13 +29,15 @@ ShipMuonShield::ShipMuonShield() : FairModule("ShipMuonShield", "") {}
 ShipMuonShield::ShipMuonShield(TString geofile)
   : FairModule("MuonShield", "ShipMuonShield")
 {
+  // TODO use other constructor once parameters extracted
   fGeofile = geofile;
   auto f = TFile::Open(geofile, "read");
   TVectorT<Double_t> params;
   params.Read("params");
-  Double_t Z, LE = 10.*m, floor = 5. *m;
+  Double_t LE = 10. * m, floor = 5. * m;
   fDesign = 8;
   fField = 1.8;
+  dZ0 = 1 * m;
   dZ1 = params[0];
   dZ2 = params[1];
   dZ3 = params[2];
@@ -50,7 +51,10 @@ ShipMuonShield::ShipMuonShield(TString geofile)
   fFloor = floor;
   fSupport = true;
 
-  zEndOfAbsorb = Z - fMuonShieldLength / 2.;
+  Double_t Z = -25 * m - fMuonShieldLength / 2.;
+
+  zEndOfAbsorb = Z + dZ0 - fMuonShieldLength / 2.;
+  zEndOfAbsorb -= dZ0;
 }
 
 ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char* Title,
@@ -97,7 +101,7 @@ ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char*
  fFloor = (fDesign >= 7) ? floor : 0;
 
  zEndOfAbsorb = Z + dZ0 - fMuonShieldLength/2.;   
- if(fDesign==6||fDesign==7){zEndOfAbsorb = Z - fMuonShieldLength/2.;}
+ if(fDesign>=6){zEndOfAbsorb = Z - fMuonShieldLength/2.;}
  fSupport = true;
 }
 
@@ -664,7 +668,7 @@ void ShipMuonShield::ConstructGeometry()
       TGeoBBox *box3    = new TGeoBBox("box3", 15*m, 15*m,dZD/2.);
       TGeoBBox *box4    = new TGeoBBox("box4", 10*m, 10*m,dZD/2.);
 
-      if (fDesign == 7 && fFloor > 0) {
+      if (fDesign >= 7 && fFloor > 0) {
 	// Only add floor for new shield
 	TGeoBBox *box5 = new TGeoBBox("shield_floor", 10 * m, fFloor / 2.,
 				      fMuonShieldLength / 2.);

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -16,26 +16,16 @@
 #include "FairGeoInterface.h"
 #include "FairGeoMedia.h"
 #include "FairGeoBuilder.h"
-#include <stddef.h>                     // for NULL
 #include <iostream>                     // for operator<<, basic_ostream, etc
-#include <string>
 
-using std::cout;
-using std::endl;
-
-Double_t cm  = 1;       // cm
-Double_t m   = 100*cm;  //  m
-Double_t mm  = 0.1*cm;  //  mm
+Double_t cm = 1;
+Double_t m = 100 * cm;
+Double_t mm = 0.1 * cm;
 Double_t kilogauss = 1.;
-Double_t tesla     = 10*kilogauss;
+Double_t tesla = 10 * kilogauss;
 
-ShipMuonShield::~ShipMuonShield()
-{
-}
-ShipMuonShield::ShipMuonShield()
-  : FairModule("ShipMuonShield", "")
-{
-}
+ShipMuonShield::~ShipMuonShield() {}
+ShipMuonShield::ShipMuonShield() : FairModule("ShipMuonShield", "") {}
 
 ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char* Title,
                                Double_t Z, Double_t L0, Double_t L1, Double_t L2, Double_t L3, Double_t L4, Double_t L5, Double_t L6,
@@ -390,7 +380,7 @@ void ShipMuonShield::ConstructGeometry()
     
     if (fDesign==4||fDesign==5||fDesign==6||fDesign==7){
       Double_t ironField = fField*tesla;
-      cout<<"fField  "<<fField<<endl;
+      std::cout << "fField  " << fField << std::endl;
       TGeoUniformMagField *magFieldIron = new TGeoUniformMagField(0.,ironField,0.);
       TGeoUniformMagField *RetField     = new TGeoUniformMagField(0.,-ironField,0.);
       TGeoUniformMagField *ConRField    = new TGeoUniformMagField(-ironField,0.,0.);
@@ -574,6 +564,5 @@ void ShipMuonShield::ConstructGeometry()
     } else {
      Fatal("ShipMuonShield","Design %i does not match implemented designs",fDesign);
     }
-
 }
 ClassImp(ShipMuonShield)

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -298,13 +298,26 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
     }
   }
 
-void ShipMuonShield::Initialize (TString (&magnetName)[9],FieldDirection (&fieldDirection)[9],
-				 Double_t (&dXIn)[9], Double_t (&dYIn)[9], Double_t (&dXOut)[9],
-				 Double_t (&dYOut)[9], Double_t (&dZ)[9],
-				  Double_t (&midGapIn)[9],Double_t (&midGapOut)[9],
-				  Double_t (&HmainSideMagIn)[9], Double_t (&HmainSideMagOut)[9],
-				  Double_t (&gapIn)[9],Double_t (&gapOut)[9], Double_t (&Z)[9])
-{
+void ShipMuonShield::Initialize(std::vector<TString> &magnetName,
+				std::vector<FieldDirection> &fieldDirection,
+				std::vector<Double_t> &dXIn, std::vector<Double_t> &dYIn,
+				std::vector<Double_t> &dXOut, std::vector<Double_t> &dYOut,
+				std::vector<Double_t> &dZ, std::vector<Double_t> &midGapIn,
+				std::vector<Double_t> &midGapOut,
+				std::vector<Double_t> &HmainSideMagIn,
+				std::vector<Double_t> &HmainSideMagOut,
+				std::vector<Double_t> &gapIn, std::vector<Double_t> &gapOut,
+				std::vector<Double_t> &Z) {
+
+  const Int_t nMagnets = (fDesign == 7) ? 9 : 8;
+  magnetName.reserve(nMagnets);
+  fieldDirection.reserve(nMagnets);
+  for (auto i :
+       {&dXIn, &dXOut, &dYIn, &dYOut, &dZ, &midGapIn, &midGapOut,
+	&HmainSideMagIn, &HmainSideMagOut, &gapIn, &gapOut, &Z}) {
+    i->reserve(nMagnets);
+  }
+
   Double_t zgap = (fDesign > 6) ? 10 : 0;  // fixed distance between magnets in Z-axis
   Double_t dYEnd = fY;
 
@@ -458,17 +471,16 @@ void ShipMuonShield::ConstructGeometry()
       if(fDesign==7){
             TGeoUniformMagField *fieldsTarget[4] = {new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.),new TGeoUniformMagField(0.,0.,0.)};
       }
-      Int_t nMagnets = (fDesign == 7) ? 9 : 8;
 
-      // need to use literal 8 here as initialisation function's signature requires it.
-      // TODO use nMagnets, std::vector and TString!
       const static int nMag = 9;
-      TString magnetName[nMag];
-      FieldDirection fieldDirection[nMag];
-      Double_t dXIn[nMag], dYIn[nMag], dXOut[nMag], dYOut[nMag], dZf[nMag], midGapIn[nMag],
-	  midGapOut[nMag], HmainSideMagIn[nMag], HmainSideMagOut[nMag], gapIn[nMag],
-	  gapOut[nMag], Z[nMag];
-      Initialize (magnetName,fieldDirection,dXIn,dYIn,dXOut,dYOut,dZf,midGapIn,midGapOut,HmainSideMagIn,HmainSideMagOut,gapIn,gapOut,Z);
+      std::vector<TString> magnetName;
+      std::vector<FieldDirection> fieldDirection;
+      std::vector<Double_t> dXIn, dYIn, dXOut, dYOut, dZf, midGapIn, midGapOut,
+	  HmainSideMagIn, HmainSideMagOut, gapIn, gapOut, Z;
+      Initialize(magnetName, fieldDirection, dXIn, dYIn, dXOut, dYOut, dZf,
+		 midGapIn, midGapOut, HmainSideMagIn, HmainSideMagOut, gapIn,
+		 gapOut, Z);
+      const Int_t nMagnets = magnetName.capacity();
       
       if (fDesign==6){
 	Double_t dA = 3*m;

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -86,7 +86,7 @@ ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char*
 }
 
 // -----   Private method InitMedium 
-Int_t ShipMuonShield::InitMedium(const char* name) 
+Int_t ShipMuonShield::InitMedium(TString name) 
 {
    static FairGeoLoader *geoLoad=FairGeoLoader::Instance();
    static FairGeoInterface *geoFace=geoLoad->getGeoInterface();
@@ -96,12 +96,9 @@ Int_t ShipMuonShield::InitMedium(const char* name)
    FairGeoMedium *ShipMedium=media->getMedium(name);
 
    if (!ShipMedium)
-   {
-     Fatal("InitMedium","Material %s not defined in media file.", name);
-     return -1111;
-   }
+     Fatal("InitMedium","Material %s not defined in media file.", name.Data());
    TGeoMedium* medium=gGeoManager->GetMedium(name);
-   if (medium!=NULL)
+   if (medium)
      return ShipMedium->getMediumIndex();
    return geoBuild->createMedium(ShipMedium);
 }

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -299,68 +299,56 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
   }
 
 void ShipMuonShield::Initialize (TString (&magnetName)[9],FieldDirection (&fieldDirection)[9],
-				    Double_t (&dXIn)[9], Double_t (&dYIn)[9], Double_t (&dXOut)[9], Double_t (&dYOut)[9], Double_t (&dZ)[9],
+				 Double_t (&dXIn)[9], Double_t (&dYIn)[9], Double_t (&dXOut)[9],
+				 Double_t (&dYOut)[9], Double_t (&dZ)[9],
 				  Double_t (&midGapIn)[9],Double_t (&midGapOut)[9],
 				  Double_t (&HmainSideMagIn)[9], Double_t (&HmainSideMagOut)[9],
 				  Double_t (&gapIn)[9],Double_t (&gapOut)[9], Double_t (&Z)[9])
 {
   Double_t zgap = (fDesign > 6) ? 10 : 0;  // fixed distance between magnets in Z-axis
   Double_t dYEnd = fY;
+
   if(fDesign==7){
       
   magnetName[0] = "MagnAbsorb1";	fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.4*m;			dYIn[0]	= 1.5*m;
   dXOut[0] = 0.40*m;			dYOut[0]= 1.5*m;
-  midGapIn[0] = 0; 			midGapOut[0] = 0;
-  HmainSideMagIn[0] = dYIn[0]/2;  	HmainSideMagOut[0] = dYOut[0]/2;
   gapIn[0] = 0.02*m;			gapOut[0] = 0.02*m;
   dZ[0] = dZ1-zgap/2;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
   
   magnetName[1] = "MagnAbsorb2";	fieldDirection[1] = FieldDirection::up;
   dXIn[1]  = 0.8*m;			dYIn[1]	= 1.5*m;
   dXOut[1] = 0.8*m;			dYOut[1]= 1.5*m;
-  midGapIn[1] = 0; 			midGapOut[1] = 0;
-  HmainSideMagIn[1] = dYIn[1]/2;  	HmainSideMagOut[1] = dYOut[1]/2;
   gapIn[1] = 0.02*m;				gapOut[1] = 0.02*m;
   dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
     
   magnetName[2] = "Magn1";		fieldDirection[2] = FieldDirection::up;
   dXIn[2]  = 0.87*m;			dYIn[2]	= 0.35*m;
   dXOut[2] = 0.65*m;			dYOut[2]= 1.21*m;
-  midGapIn[2] = 0; 			midGapOut[2] = 0;
-  HmainSideMagIn[2] = dYIn[2]/2;  	HmainSideMagOut[2] = dYOut[2]/2;
   gapIn[2] = 0.11*m;				gapOut[2] = 0.02*m;
   dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
 
   magnetName[3] = "Magn2";		fieldDirection[3] = FieldDirection::up;
   dXIn[3]  = 0.65*m;			dYIn[3]	= 1.21*m;
   dXOut[3] = 0.43*m;			dYOut[3]= 2.07*m;
-  midGapIn[3] = 0; 			midGapOut[3] = 0;
-  HmainSideMagIn[3] = dYIn[3]/2;  	HmainSideMagOut[3] = dYOut[3]/2;
   gapIn[3] = 0.11*m;				gapOut[3] = 0.02*m;
   dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
 
   magnetName[4] = "Magn3";		fieldDirection[4] = FieldDirection::up;
   dXIn[4]  = 0.06*m;			dYIn[4]	= 0.32*m;
   dXOut[4] = 0.33*m;			dYOut[4]= 0.13*m;
-  midGapIn[4] = 0; 			midGapOut[4] = 0;
-  HmainSideMagIn[4] = dYIn[4]/2;  	HmainSideMagOut[4] = dYOut[4]/2;
   gapIn[4] = 0.7*m;			gapOut[4] = 0.11*m;
   dZ[4] = dZ5-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
   
   magnetName[5] = "Magn4";		fieldDirection[5] = FieldDirection::down;
   dXIn[5]  = 0.05*m;			dYIn[5]	= 1.12*m;
   dXOut[5] =0.16*m;			dYOut[5]= 0.05*m;
-  midGapIn[5] = 0; 			midGapOut[5] = 0;
-  HmainSideMagIn[5] = dYIn[5]/2;  	HmainSideMagOut[5] = dYOut[5]/2;
   gapIn[5] = 0.04*m;			gapOut[5] = 0.02*m;
   dZ[5] = dZ6-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
   
   magnetName[6] = "Magn5";		fieldDirection[6] = FieldDirection::down;
   dXIn[6]  = 0.15*m;			dYIn[6]	= 2.35*m;
   dXOut[6] = 0.34*m;			dYOut[6]= 0.32*m;
-  midGapIn[6] = 0; 		        midGapOut[6] = 0;
-  HmainSideMagIn[6] = dYIn[6]/2;  	HmainSideMagOut[6] = dYOut[6]/2;
   gapIn[6] = 0.05*m;			gapOut[6] = 0.08*m;
   dZ[6] = dZ7-zgap/2;			Z[6] = Z[5] + dZ[5] + dZ[6]+zgap;
   
@@ -368,21 +356,24 @@ void ShipMuonShield::Initialize (TString (&magnetName)[9],FieldDirection (&field
   magnetName[7] = "Magn6";		fieldDirection[7] = FieldDirection::down;
   dXIn[7]  = 0.31*m;			dYIn[7]	= 1.86*m;
   dXOut[7] = 0.9*m - clip_width;	dYOut[7]= 3.1*m;
-  midGapIn[7] = 0; 		        midGapOut[7] = 0;
   Double_t clip_len =
        (dZ8-zgap/2) * (1 - (dXOut[7] - dXIn[7]) / (dXOut[7] + clip_width - dXIn[7]));
-  HmainSideMagIn[7] = dYIn[7]/2;  	HmainSideMagOut[7] = dYOut[7]/2;
   gapIn[7] = 0.02*m;			gapOut[7] = 0.55*m;
   dZ[7] = dZ8 - clip_len - zgap / 2;	Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
 
   magnetName[8] = "Magn7";		fieldDirection[8] = FieldDirection::down;
   dXIn[8]  = dXOut[7];			dYIn[8]	= dYOut[7];
   dXOut[8] = dXOut[7];			dYOut[8]= dYOut[7];
-  midGapIn[8] = 0; 		        midGapOut[8] = 0;
-  HmainSideMagIn[8] = dYIn[8]/2;  	HmainSideMagOut[8] = dYOut[8]/2;
   gapIn[8] = 0.55*m;			gapOut[8] = 0.55*m;
   dZ[8] = clip_len;			Z[8] = Z[7] + dZ[7] + dZ[8];
       
+  for (int i = 0; i <= 8; ++i) {
+    midGapIn[i] = 0.;
+    midGapOut[i] = 0.;
+    HmainSideMagIn[i] = dYIn[i] / 2;
+    HmainSideMagOut[i] = dYOut[i] / 2;
+  }
+
   } else {
   magnetName[0] = "1";			fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.7*m;			dYIn[0]	= 1.*m; 

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -38,8 +38,8 @@ ShipMuonShield::ShipMuonShield(TString geofile)
   fDesign = 8;
   fField = 1.8;
   dZ0 = 1 * m;
-  dZ1 = params[0];
-  dZ2 = params[1];
+  dZ1 = 0.4 * m;
+  dZ2 = 2.31 * m;
   dZ3 = params[2];
   dZ4 = params[3];
   dZ5 = params[4];
@@ -324,7 +324,20 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
 
     const int offset = 7;
 
-    for (Int_t i = 0; i < nMagnets - 1; ++i) {
+    dXIn[0] = 0.4 * m;
+    dXOut[0] = 0.40 * m;
+    gapIn[0] = 0.1 * mm;
+    dYIn[0] = 1.5 * m;
+    dYOut[0] = 1.5 * m;
+    gapOut[0] = 0.1 * mm;
+    dXIn[1] = 0.5 * m;
+    dXOut[1] = 0.5 * m;
+    gapIn[1] = 0.02 * m;
+    dYIn[1] = 1.3 * m;
+    dYOut[1] = 1.3 * m;
+    gapOut[1] = 0.02 * m;
+
+    for (Int_t i = 2; i < nMagnets - 1; ++i) {
       dXIn[i] = params[offset + i * 6 + 1];
       dXOut[i] = params[offset + i * 6 + 2];
       dYIn[i] = params[offset + i * 6 + 3];
@@ -338,7 +351,7 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
     dZ[1] = dZ2 - zgap / 2;
     Z[1] = Z[0] + dZ[0] + dZ[1] + zgap;
     dZ[2] = dZ3 - zgap / 2;
-    Z[2] = Z[1] + dZ[1] + dZ[2] + zgap;
+    Z[2] = Z[1] + dZ[1] + dZ[2] + 2 * zgap;
     dZ[3] = dZ4 - zgap / 2;
     Z[3] = Z[2] + dZ[2] + dZ[3] + zgap;
     dZ[4] = dZ5 - zgap / 2;
@@ -374,12 +387,12 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.4*m;			dYIn[0]	= 1.5*m;
   dXOut[0] = 0.40*m;			dYOut[0]= 1.5*m;
-  gapIn[0] = 0.02*m;			gapOut[0] = 0.02*m;
+  gapIn[0] = 0.1*mm;			gapOut[0] = 0.1*mm;
   dZ[0] = dZ1-zgap/2;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
   
   fieldDirection[1] = FieldDirection::up;
-  dXIn[1]  = 0.8*m;			dYIn[1]	= 1.5*m;
-  dXOut[1] = 0.8*m;			dYOut[1]= 1.5*m;
+  dXIn[1]  = 0.5*m;			dYIn[1]	= 1.3*m;
+  dXOut[1] = 0.5*m;			dYOut[1]= 1.3*m;
   gapIn[1] = 0.02*m;			gapOut[1] = 0.02*m;
   dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
     
@@ -387,7 +400,7 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   dXIn[2]  = 0.87*m;			dYIn[2]	= 0.35*m;
   dXOut[2] = 0.65*m;			dYOut[2]= 1.21*m;
   gapIn[2] = 0.11*m;			gapOut[2] = 0.02*m;
-  dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
+  dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+2*zgap;
 
   fieldDirection[3] = FieldDirection::up;
   dXIn[3]  = 0.65*m;			dYIn[3]	= 1.21*m;
@@ -538,11 +551,20 @@ void ShipMuonShield::ConstructGeometry()
         TGeoVolume* passivAbsorber = new TGeoVolume("passiveAbsorberStop-1",Tc, iron);
         tShield->AddNode(passivAbsorber, 1, new TGeoTranslation(0,0,zEndOfAbsorb - 5.*dZ0/3.));
       } else if (fDesign==7||fDesign==8) {
+
+	TGeoUniformMagField *fieldsAbsorber[4] = {
+	    new TGeoUniformMagField(0., 1.6 * tesla, 0.),
+	    new TGeoUniformMagField(0., -1.6 * tesla, 0.),
+	    new TGeoUniformMagField(-1.6 * tesla, 0., 0.),
+	    new TGeoUniformMagField(1.6 * tesla, 0., 0.)
+	};
+
 	for (Int_t nM = 0; nM < 2; nM++) {
-	  CreateMagnet(magnetName[nM],iron,tShield,fields,fieldDirection[nM],
-		    dXIn[nM],dYIn[nM],dXOut[nM],dYOut[nM],dZf[nM],
-		    midGapIn[nM],midGapOut[nM],HmainSideMagIn[nM],HmainSideMagOut[nM],
-		    gapIn[nM],gapOut[nM],Z[nM],1);
+	  CreateMagnet(magnetName[nM], iron, tShield, fieldsAbsorber,
+		       fieldDirection[nM], dXIn[nM], dYIn[nM], dXOut[nM],
+		       dYOut[nM], dZf[nM], midGapIn[nM], midGapOut[nM],
+		       HmainSideMagIn[nM], HmainSideMagOut[nM], gapIn[nM],
+		       gapOut[nM], Z[nM], nM == 1);
 	}
 
       TGeoTranslation *mag1 = new TGeoTranslation("mag1", 0, 0, -dZ2);
@@ -579,6 +601,13 @@ void ShipMuonShield::ConstructGeometry()
       TGeoVolume *absorber = new TGeoVolume("AbsorberVol", absorberShape, iron);
       absorber->SetLineColor(42); // brown / light red
       tShield->AddNode(absorber, 1, new TGeoTranslation(0, 0, zEndOfAbsorb + absorber_half_length + absorber_offset));
+
+      TGeoVolume *wall = gGeoManager->MakeBox("wall", concrete, 3 * m, 3 * m,
+					      10 * cm - 1 * mm);
+      tShield->AddNode(
+	  wall, 1, new TGeoTranslation(0, 0,
+				       zEndOfAbsorb + 2 * absorber_half_length +
+					   absorber_offset + 10 * cm));
 
       for (Int_t nM = 2; nM <= (nMagnets - 1); nM++) {
 	CreateMagnet(magnetName[nM], iron, tShield, fields, fieldDirection[nM],

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -129,8 +129,7 @@ void ShipMuonShield::CreateArb8(const char* arbName, TGeoMedium* medium,Double_t
 				     TGeoUniformMagField *magField,TGeoVolume *tShield,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
 					Double_t z_translation)
 {
-  Double_t* corner=&corners[0];
-  TGeoVolume* magF = gGeoManager->MakeArb8(arbName, medium, dZ, corner);
+  TGeoVolume* magF = gGeoManager->MakeArb8(arbName, medium, dZ, corners.data());
   magF->SetLineColor(color);
   magF->SetField(magField);
   tShield->AddNode(magF, 1, new TGeoTranslation(x_translation, y_translation, z_translation ));

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -485,12 +485,12 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   fieldDirection[0] = FieldDirection::up;
   dXIn[0]  = 0.4*m;			dYIn[0]	= 1.5*m;
   dXOut[0] = 0.40*m;			dYOut[0]= 1.5*m;
-  gapIn[0] = 0.1*mm;			gapOut[0] = 0.1*mm;
+  gapIn[0] = 0.02 * m;			gapOut[0] = 0.02 * m;
   dZ[0] = dZ1-zgap/2;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
   
   fieldDirection[1] = FieldDirection::up;
-  dXIn[1]  = 0.5*m;			dYIn[1]	= 1.3*m;
-  dXOut[1] = 0.5*m;			dYOut[1]= 1.3*m;
+  dXIn[1]  = 0.8*m;			dYIn[1]	= 1.5*m;
+  dXOut[1] = 0.8*m;			dYOut[1]= 1.5*m;
   gapIn[1] = 0.02*m;			gapOut[1] = 0.02*m;
   dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
     
@@ -498,7 +498,7 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
   dXIn[2]  = 0.87*m;			dYIn[2]	= 0.35*m;
   dXOut[2] = 0.65*m;			dYOut[2]= 1.21*m;
   gapIn[2] = 0.11*m;			gapOut[2] = 0.02*m;
-  dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+2*zgap;
+  dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2] + zgap;
 
   fieldDirection[3] = FieldDirection::up;
   dXIn[3]  = 0.65*m;			dYIn[3]	= 1.21*m;
@@ -662,7 +662,7 @@ void ShipMuonShield::ConstructGeometry()
 		       fieldDirection[nM], dXIn[nM], dYIn[nM], dXOut[nM],
 		       dYOut[nM], dZf[nM], midGapIn[nM], midGapOut[nM],
 		       HmainSideMagIn[nM], HmainSideMagOut[nM], gapIn[nM],
-		       gapOut[nM], Z[nM], nM == 1);
+		       gapOut[nM], Z[nM], nM == 1 || fDesign == 7);
 	}
 
       TGeoTranslation *mag1 = new TGeoTranslation("mag1", 0, 0, -dZ2);
@@ -700,12 +700,11 @@ void ShipMuonShield::ConstructGeometry()
       absorber->SetLineColor(42); // brown / light red
       tShield->AddNode(absorber, 1, new TGeoTranslation(0, 0, zEndOfAbsorb + absorber_half_length + absorber_offset));
 
-      TGeoVolume *wall = gGeoManager->MakeBox("wall", concrete, 3 * m, 3 * m,
-					      10 * cm - 1 * mm);
-      tShield->AddNode(
-	  wall, 1, new TGeoTranslation(0, 0,
-				       zEndOfAbsorb + 2 * absorber_half_length +
-					   absorber_offset + 10 * cm));
+      if (fDesign >=8 ){
+         TGeoVolume *wall = gGeoManager->MakeBox("wall", concrete, 3 * m, 3 * m, 10 * cm - 1 * mm);
+         tShield->AddNode(
+            wall, 1, new TGeoTranslation(0, 0, zEndOfAbsorb + 2 * absorber_half_length + absorber_offset + 10 * cm));
+      }
 
       for (Int_t nM = 2; nM <= (nMagnets - 1); nM++) {
 	CreateMagnet(magnetName[nM], iron, tShield, fields, fieldDirection[nM],

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -43,10 +43,6 @@ class ShipMuonShield : public FairModule
   Bool_t fSupport;
   Double_t  dZ0,dZ1,dZ2,dZ3,dZ4,dZ5,dZ6,dZ7,dZ8,dXgap,zEndOfAbsorb,mag4Gap,midGapOut7,midGapOut8;
   Int_t InitMedium(TString name);
-  
-  void CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,std::array<Double_t,16> corners,Int_t color,
-				     TGeoUniformMagField *magField,TGeoVolume *top,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
-					Double_t z_translation);
 
   void CreateArb8(TString arbName, TGeoMedium *medium, Double_t dZ,
 		  std::array<Double_t, 16> corners, Int_t color,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -10,6 +10,7 @@
 #include "TGeoUniformMagField.h"
 #include "TGeoMedium.h"
 #include "TGeoShapeAssembly.h"
+#include "TString.h"
 #include <vector>
 
 
@@ -37,7 +38,7 @@ class ShipMuonShield : public FairModule
   Double_t fFloor;
   Bool_t fSupport;
   Double_t  dZ0,dZ1,dZ2,dZ3,dZ4,dZ5,dZ6,dZ7,dZ8,dXgap,zEndOfAbsorb,mag4Gap,midGapOut7,midGapOut8;
-  Int_t InitMedium(const char* name);
+  Int_t InitMedium(TString name);
   
  /* void CreateBox(const char* boxName, TGeoMedium* medium, Double_t dX,Double_t dY,Double_t dZ,
 					Int_t color,TGeoUniformMagField *magField,TGeoVolume *top,Int_t numberOfItems, Double_t x_translation,Double_t y_translation,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -11,6 +11,7 @@
 #include "TGeoShapeAssembly.h"
 #include "TString.h"
 #include <vector>
+#include <array>
 
 enum class FieldDirection { up, down };
 
@@ -41,19 +42,10 @@ class ShipMuonShield : public FairModule
   Double_t  dZ0,dZ1,dZ2,dZ3,dZ4,dZ5,dZ6,dZ7,dZ8,dXgap,zEndOfAbsorb,mag4Gap,midGapOut7,midGapOut8;
   Int_t InitMedium(TString name);
   
- /* void CreateBox(const char* boxName, TGeoMedium* medium, Double_t dX,Double_t dY,Double_t dZ,
-					Int_t color,TGeoUniformMagField *magField,TGeoVolume *top,Int_t numberOfItems, Double_t x_translation,Double_t y_translation,
-					Double_t z_translation);
-  */
-  void CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,Double_t corners[16],Int_t color,
+  void CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,std::array<Double_t,16> corners,Int_t color,
 				     TGeoUniformMagField *magField,TGeoVolume *top,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
 					Double_t z_translation);
 
-  void CreateArb8(const char* arbName, TGeoMedium* medium,Double_t dZ,std::vector<Double_t> corners,Int_t color,
-				     TGeoUniformMagField *magField,TGeoVolume *top,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
-					Double_t z_translation);
- 
- 
   void CreateTube(const char* tubeName, TGeoMedium* medium, Double_t dX,Double_t dY,Double_t dZ,Int_t color,TGeoVolume *top,Int_t numberOfItems, Double_t x_translation,Double_t y_translation,
 					Double_t z_translation);
 

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -21,7 +21,7 @@ class ShipMuonShield : public FairModule
 
    ShipMuonShield(const char* name, const Int_t Design=1,  const char* Title="ShipMuonShield",
                                Double_t Z=0, Double_t L0=0, Double_t L1=0, Double_t L2=0, Double_t L3=0, Double_t L4=0, Double_t L5=0, Double_t L6=0, 
-                               Double_t L7=0, Double_t L8=0,Double_t gap=0,Double_t LE=0,Double_t y=400, Double_t floor=500, Double_t field=1.8);
+                               Double_t L7=0, Double_t L8=0,Double_t gap=0,Double_t LE=0,Double_t y=400, Double_t floor=500, Double_t field=1.7);
 
    explicit ShipMuonShield(TString geofile);
    ShipMuonShield();

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -57,14 +57,16 @@ class ShipMuonShield : public FairModule
 		  Double_t x_translation, Double_t y_translation,
 		  Double_t z_translation);
 
-  void Initialize(TString (&magnetName)[9],
-		  FieldDirection (&fieldDirection)[9], Double_t (&dXIn)[9],
-		  Double_t (&dYIn)[9], Double_t (&dXOut)[9],
-		  Double_t (&dYOut)[9], Double_t (&dZ)[9],
-		  Double_t (&midGapIn)[9], Double_t (&midGapOut)[9],
-		  Double_t (&HmainSideMagIn)[9], Double_t (&HmainSideMagOut)[9],
-		  Double_t (&gapIn)[9], Double_t (&gapOut)[9],
-		  Double_t (&Z)[9]);
+  void Initialize(std::vector<TString> &magnetName,
+		  std::vector<FieldDirection> &fieldDirection,
+		  std::vector<Double_t> &dXIn, std::vector<Double_t> &dYIn,
+		  std::vector<Double_t> &dXOut, std::vector<Double_t> &dYOut,
+		  std::vector<Double_t> &dZ, std::vector<Double_t> &midGapIn,
+		  std::vector<Double_t> &midGapOut,
+		  std::vector<Double_t> &HmainSideMagIn,
+		  std::vector<Double_t> &HmainSideMagOut,
+		  std::vector<Double_t> &gapIn, std::vector<Double_t> &gapOut,
+		  std::vector<Double_t> &Z);
 
   void CreateMagnet(TString magnetName, TGeoMedium *medium, TGeoVolume *tShield,
 		    TGeoUniformMagField *fields[4],

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -6,7 +6,6 @@
 
 #include "Rtypes.h"                     // for ShipMuonShield::Class, Bool_t, etc
 
-#include <string>                       // for string
 #include "TGeoUniformMagField.h"
 #include "TGeoMedium.h"
 #include "TGeoShapeAssembly.h"
@@ -18,6 +17,7 @@ enum class FieldDirection { up, down };
 class ShipMuonShield : public FairModule
 {
   public:
+
    ShipMuonShield(const char* name, const Int_t Design=1,  const char* Title="ShipMuonShield",
                                Double_t Z=0, Double_t L0=0, Double_t L1=0, Double_t L2=0, Double_t L3=0, Double_t L4=0, Double_t L5=0, Double_t L6=0, 
                                Double_t L7=0, Double_t L8=0,Double_t gap=0,Double_t LE=0,Double_t y=400, Double_t floor=500, Double_t field=1.8);

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -57,7 +57,7 @@ class ShipMuonShield : public FairModule
 		  Double_t x_translation, Double_t y_translation,
 		  Double_t z_translation);
 
-  void Initialize(std::vector<TString> &magnetName,
+  Int_t Initialize(std::vector<TString> &magnetName,
 		  std::vector<FieldDirection> &fieldDirection,
 		  std::vector<Double_t> &dXIn, std::vector<Double_t> &dYIn,
 		  std::vector<Double_t> &dXOut, std::vector<Double_t> &dYOut,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -46,11 +46,18 @@ class ShipMuonShield : public FairModule
 				     TGeoUniformMagField *magField,TGeoVolume *top,Int_t numberOfItems,Double_t x_translation,Double_t y_translation,
 					Double_t z_translation);
 
-  void CreateTube(const char* tubeName, TGeoMedium* medium, Double_t dX,Double_t dY,Double_t dZ,Int_t color,TGeoVolume *top,Int_t numberOfItems, Double_t x_translation,Double_t y_translation,
-					Double_t z_translation);
+  void CreateArb8(TString arbName, TGeoMedium *medium, Double_t dZ,
+		  std::array<Double_t, 16> corners, Int_t color,
+		  TGeoUniformMagField *magField, TGeoVolume *top,
+		  Double_t x_translation, Double_t y_translation,
+		  Double_t z_translation);
 
+  void CreateTube(TString tubeName, TGeoMedium *medium, Double_t dX,
+		  Double_t dY, Double_t dZ, Int_t color, TGeoVolume *top,
+		  Double_t x_translation, Double_t y_translation,
+		  Double_t z_translation);
 
-  void Initialize(const char *(&magnetName)[9],
+  void Initialize(TString (&magnetName)[9],
 		  FieldDirection (&fieldDirection)[9], Double_t (&dXIn)[9],
 		  Double_t (&dYIn)[9], Double_t (&dXOut)[9],
 		  Double_t (&dYOut)[9], Double_t (&dZ)[9],
@@ -59,7 +66,7 @@ class ShipMuonShield : public FairModule
 		  Double_t (&gapIn)[9], Double_t (&gapOut)[9],
 		  Double_t (&Z)[9]);
 
-  void CreateMagnet(const char* magnetName, TGeoMedium *medium, TGeoVolume *tShield,
+  void CreateMagnet(TString magnetName, TGeoMedium *medium, TGeoVolume *tShield,
 		    TGeoUniformMagField *fields[4],
 		    FieldDirection fieldDirection, Double_t dX, Double_t dY,
 		    Double_t dX2, Double_t dY2, Double_t dZ, Double_t middleGap,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -13,6 +13,7 @@
 #include "TString.h"
 #include <vector>
 
+enum class FieldDirection { up, down };
 
 class ShipMuonShield : public FairModule
 {
@@ -58,7 +59,7 @@ class ShipMuonShield : public FairModule
 
 
   void Initialize(const char *(&magnetName)[9],
-		  const char *(&fieldDirection)[9], Double_t (&dXIn)[9],
+		  FieldDirection (&fieldDirection)[9], Double_t (&dXIn)[9],
 		  Double_t (&dYIn)[9], Double_t (&dXOut)[9],
 		  Double_t (&dYOut)[9], Double_t (&dZ)[9],
 		  Double_t (&midGapIn)[9], Double_t (&midGapOut)[9],
@@ -66,11 +67,13 @@ class ShipMuonShield : public FairModule
 		  Double_t (&gapIn)[9], Double_t (&gapOut)[9],
 		  Double_t (&Z)[9]);
 
-  void CreateMagnet(const char* magnetName,TGeoMedium* medium,TGeoVolume *tShield,TGeoUniformMagField *fields[4],const char* fieldDirection,
-				  Double_t dX, Double_t dY, Double_t dX2, Double_t dY2, Double_t dZ,
-				  Double_t middleGap,Double_t middleGap2,
-				  Double_t HmainSideMag, Double_t HmainSideMag2,
-				  Double_t gap,Double_t gap2, Double_t Z,Bool_t NotMagnet);
+  void CreateMagnet(const char* magnetName, TGeoMedium *medium, TGeoVolume *tShield,
+		    TGeoUniformMagField *fields[4],
+		    FieldDirection fieldDirection, Double_t dX, Double_t dY,
+		    Double_t dX2, Double_t dY2, Double_t dZ, Double_t middleGap,
+		    Double_t middleGap2, Double_t HmainSideMag,
+		    Double_t HmainSideMag2, Double_t gap, Double_t gap2,
+		    Double_t Z, Bool_t NotMagnet);
 };
 
 #endif //MuonSield_H

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include <array>
 
-enum class FieldDirection { up, down };
+enum class FieldDirection : bool { up, down };
 
 class ShipMuonShield : public FairModule
 {
@@ -23,6 +23,7 @@ class ShipMuonShield : public FairModule
                                Double_t Z=0, Double_t L0=0, Double_t L1=0, Double_t L2=0, Double_t L3=0, Double_t L4=0, Double_t L5=0, Double_t L6=0, 
                                Double_t L7=0, Double_t L8=0,Double_t gap=0,Double_t LE=0,Double_t y=400, Double_t floor=500, Double_t field=1.8);
 
+   explicit ShipMuonShield(TString geofile);
    ShipMuonShield();
    virtual ~ShipMuonShield();
    void ConstructGeometry();
@@ -36,6 +37,7 @@ class ShipMuonShield : public FairModule
  protected:
   
   Int_t  fDesign;       // design of muon shield, 1=passive, active = ...
+  TString fGeofile;
   Double_t  fMuonShieldLength,fY,fField;
   Double_t fFloor;
   Bool_t fSupport;
@@ -75,6 +77,8 @@ class ShipMuonShield : public FairModule
 		    Double_t middleGap2, Double_t HmainSideMag,
 		    Double_t HmainSideMag2, Double_t gap, Double_t gap2,
 		    Double_t Z, Bool_t NotMagnet);
+
+
 };
 
 #endif //MuonSield_H

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -82,7 +82,7 @@ def configure(run,ship_geo):
  if not hasattr(ship_geo,'NuTauTT') : ship_geo.NuTauTT= AttrDict(z=0*u.cm)
  if not hasattr(ship_geo.NuTauTT,'design') : ship_geo.NuTauTT.design = 0
  if not hasattr(ship_geo,'EcalOption'):     ship_geo.EcalOption = 1      
- latestShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_config.py",Yheight = ship_geo.Yheight/u.m, tankDesign = ship_geo.tankDesign, muShieldDesign = ship_geo.muShieldDesign, nuTauTargetDesign = ship_geo.nuTauTargetDesign)
+ latestShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_config.py",Yheight = ship_geo.Yheight/u.m, tankDesign = ship_geo.tankDesign, muShieldDesign = ship_geo.muShieldDesign, nuTauTargetDesign = ship_geo.nuTauTargetDesign, muShieldGeo = ship_geo.muShieldGeo)
 # -----Create media-------------------------------------------------
  run.SetMaterials("media.geo")  # Materials
 # ------------------------------------------------------------------------
@@ -93,7 +93,7 @@ def configure(run,ship_geo):
  else: cave.SetGeometryFileName("caveWithAir.geo")
  detectorList.append(cave)
 
- if ship_geo.muShieldDesign==6 or ship_geo.muShieldDesign==7: # magnetized hadron absorber defined in ShipMuonShield 
+ if ship_geo.muShieldDesign in [6, 7, 8]:  # magnetized hadron absorber defined in ShipMuonShield 
   TargetStation = ROOT.ShipTargetStation("TargetStation",ship_geo.target.length,
                                                         ship_geo.target.z,ship_geo.targetOpt,ship_geo.target.sl)
  else:
@@ -115,7 +115,7 @@ def configure(run,ship_geo):
  elif ship_geo.muShieldDesign==2:
   MuonShield = ROOT.ShipMuonShield("MuonShield",ship_geo.muShieldDesign,"ShipMuonShield",ship_geo.muShield.z,ship_geo.muShield.dZ0,ship_geo.muShield.dZ1,\
                ship_geo.muShield.dZ2,ship_geo.muShield.dZ3,ship_geo.muShield.dZ4,ship_geo.muShield.dZ5,ship_geo.muShield.dZ6,ship_geo.muShield.LE) 
- elif ship_geo.muShieldDesign==3 or ship_geo.muShieldDesign==4 or ship_geo.muShieldDesign==5 or ship_geo.muShieldDesign==6 or ship_geo.muShieldDesign==7 :
+ elif ship_geo.muShieldDesign in [3, 4, 5, 6, 7]:
   if not hasattr(ship_geo.muShield,"Field"):
    MuonShield = ROOT.ShipMuonShield("MuonShield",ship_geo.muShieldDesign,"ShipMuonShield",ship_geo.muShield.z,ship_geo.muShield.dZ0,ship_geo.muShield.dZ1,\
                ship_geo.muShield.dZ2,ship_geo.muShield.dZ3,ship_geo.muShield.dZ4,ship_geo.muShield.dZ5,ship_geo.muShield.dZ6,\
@@ -125,6 +125,9 @@ def configure(run,ship_geo):
                ship_geo.muShield.dZ2,ship_geo.muShield.dZ3,ship_geo.muShield.dZ4,ship_geo.muShield.dZ5,ship_geo.muShield.dZ6,\
                ship_geo.muShield.dZ7,ship_geo.muShield.dZ8,ship_geo.muShield.dXgap,ship_geo.muShield.LE,ship_geo.Yheight*4./10.,\
                ship_geo.cave.floorHeightMuonShield,ship_geo.muShield.Field) 
+ elif ship_geo.muShieldDesign == 8:
+  # TODO use new constructor
+  MuonShield = ROOT.ShipMuonShield(ship_geo.muShieldGeo)
  
  detectorList.append(MuonShield)
 

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -94,7 +94,7 @@ def configure(run,ship_geo):
  else: cave.SetGeometryFileName("caveWithAir.geo")
  detectorList.append(cave)
 
- if ship_geo.muShieldDesign in [6, 7, 8]:  # magnetized hadron absorber defined in ShipMuonShield 
+ if ship_geo.muShieldDesign in [6, 7, 8, 9]:  # magnetized hadron absorber defined in ShipMuonShield 
   TargetStation = ROOT.ShipTargetStation("TargetStation",ship_geo.target.length,
                                                         ship_geo.target.z,ship_geo.targetOpt,ship_geo.target.sl)
  else:
@@ -116,15 +116,26 @@ def configure(run,ship_geo):
  elif ship_geo.muShieldDesign==2:
   MuonShield = ROOT.ShipMuonShield("MuonShield",ship_geo.muShieldDesign,"ShipMuonShield",ship_geo.muShield.z,ship_geo.muShield.dZ0,ship_geo.muShield.dZ1,\
                ship_geo.muShield.dZ2,ship_geo.muShield.dZ3,ship_geo.muShield.dZ4,ship_geo.muShield.dZ5,ship_geo.muShield.dZ6,ship_geo.muShield.LE) 
- elif ship_geo.muShieldDesign in [3, 4, 5, 6, 7]:
+ elif ship_geo.muShieldDesign in [3, 4, 5, 6, 7, 9]:
   if not hasattr(ship_geo.muShield,"Field"):
-   MuonShield = ROOT.ShipMuonShield("MuonShield",ship_geo.muShieldDesign,"ShipMuonShield",ship_geo.muShield.z,ship_geo.muShield.dZ0,ship_geo.muShield.dZ1,\
-               ship_geo.muShield.dZ2,ship_geo.muShield.dZ3,ship_geo.muShield.dZ4,ship_geo.muShield.dZ5,ship_geo.muShield.dZ6,\
-               ship_geo.muShield.dZ7,ship_geo.muShield.dZ8,ship_geo.muShield.dXgap,ship_geo.muShield.LE,ship_geo.Yheight*4./10., ship_geo.cave.floorHeightMuonShield) 
+        MuonShield = ROOT.ShipMuonShield(
+            "MuonShield", ship_geo.muShieldDesign, "ShipMuonShield",
+            ship_geo.muShield.z, ship_geo.muShield.dZ0, ship_geo.muShield.dZ1,
+            ship_geo.muShield.dZ2, ship_geo.muShield.dZ3,
+            ship_geo.muShield.dZ4, ship_geo.muShield.dZ5,
+            ship_geo.muShield.dZ6, ship_geo.muShield.dZ7,
+            ship_geo.muShield.dZ8, ship_geo.muShield.dXgap,
+            ship_geo.muShield.LE, ship_geo.Yheight * 4. / 10.,
+            ship_geo.cave.floorHeightMuonShield)
   else:
-   MuonShield = ROOT.ShipMuonShield("MuonShield",ship_geo.muShieldDesign,"ShipMuonShield",ship_geo.muShield.z,ship_geo.muShield.dZ0,ship_geo.muShield.dZ1,\
-               ship_geo.muShield.dZ2,ship_geo.muShield.dZ3,ship_geo.muShield.dZ4,ship_geo.muShield.dZ5,ship_geo.muShield.dZ6,\
-               ship_geo.muShield.dZ7,ship_geo.muShield.dZ8,ship_geo.muShield.dXgap,ship_geo.muShield.LE,ship_geo.Yheight*4./10.,\
+        MuonShield = ROOT.ShipMuonShield(
+            "MuonShield", ship_geo.muShieldDesign, "ShipMuonShield",
+            ship_geo.muShield.z, ship_geo.muShield.dZ0, ship_geo.muShield.dZ1,
+            ship_geo.muShield.dZ2, ship_geo.muShield.dZ3,
+            ship_geo.muShield.dZ4, ship_geo.muShield.dZ5,
+            ship_geo.muShield.dZ6, ship_geo.muShield.dZ7,
+            ship_geo.muShield.dZ8, ship_geo.muShield.dXgap,
+            ship_geo.muShield.LE, ship_geo.Yheight * 4. / 10.,
                ship_geo.cave.floorHeightMuonShield,ship_geo.muShield.Field) 
  elif ship_geo.muShieldDesign == 8:
   MuonShield = ROOT.ShipMuonShield(ship_geo.muShieldGeo)

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -127,7 +127,6 @@ def configure(run,ship_geo):
                ship_geo.muShield.dZ7,ship_geo.muShield.dZ8,ship_geo.muShield.dXgap,ship_geo.muShield.LE,ship_geo.Yheight*4./10.,\
                ship_geo.cave.floorHeightMuonShield,ship_geo.muShield.Field) 
  elif ship_geo.muShieldDesign == 8:
-  # TODO use new constructor
   MuonShield = ROOT.ShipMuonShield(ship_geo.muShieldGeo)
  
  detectorList.append(MuonShield)

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -72,6 +72,7 @@ def posEcal(z,efile):
 def configure(run,ship_geo):
 # ---- for backward compatibility ----
  if not hasattr(ship_geo,"tankDesign"): ship_geo.tankDesign = 5
+ if not hasattr(ship_geo,"muShieldGeo"): ship_geo.muShieldGeo = None
  if not hasattr(ship_geo.hcal,"File"):  ship_geo.hcal.File = "hcal.geo"
  if not hasattr(ship_geo.Bfield,'x') :  ship_geo.Bfield.x   = 3.*u.m
  if not hasattr(ship_geo,'cave') :       


### PR DESCRIPTION
This pull request will upstream all changes necessary for the new muon shield and for the use of arbitrary muon shield configurations.

Many of the commits refactor the muon shield to facilitate later changes and allow for easier maintenance/understanding of the code. `TString` is used to replace `const char*` (almost?) everywhere, similarly I have tried to replace all C-style arrays with `std::array` or `std::vector` as suitable.

Additionally it includes the new hadron stopper.

To be done/decided before this can be merged:

- [x] Which muon shield should be the default, shall the new muon shield be hard-coded or read from file by default?
- [x] Only update hadron absorber for configs >= 8

Future things to consider:

* Should the hadron stopper implementation be split from the muon shield? As it's out of the scope of the optimisation and the design details will diverge further and further from the rest of the muon shield it might make sense to separate them.