### PR TITLE
Use floating-point precision for field maps.

### DIFF
--- a/field/ShipBFieldMap.h
+++ b/field/ShipBFieldMap.h
@@ -8,7 +8,6 @@
 
 #include "TGeoMatrix.h"
 #include "TVirtualMagField.h"
-#include "TVector3.h"
 
 #include <string>
 #include <utility>
@@ -30,16 +29,17 @@ class ShipBFieldMap : public TVirtualMagField
       \param [in] theta The second Euler rotation angle about the new x axis (degrees)
       \param [in] psi The third Euler rotation angle about the new z axis (degrees)
       \param [in] scale The field magnitude scaling factor (default = 1.0)
+      \param [in] isSymmetric Boolean to specify if we have quadrant symmetry (default = false)
     */
     ShipBFieldMap(const std::string& label, const std::string& mapFileName,
-		  Double_t xOffset = 0.0, Double_t yOffset = 0.0, Double_t zOffset = 0.0,
-		  Double_t phi = 0.0, Double_t theta = 0.0, Double_t psi = 0.0,
-		  Double_t scale = 1.0);
+		  Float_t xOffset = 0.0, Float_t yOffset = 0.0, Float_t zOffset = 0.0,
+		  Float_t phi = 0.0, Float_t theta = 0.0, Float_t psi = 0.0,
+		  Float_t scale = 1.0, Bool_t isSymmetric = kFALSE);
 
     //! Copy constructor with a new global transformation. Use this if you want
     //! to reuse the same field map information elsewhere in the geometry
     /*! 
-      \param [in] rhs The ShipBFieldMap object to be copied
+      \param [in] rhs The ShipBFieldMap object to be copied (retaining any symmetry)
       \param [in] newName The new description or title of the field
       \param [in] newXOffset The new global offset x co-ordinate (cm)
       \param [in] newYOffset The new global offset y co-ordinate (cm)
@@ -51,9 +51,9 @@ class ShipBFieldMap : public TVirtualMagField
      \returns a copy of the field map object "rhs", keeping the same fieldMap pointer
     */
     ShipBFieldMap(const std::string& newName, const ShipBFieldMap& rhs,
-		  Double_t newXOffset, Double_t newYOffset, Double_t newZOffset,
-		  Double_t newPhi = 0.0, Double_t newTheta = 0.0, Double_t newPsi = 0.0,
-		  Double_t newScale = 1.0);
+		  Float_t newXOffset, Float_t newYOffset, Float_t newZOffset,
+		  Float_t newPhi = 0.0, Float_t newTheta = 0.0, Float_t newPsi = 0.0,
+		  Float_t newScale = 1.0);
 
     //! Destructor
     virtual ~ShipBFieldMap();
@@ -65,47 +65,63 @@ class ShipBFieldMap : public TVirtualMagField
     */
     virtual void Field(const Double_t* position, Double_t* B);
 
+    //! Typedef for a vector containing a vector of floats
+    typedef std::vector< std::vector<Float_t> > floatArray;
+
+    //! Retrieve the field map
+    /*!
+      \returns the field map
+    */
+    floatArray* getFieldMap() const {return fieldMap_;}
+
     //! Set the x global co-ordinate shift
     /*!
       \param [in] xValue The value of the x global co-ordinate shift (cm)
     */
-    void SetXOffset(Double_t xValue) {xOffset_ = xValue;}
+    void SetXOffset(Float_t xValue) {xOffset_ = xValue;}
 
     //! Set the y global co-ordinate shift
     /*!
       \param [in] yValue The value of the y global co-ordinate shift (cm)
     */
-    void SetYOffset(Double_t yValue) {yOffset_ = yValue;}
+    void SetYOffset(Float_t yValue) {yOffset_ = yValue;}
 
     //! Set the z global co-ordinate shift
     /*!
       \param [in] zValue The value of the z global co-ordinate shift (cm)
     */
-    void SetZOffset(Double_t zValue) {zOffset_ = zValue;}
+    void SetZOffset(Float_t zValue) {zOffset_ = zValue;}
 
     //! Set the first Euler rotation angle phi about the z axis
     /*!
       \param [in] phi The first Euler rotation angle about the z axis (degrees)
     */
-    void SetPhi(Double_t phi) {phi_ = phi;}
+    void SetPhi(Float_t phi) {phi_ = phi;}
 
     //! Set the second Euler rotation angle theta about the new x axis
     /*!
       \param [in] theta The second Euler rotation angle about the new x axis (degrees)
     */
-    void SetTheta(Double_t theta) {theta_ = theta;}
+    void SetTheta(Float_t theta) {theta_ = theta;}
 
     //! Set the third Euler rotation angle psi about the new z axis
     /*!
       \param [in] psi The third Euler rotation angle about the new z axis (degrees)
     */
-    void SetPsi(Double_t psi) {psi_ = psi;}
+    void SetPsi(Float_t psi) {psi_ = psi;}
 
     //! Set the field magnitude scaling factor
     /*!
       \param [in] scale The scaling factor for the field magnitude
     */
-    void SetScale(Double_t scale) {scale_ = scale;}
+    void SetScale(Float_t scale) {scale_ = scale;}
+
+    //! Set the boolean to specify if we have quadrant symmetry
+    /*!
+      \param [in] isSymmetric Boolean to specify if we have quadrant symmetry
+    */
+    void UseSymmetry(Bool_t flag) {isSymmetric_ = flag;}
+
 
     //! Get the name of the map file
     /*!
@@ -141,115 +157,121 @@ class ShipBFieldMap : public TVirtualMagField
     /*!
       \returns the minimum x co-ordinate (cm)
     */
-    Double_t GetXMin() const {return xMin_;}
+    Float_t GetXMin() const {return xMin_;}
 
     //! Get the maximum value of x for the map
     /*!
       \returns the maximum x co-ordinate (cm)
     */
-    Double_t GetXMax() const {return xMax_;}
+    Float_t GetXMax() const {return xMax_;}
 
     //! Get the bin width along x for the map
     /*!
       \returns the bin width along x (cm)
     */
-    Double_t GetdX() const {return dx_;}
+    Float_t GetdX() const {return dx_;}
 
      //! Get the x co-ordinate range for the map
     /*!
       \returns the x co-ordinate range (cm)
     */
-    Double_t GetXRange() const {return xRange_;}
+    Float_t GetXRange() const {return xRange_;}
 
    //! Get the minimum value of y for the map
     /*!
       \returns the minimum y co-ordinate (cm)
     */
-    Double_t GetYMin() const {return yMin_;}
+    Float_t GetYMin() const {return yMin_;}
 
     //! Get the maximum value of y for the map
     /*!
       \returns the maximum y co-ordinate (cm)
     */
-    Double_t GetYMax() const {return yMax_;}
+    Float_t GetYMax() const {return yMax_;}
 
     //! Get the bin width along y for the map
     /*!
       \returns the bin width along y (cm)
     */
-    Double_t GetdY() const {return dy_;}
+    Float_t GetdY() const {return dy_;}
 
      //! Get the y co-ordinate range for the map
     /*!
       \returns the y co-ordinate range (cm)
     */
-    Double_t GetYRange() const {return yRange_;}
+    Float_t GetYRange() const {return yRange_;}
 
     //! Get the minimum value of z for the map
     /*!
       \returns the minimum z co-ordinate (cm)
     */
-    Double_t GetZMin() const {return zMin_;}
+    Float_t GetZMin() const {return zMin_;}
 
     //! Get the maximum value of z for the map
     /*!
       \returns the maximum z co-ordinate (cm)
     */
-    Double_t GetZMax() const {return zMax_;}
+    Float_t GetZMax() const {return zMax_;}
 
     //! Get the bin width along z for the map
     /*!
       \returns the bin width along z (cm)
     */
-    Double_t GetdZ() const {return dz_;}
+    Float_t GetdZ() const {return dz_;}
 
      //! Get the z co-ordinate range for the map
     /*!
       \returns the z co-ordinate range (cm)
     */
-    Double_t GetZRange() const {return zRange_;}
+    Float_t GetZRange() const {return zRange_;}
 
     //! Get the x offset co-ordinate of the map for global positioning
     /*!
       \returns the map's x offset co-ordinate for global positioning (cm)
     */
-    Double_t GetXOffset() const {return xOffset_;}
+    Float_t GetXOffset() const {return xOffset_;}
 
     //! Get the y offset co-ordinate of the map for global positioning
     /*!
       \returns the map's y offset co-ordinate for global positioning (cm)
     */
-    Double_t GetYOffset() const {return yOffset_;}
+    Float_t GetYOffset() const {return yOffset_;}
 
     //! Get the z offset co-ordinate of the map for global positioning
     /*!
       \returns the map's z offset co-ordinate for global positioning (cm)
     */
-    Double_t GetZOffset() const {return zOffset_;}
+    Float_t GetZOffset() const {return zOffset_;}
 
     //! Get the first Euler rotation angle about the z axis for global positioning
     /*!
       \returns the map's first Euler rotation angle about the z axis (degrees)
     */
-    Double_t GetPhi() const {return phi_;}
+    Float_t GetPhi() const {return phi_;}
 
     //! Get the second Euler rotation angle about the new x axis for global positioning
     /*!
       \returns the map's second Euler rotation angle about the new x axis (degrees)
     */
-    Double_t GetTheta() const {return theta_;}
+    Float_t GetTheta() const {return theta_;}
 
     //! Get the third Euler rotation angle about the new z axis for global positioning
     /*!
       \returns the map's third Euler rotation angle about the new z axis (degrees)
     */
-    Double_t GetPsi() const {return psi_;}
+    Float_t GetPsi() const {return psi_;}
 
     //! Get the field magnitude scaling factor
     /*!
       \returns the scaling factor for the field magnitude
     */
-    Double_t GetScale() const {return scale_;}
+    Float_t GetScale() const {return scale_;}
+
+    //! Get the boolean flag to specify if we have quadrant symmetry
+    /*!
+      \returns the boolean specifying if we have quadrant symmetry
+    */
+    Bool_t HasSymmetry() const {return isSymmetric_;}
 
     //! Get the boolean flag to specify if we are a "copy"
     /*!
@@ -296,10 +318,10 @@ class ShipBFieldMap : public TVirtualMagField
       \param [in] z The z co-ordinate of the point (cm)
       \returns true/false if the point is inside the field map range
     */
-    Bool_t insideRange(Double_t x, Double_t y, Double_t z);
+    Bool_t insideRange(Float_t x, Float_t y, Float_t z);
 
     //! Typedef for an int-double pair
-    typedef std::pair<Int_t, Double_t> binPair;
+    typedef std::pair<Int_t, Float_t> binPair;
 
     //! Get the bin number and fractional distance from the leftmost bin edge
     /*!
@@ -307,7 +329,7 @@ class ShipBFieldMap : public TVirtualMagField
       \param [in] theAxis The co-ordinate axis (CoordAxis enumeration for x, y or z)
       \returns the bin number and fractional distance from the leftmost bin edge as a pair
     */
-    binPair getBinInfo(Double_t x, CoordAxis theAxis);
+    binPair getBinInfo(Float_t x, CoordAxis theAxis);
 
     //! Find the vector entry of the field map data given the bins iX, iY and iZ
     /*!
@@ -324,11 +346,11 @@ class ShipBFieldMap : public TVirtualMagField
       \param [in] theAxis The co-ordinate axis (CoordAxis enumeration for x, y or z)
       \returns the magnetic field component for the given axis
     */
-    Double_t BInterCalc(CoordAxis theAxis);
+    Float_t BInterCalc(CoordAxis theAxis);
 
-    //! Store the field map information as a vector of 3-vectors, whose order
-    //! is given by first incrementing z, then y, then x
-    std::vector<TVector3>* fieldMap_;
+    //! Store the field map information as a vector of 3 floats.
+    //! Map data ordering is given by first incrementing z, then y, then x
+    floatArray* fieldMap_;
 
     //! The name of the map file
     std::string mapFileName_;
@@ -352,67 +374,70 @@ class ShipBFieldMap : public TVirtualMagField
     Int_t N_;
 
     //! The minimum value of x for the map
-    Double_t xMin_;
+    Float_t xMin_;
 
     //! The maximum value of x for the map
-    Double_t xMax_;
+    Float_t xMax_;
 
     //! The bin width along x
-    Double_t dx_;
+    Float_t dx_;
 
     //! The co-ordinate range along x
-    Double_t xRange_;
+    Float_t xRange_;
 
     //! The minimum value of y for the map
-    Double_t yMin_;
+    Float_t yMin_;
 
     //! The maximum value of y for the map
-    Double_t yMax_;
+    Float_t yMax_;
 
     //! The bin width along y
-    Double_t dy_;
+    Float_t dy_;
 
     //! The co-ordinate range along y
-    Double_t yRange_;
+    Float_t yRange_;
 
     //! The minimum value of z for the map
-    Double_t zMin_;
+    Float_t zMin_;
 
     //! The maximum value of z for the map
-    Double_t zMax_;
+    Float_t zMax_;
 
     //! The bin width along z
-    Double_t dz_;
+    Float_t dz_;
 
     //! The co-ordinate range along z
-    Double_t zRange_;
+    Float_t zRange_;
 
     //! The x value of the positional offset for the map
-    Double_t xOffset_;
+    Float_t xOffset_;
 
     //! The y value of the positional offset for the map
-    Double_t yOffset_;
+    Float_t yOffset_;
 
     //! The z value of the positional offset for the map
-    Double_t zOffset_;
+    Float_t zOffset_;
 
     //! The first Euler rotation angle about the z axis
-    Double_t phi_;
+    Float_t phi_;
 
     //! The second Euler rotation angle about the new x axis
-    Double_t theta_;
+    Float_t theta_;
 
     //! The third Euler rotation angle about the new z axis
-    Double_t psi_;
+    Float_t psi_;
 
     //! The B field magnitude scaling factor
-    Double_t scale_;
+    Float_t scale_;
+
+    //! The boolean specifying if we have quadrant symmetry
+    Bool_t isSymmetric_;
 
     //! The combined translation and rotation transformation
     TGeoMatrix* theTrans_;
 
     //! Double converting Tesla to kiloGauss (for VMC/FairRoot B field units)
-    Double_t Tesla_;
+    Float_t Tesla_;
 
     //! Bin A for the trilinear interpolation
     Int_t binA_;
@@ -439,22 +464,22 @@ class ShipBFieldMap : public TVirtualMagField
     Int_t binH_;
 
     //! Fractional bin distance along x
-    Double_t xFrac_;
+    Float_t xFrac_;
 
     //! Fractional bin distance along y
-    Double_t yFrac_;
+    Float_t yFrac_;
 
     //! Fractional bin distance along z
-    Double_t zFrac_;
+    Float_t zFrac_;
 
     //! Complimentary fractional bin distance along x
-    Double_t xFrac1_;
+    Float_t xFrac1_;
 
     //! Complimentary fractional bin distance along y
-    Double_t yFrac1_;
+    Float_t yFrac1_;
 
     //! Complimentary fractional bin distance along z
-    Double_t zFrac1_;
+    Float_t zFrac1_;
 
 };
 

--- a/field/ShipFieldMaker.h
+++ b/field/ShipFieldMaker.h
@@ -156,8 +156,9 @@ class ShipFieldMaker
     //! Create the field map based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
+      \param [in] useSymmetry Boolean to specify if we have x-y quadrant symmetry
     */
-    void createFieldMap(const stringVect& inputLine);
+    void createFieldMap(const stringVect& inputLine, Bool_t useSymmetry = kFALSE);
 
     //! Copy (&translate) a field map based on information from the inputLine
     /*!

--- a/field/convertMisisMap.py
+++ b/field/convertMisisMap.py
@@ -1,0 +1,181 @@
+#!/bin/python
+
+# Python script to convert B field maps from MISIS text files into 
+# ROOT files for FairShip. Text files are assumed to contain two
+# preamble lines giving the binning details and variable names, followed 
+# by data lines x y z Bx By Bz, where the co-ordinates are assumed to
+# be in ascending z, y and x, in that order. Need distances in cm
+
+import ROOT
+
+# Struct for the ROOT file TTree data: coord range and field info
+
+ROOT.gROOT.ProcessLine(
+"struct rangeStruct{\
+   float xMin;\
+   float xMax;\
+   float dx;\
+   float yMin;\
+   float yMax;\
+   float dy;\
+   float zMin;\
+   float zMax;\
+   float dz;\
+};");
+
+# The field map is assumed to obey the following co-ordinate bin ordering:
+# z is increased first, y is increased 2nd, x is increased last.
+# So we only store the field components (x,y,z is known from the ordering).
+# For the coordinate bin (iX, iY, iZ), the field bin = (iX*Ny + iY)*Nz + iZ, 
+# where Ny and Nz are the number of y and z bins
+
+ROOT.gROOT.ProcessLine(
+"struct dataStruct{\
+   float Bx;\
+   float By;\
+   float Bz;\
+};");
+
+
+def run(inFileName  = 'BFieldTest.txt',
+        rootFileName = 'BFieldTest.root'):
+
+    createRootMap(inFileName, rootFileName)
+
+
+def createRootMap(inFileName, rootFileName):
+
+    print 'Create ROOT map {0} from {1}'.format(rootFileName, inFileName)
+
+    # Define ROOT file and its TTree
+    theFile = ROOT.TFile.Open(rootFileName, 'recreate')
+
+    rangeTree = ROOT.TTree('Range', 'Range')
+    rangeTree.SetDirectory(theFile)
+
+    # Co-ordinate ranges
+    rStruct = ROOT.rangeStruct()
+    rangeTree.Branch('xMin', ROOT.AddressOf(rStruct, 'xMin'), 'xMin/F')
+    rangeTree.Branch('xMax', ROOT.AddressOf(rStruct, 'xMax'), 'xMax/F')
+    rangeTree.Branch('dx', ROOT.AddressOf(rStruct, 'dx'), 'dx/F')
+    rangeTree.Branch('yMin', ROOT.AddressOf(rStruct, 'yMin'), 'yMin/F')
+    rangeTree.Branch('yMax', ROOT.AddressOf(rStruct, 'yMax'), 'yMax/F')
+    rangeTree.Branch('dy', ROOT.AddressOf(rStruct, 'dy'), 'dy/F')
+    rangeTree.Branch('zMin', ROOT.AddressOf(rStruct, 'zMin'), 'zMin/F')
+    rangeTree.Branch('zMax', ROOT.AddressOf(rStruct, 'zMax'), 'zMax/F')
+    rangeTree.Branch('dz', ROOT.AddressOf(rStruct, 'dz'), 'dz/F')
+
+    dataTree = ROOT.TTree('Data', 'Data')
+    dataTree.SetDirectory(theFile)
+
+    # Field components with (x,y,z) coordinate binning ordered such that
+    # z, then y, then x is increased. For the coordinate bin (iX, iY, iZ),
+    # the field bin = (iX*Ny + iY)*Nz + iZ, where Ny and Nz are the number 
+    # of y and z bins
+    dStruct = ROOT.dataStruct()
+    dataTree.Branch('Bx', ROOT.AddressOf(dStruct, 'Bx'), 'Bx/F')
+    dataTree.Branch('By', ROOT.AddressOf(dStruct, 'By'), 'By/F')
+    dataTree.Branch('Bz', ROOT.AddressOf(dStruct, 'Bz'), 'Bz/F')
+
+    # mm to cm conversion
+    mm2cm = 0.1
+    # m to cm conversion
+    m2cm = 100.0
+
+    # Open text file and process the information
+    iLine = 0
+
+    # Number of bins initialised by reading first line
+    Nx = 0
+    Ny = 0
+    Nz = 0
+    Nzy = 0
+
+    # Field centering co-ordinates
+    x0 = 0.0
+    y0 = 0.0
+    z0 = 0.0
+
+    with open(inFileName, 'r') as f:
+
+        for line in f:
+            iLine += 1
+
+            # First line contains ranges
+            if iLine == 1:
+                # Remove extraneous, unneeded symbols in the line
+                line = line.replace('[','')
+                line = line.replace(']','')
+                line = line.replace('mm','')
+                sLine = line.split()
+
+                # Bin info line assumed to be formatted as:
+                # Grid Output Min: xMin yMin zMin Max: xMax yMax zMax Grid Size: dx dy dz
+                # These co-ordinate limits are in mm, but the actual data lines use m
+
+                print 'sLine = {0}'.format(sLine)
+                # For each value, convert from mm to cm
+                rStruct.xMin = float(sLine[3])*mm2cm
+                rStruct.xMax = float(sLine[7])*mm2cm
+                rStruct.dx = float(sLine[12])*mm2cm
+                rStruct.yMin = float(sLine[4])*mm2cm
+                rStruct.yMax = float(sLine[8])*mm2cm
+                rStruct.dy = float(sLine[13])*mm2cm
+                rStruct.zMin = float(sLine[5])*mm2cm
+                rStruct.zMax = float(sLine[9])*mm2cm
+                rStruct.dz = float(sLine[14])*mm2cm
+
+                Nx = int(((rStruct.xMax - rStruct.xMin)/rStruct.dx) + 1.0)
+                Ny = int(((rStruct.yMax - rStruct.yMin)/rStruct.dy) + 1.0)
+                Nz = int(((rStruct.zMax - rStruct.zMin)/rStruct.dz) + 1.0)
+                Nzy = Nz*Ny
+
+                print 'Nx = {0}, Ny = {1}, Nz = {2}'.format(Nx, Ny, Nz)
+
+                # Centre the field map on the local origin (cm)
+                x0 = 0.5*(rStruct.xMin + rStruct.xMax)
+                y0 = 0.5*(rStruct.yMin + rStruct.yMax)
+                z0 = 0.5*(rStruct.zMin + rStruct.zMax)
+
+                print 'Centering field map using co-ordinate shift {0} {1} {2} cm'.format(x0, y0, z0)
+
+                # Center co-ordinate range limits (cm)
+                rStruct.xMin = rStruct.xMin - x0
+                rStruct.xMax = rStruct.xMax - x0
+
+                rStruct.yMin = rStruct.yMin - y0
+                rStruct.yMax = rStruct.yMax - y0
+
+                rStruct.zMin = rStruct.zMin - z0
+                rStruct.zMax = rStruct.zMax - z0
+
+                # Fill info into range tree
+                rangeTree.Fill()
+                
+
+            # Field data values start from line 3
+            elif iLine > 2:
+
+                sLine = line.split()
+
+                # Bin centre coordinates (m to cm), with origin shift (cm)
+                dStruct.x = float(sLine[0])*m2cm - x0
+                dStruct.y = float(sLine[1])*m2cm - y0
+                dStruct.z = float(sLine[2])*m2cm - z0
+
+                # B field components (Tesla)
+                dStruct.Bx = float(sLine[3])
+                dStruct.By = float(sLine[4])
+                dStruct.Bz = float(sLine[5])
+
+                dataTree.Fill()
+                
+    theFile.cd()
+    rangeTree.Write()
+    dataTree.Write()
+    theFile.Close()
+
+
+if __name__ == "__main__":
+
+    run('BFieldTest.txt', 'BFieldTest.root')


### PR DESCRIPTION
Modified ShipBFieldMap to store the field map data using floating-point
precision. Also allow the use of quadrant-symmetric field maps. Added
convertMisisMap.py as a basis for converting field maps from MISIS
and renamed convertMap.py to field/convertRALMap.py. Updated README
file to mention the above changes.