### PR TITLE
Add Dockerfile (for Skygrid, Condor & continuous integration)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+map
+files
+system
+travis.sh
+localBuild.sh
+aliBuild.sh
+Dockerfile
+Vagrantfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM olantwin/ship-base:20180528
+
+RUN git clone https://github.com/ShipSoft/FairShip.git
+
+RUN aliBuild -c shipdist/ --defaults fairship build FairShip --no-local ROOT \
+	&& aliBuild clean --aggressive-cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM olantwin/ship-base:20180528
 
-RUN git clone https://github.com/ShipSoft/FairShip.git
+ADD . /FairShip
 
 RUN aliBuild -c shipdist/ --defaults fairship build FairShip --no-local ROOT \
 	&& aliBuild clean --aggressive-cleanup


### PR DESCRIPTION
This adds a Dockerfile that can be used to build the current commit using aliBuild based on an image containing all the dependencies pre-installed using aliBuild.

This can be used to automatically build every commit, and in future to run tests on new commits (similar to what Travis does/did), but using our normal build methods, instead of manually copying pre-built files.

The .dockerignore is there to avoid copying files not necessary for the build. Unfortunately the `.git` directory is needed or `aliBuild`.

I currently have automatic builds set up for my fork, but as I'm not in `ShipSoft` I cannot do so for the official repository.