### PR TITLE
 Add field definition functions to ShipFieldMaker

### DIFF
--- a/field/README.md
+++ b/field/README.md
@@ -35,10 +35,8 @@ reads a control file, or calls definition functions, that specifies what magneti
 for the simulation. Note that B fields (TVirtualMagFields) already defined in the geometry C++ source 
 code do not need to be added again via either the input file or with definition functions. The
 ShipFieldMaker, which inherits from 
-[TG4VUserPostDetConstruction]
-(https://github.com/vmc-project/geant4_vmc/blob/master/source/geometry/include/TG4VUserRegionConstruction.h), 
-is then passed onto the ROOT/Geant4 [geometry manager]
-(https://github.com/vmc-project/geant4_vmc/blob/master/source/geometry/include/TG4GeometryManager.h) 
+[TG4VUserPostDetConstruction](https://github.com/vmc-project/geant4_vmc/blob/master/source/geometry/include/TG4VUserRegionConstruction.h), 
+is then passed onto the ROOT/Geant4 geometry [manager](https://github.com/vmc-project/geant4_vmc/blob/master/source/geometry/include/TG4GeometryManager.h) 
 and the VMC fields are updated via the overriden ShipFieldMaker::Construct() function.
 
 The run script can also generate plots of the magnitude of the magnetic field in the z-x, z-y and/or 

--- a/field/README.md
+++ b/field/README.md
@@ -35,7 +35,7 @@ reads a control file, or calls definition functions, that specifies what magneti
 for the simulation. Note that B fields (TVirtualMagFields) already defined in the geometry C++ source 
 code do not need to be added again via either the input file or with definition functions. The
 ShipFieldMaker, which inherits from 
-[TG4VUserPostDetConstruction](https://github.com/vmc-project/geant4_vmc/blob/master/source/geometry/include/TG4VUserRegionConstruction.h), 
+[TG4VUserPostDetConstruction](https://github.com/vmc-project/geant4_vmc/blob/master/source/geometry/include/TG4VUserPostDetConstruction.h), 
 is then passed onto the ROOT/Geant4 geometry [manager](https://github.com/vmc-project/geant4_vmc/blob/master/source/geometry/include/TG4GeometryManager.h) 
 and the VMC fields are updated via the overriden ShipFieldMaker::Construct() function.
 

--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -413,9 +413,12 @@ void ShipBFieldMap::setLimits() {
 
     N_ = Nx_*Ny_*Nz_;
 
-    std::cout<<"x values: "<<xMin_<<", "<<xMax_<<", dx = "<<dx_<<std::endl;
-    std::cout<<"y values: "<<yMin_<<", "<<yMax_<<", dy = "<<dy_<<std::endl;
-    std::cout<<"z values: "<<zMin_<<", "<<zMax_<<", dz = "<<dz_<<std::endl;
+    std::cout<<"x limits: "<<xMin_<<", "<<xMax_<<", dx = "<<dx_<<std::endl;
+    std::cout<<"y limits: "<<yMin_<<", "<<yMax_<<", dy = "<<dy_<<std::endl;
+    std::cout<<"z limits: "<<zMin_<<", "<<zMax_<<", dz = "<<dz_<<std::endl;
+
+    std::cout<<"Offsets: x = "<<xOffset_<<", y = "<<yOffset_<<", z = "<<zOffset_<<std::endl;
+    std::cout<<"Angles : phi = "<<phi_<<", theta = "<<theta_<<", psi = "<<psi_<<std::endl;
 
     std::cout<<"Total number of bins = "<<N_
 	     <<"; Nx = "<<Nx_<<", Ny = "<<Ny_<<", Nz = "<<Nz_<<std::endl;

--- a/field/ShipFieldMaker.h
+++ b/field/ShipFieldMaker.h
@@ -20,6 +20,7 @@
 
 #include "TString.h"
 #include "TVirtualMagField.h"
+#include "TVector2.h"
 #include "TVector3.h"
 #include "TG4VUserPostDetConstruction.h"
 
@@ -37,7 +38,7 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
  public:
 
     //! Constructor
-    ShipFieldMaker(const std::string& inputFile, Bool_t verbose = kFALSE);
+    ShipFieldMaker(Bool_t verbose = kFALSE);
 
     //! Destructor
     virtual ~ShipFieldMaker();
@@ -48,8 +49,144 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
     //! Typedef of a vector of strings
     typedef std::vector<std::string> stringVect;
 
-    //! Set-up all the fields and assign to local volumes
+    //! Structure to hold volume name, field name and field scaling factor
+    struct fieldInfo {
+
+	//! The name of the volume
+	TString volName_;
+	//! The name of the field
+	TString fieldName_;
+	//! The field scaling factor
+	Double_t scale_;
+	
+	//! Default constructor
+        fieldInfo() : volName_(""), fieldName_(""), scale_(1.0) {};
+
+	//! Constructor
+        fieldInfo(const TString& volName, const TString& fieldName, Double_t scale = 1.0) :
+	          volName_(volName), fieldName_(fieldName), scale_(scale) {};
+
+    };
+
+    //! Set-up all local and regional fields and assign them to volumes
     virtual void Construct();
+
+    //! Read an input file to define fields and associated volumes
+    /*!
+      \param [in] inputFile The input text file
+    */
+    void readInputFile(const std::string& inputFile);
+
+    //! Define a uniform field
+    /*!
+      \param [in] name The name of the field
+      \param [in] BVector The vector of B field components (Bx, By, Bz) in Tesla
+    */
+    void defineUniform(const TString& name, const TVector3& BVector);
+
+    //! Define a constant field
+    /*!
+      \param [in] name The name of the field
+      \param [in] xRange The x range as a TVector2(xMin, xMax)
+      \param [in] yRange The y range as a TVector2(yMin, yMax)
+      \param [in] zRange The z range as a TVector2(zMin, zMax)
+      \param [in] BVector The vector of B field components (Bx, By, Bz) in Tesla
+    */
+    void defineConstant(const TString& name, const TVector2& xRange, const TVector2& yRange,
+			const TVector2& zRange, const TVector3& BVector);
+
+    //! Define a Bell field
+    /*!
+      \param [in] name The name of the field
+      \param [in] BPeak The peak B field magnitude (Tesla)
+      \param [in] zMiddle The middle z global position of the magnet (cm)
+      \param [in] orient Orientation flag: 1 => Bx = 0 (default), 0 => By = 0  
+      \param [in] tubeR The largest inner radius of the tube ellipse (cm); default = 500 cm
+      \param [in] xy Optional target xy radius region (cm)
+      \param [in] z Optional target start z global position (cm)
+      \param [in] L Optional target region length (cm)
+    */
+    void defineBell(const TString& name, Double_t BPeak, Double_t zMiddle,
+		    Int_t orient = 1, Double_t tubeR = 500.0,
+		    Double_t xy = 0.0, Double_t z = 0.0, Double_t L = 0.0);
+
+    // ! Define a field map
+    /*!
+      \param [in] name The name of the field
+      \param [in] mapFileName The location of the field map ROOT file relative to VMCWORKDIR
+      \param [in] localCentre The TVector3(x,y,z) offset shift applied to all field map coordinates
+      \param [in] localAngles The TVector3(phi, theta, psi) Euler rotation applied to all map coords
+      \param [in] useSymmetry Boolean to specify if the map has quadrant symmetry (default = false)
+    */   
+    void defineFieldMap(const TString& name, const TString& mapFileName,
+			const TVector3& localCentre = TVector3(0.0, 0.0, 0.0),
+			const TVector3& localAngles = TVector3(0.0, 0.0, 0.0),
+			Bool_t useSymmetry = kFALSE);
+
+    //! Define a copy of a field map with a coordinate translation and optional rotation
+    /*!
+      \param [in] name The name of the field
+      \param [in] mapNameToCopy The name of the field map that is to be copied
+      \param [in] translation The TVector3(x,y,z) coordinate translation
+      \param [in] eulerAngles The TVector3(phi, theta, psi) Euler angle rotation
+    */
+    void defineFieldMapCopy(const TString& name, const TString& mapNameToCopy,
+			    const TVector3& translation,
+			    const TVector3& eulerAngles = TVector3(0.0, 0.0, 0.0));
+
+    //! Define a composite field from up to four fields
+    /*!
+      \param [in] name The name of the composite field
+      \param [in] field1Name The name of the first field
+      \param [in] field2Name The name of the second field
+      \param [in] field3Name The name of the third field (optional)
+      \param [in] field4Name The name of the fourth field (optional)
+    */
+    void defineComposite(const TString& name, const TString& field1Name,
+			 const TString& field2Name, const TString& field3Name = "",
+			 const TString& field4Name = "");
+
+    //! Define a composite field from a vector of field names
+    /*!
+      \param [in] name The name of the composite field
+      \param [in] fieldNames Vector of all of the field names to be combined
+    */
+    void defineComposite(const TString& name, std::vector<TString> fieldNames);
+
+    //! Define a composite field from up to four fields
+    /*!
+      \param [in] field1Name The name of the first field
+      \param [in] field2Name The name of the second field (optional)
+      \param [in] field3Name The name of the third field (optional)
+      \param [in] field4Name The name of the fourth field (optional)
+    */
+    void defineGlobalField(const TString& field1Name, const TString& field2Name = "",
+			   const TString& field3Name = "", const TString& field4Name = "");
+
+    //! Define the Global field using a vector of field names
+    /*!
+      \param [in] fieldNames Vector of all of the field names to be combined
+    */
+    void defineGlobalField(std::vector<TString> fieldNames);
+
+    //! Define a regional (local + global) field and volume pairing
+    /*!
+      \param [in] volName The name of the volume
+      \param [in] fieldName The name of the field for the volume
+      \param [in] scale Optional scale factor for field maps (default = 1.0)
+    */
+    void defineRegionField(const TString& volName, const TString& fieldName,
+			   Double_t scale = 1.0);
+
+    //! Define a localised field and volume pairing
+    /*!
+      \param [in] volName The name of the volume
+      \param [in] fieldName The name of the local field for the volume
+      \param [in] scale Optional scale factor for field maps (default = 1.0)
+    */
+    void defineLocalField(const TString& volName, const TString& fieldName,
+			  Double_t scale = 1.0);
+
 
     //! Get the global magnetic field
     /*!
@@ -70,19 +207,19 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
     */
     TVirtualMagField* getVolumeField(const TString& volName) const;
 
-    //! Check if we have a field stored with the given label name
+    //! Check if we have a field stored with the given name name
     /*!
-      \param [in] label The label name of the field
+      \param [in] name The name of the field
       \returns a boolean to say if we already have the field stored in the internal map
     */
-    Bool_t gotField(const TString& label) const;
+    Bool_t gotField(const TString& name) const;
 
-    //! Get the field stored with the given label name
+    //! Get the field stored with the given name name
     /*!
-      \param [in] label The label name of the field
+      \param [in] name The name of the field
       \returns the pointer to the magnetic field object
     */
-    TVirtualMagField* getField(const TString& label) const;
+    TVirtualMagField* getField(const TString& name) const;
 
     //! Plot the magnetic field in x-y plane
     /*!
@@ -115,7 +252,7 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
       \param [in] yAxis Three vector specifying the min, max and bin width of the y axis
       \param [in] plotFile The name of the output file containing the plot of the magnetic field
     */
-    void plotField(Int_t type, const TVector3& xAxis, const TVector3& yAxis, 
+    void plotField(Int_t type, const TVector3& xAxis, const TVector3& yAxis,
 		   const std::string& plotFile) const;
 
     //! ClassDef for ROOT
@@ -143,60 +280,64 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
 
     };
 
-    //! Create the uniform field based on information from the inputLine
+    //! Define a uniform field based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void createUniform(const stringVect& inputLine);
+    void defineUniform(const stringVect& inputLine);
 
-    //! Create the constant field based on information from the inputLine
+    //! Define a constant field based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void createConstant(const stringVect& inputLine);
+    void defineConstant(const stringVect& inputLine);
 
-    //! Create the Bell field based on information from the inputLine
+    //! Define a Bell field based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void createBell(const stringVect& inputLine);
+    void defineBell(const stringVect& inputLine);
 
-    //! Create the field map based on information from the inputLine
+    //! Define a field map based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
       \param [in] useSymmetry Boolean to specify if we have x-y quadrant symmetry
     */
-    void createFieldMap(const stringVect& inputLine, Bool_t useSymmetry = kFALSE);
+    void defineFieldMap(const stringVect& inputLine, Bool_t useSymmetry = kFALSE);
 
-    //! Copy (&translate) a field map based on information from the inputLine
+    //! Define a (translated) copy of a field map based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void copyFieldMap(const stringVect& inputLine);
+    void defineFieldMapCopy(const stringVect& inputLine);
 
-     //! Create the composite field based on information from the inputLine
+     //! Define a composite field based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void createComposite(const stringVect& inputLine);
+    void defineComposite(const stringVect& inputLine);
 
-   //! Set the global field based on information from the inputLine
+   //! Define the global field based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void setGlobalField(const stringVect& inputLine);
+    void defineGlobalField(const stringVect& inputLine);
 
-    //! Set the regional (local+global) field based on the info from the inputLine
+    //! Define a regional (local+global) field based on the info from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void setRegionField(const stringVect& inputLine);
+    void defineRegionField(const stringVect& inputLine);
 
-    //! Set the local field only based on information from the inputLine
+    // ! Setup all of the regional fields. Called by Construct()
+    void setAllRegionFields();
+
+
+    //! Define a local field only based on information from the inputLine
     /*!
       \param [in] inputLine The space separated input line
     */
-    void setLocalField(const stringVect& inputLine);
+    void defineLocalField(const stringVect& inputLine);
 
     //! Check if we have a local field map and store the volume global transformation
     /*!
@@ -205,6 +346,10 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
       \param [in] scale The B field magnitude scaling factor
     */
     void checkLocalFieldMap(TVirtualMagField*& localField, const TString& volName, Double_t scale);
+
+    // ! Setup all of the local fields. Called by Construct()
+    void setAllLocalFields();
+
 
     //! Get the transformation matrix for the volume position and orientation
     /*!
@@ -220,7 +365,6 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
     */
     void findNode(TGeoVolume* aVolume, const TString& volName);
 
-
  private:
 
     //! The global magnetic field
@@ -229,8 +373,11 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
     //! The map storing all created magnetic fields
     SFMap theFields_;
 
-    //! Configuration input file
-    std::string inputFile_;
+    //! Vector of fieldInfo for regional fields
+    std::vector<fieldInfo> regionInfo_;
+
+    //! Vector of fieldInfo for local fields
+    std::vector<fieldInfo> localInfo_;
 
     //! Verbose boolean
     Bool_t verbose_;

--- a/field/ShipGoliathField.cxx
+++ b/field/ShipGoliathField.cxx
@@ -64,8 +64,7 @@ ShipGoliathField::~ShipGoliathField() { }
 
 void ShipGoliathField::Init(const char* fieldfile){
 
-  TFile *fieldmap = new TFile(fieldfile); 
-  
+  fieldmap = new TFile(fieldfile);  
   
   TH3D* histbx= (TH3D*)fieldmap->Get("Bx");
   TH3D* histby= (TH3D*)fieldmap->Get("By"); 

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -162,7 +162,7 @@ modules = charmDet_conf.configure(run,ShipGeo)
 run.Init()
 
 #import geomGeant4
-#fieldMaker = geomGeant4.addVMCFields('field/GoliathBFieldSetup.txt', False)
+#fieldMaker = geomGeant4.addVMCFields(ShipGeo, 'field/GoliathBFieldSetup.txt', False)
 #print "!!!!!!!!!!!! printing fields"
 #geomGeant4.printVMCFields()
 

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -76,7 +76,7 @@ modules = shipDet_conf.configure(run,ShipGeo)
 run.Init()
 import geomGeant4
 if hasattr(ShipGeo.Bfield,"fieldMap"):
-  fieldMaker = geomGeant4.addVMCFields(ShipGeo.Bfield.fieldMap, ShipGeo.Bfield.z, True)
+  fieldMaker = geomGeant4.addVMCFields(ShipGeo, '', True)
 
 sGeo   = ROOT.gGeoManager
 geoMat =  ROOT.genfit.TGeoMaterialInterface()

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -130,7 +130,7 @@ run.Init()
 import geomGeant4
 
 if hasattr(ShipGeo.Bfield,"fieldMap"):
-  fieldMaker = geomGeant4.addVMCFields(ShipGeo.Bfield.fieldMap, ShipGeo.Bfield.z, True)
+  fieldMaker = geomGeant4.addVMCFields(ShipGeo, '', True)
 
 # make global variables
 builtin.debug    = debug

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -492,7 +492,7 @@ import geomGeant4
 # any field maps, or defining if any volumes feel only the local or local+global field.
 # For now, just keep the fields already defined by the C++ code, i.e comment out the fieldMaker
 if hasattr(ship_geo.Bfield,"fieldMap"):
-  fieldMaker = geomGeant4.addVMCFields(ship_geo.Bfield.fieldMap, ship_geo.Bfield.z, True)
+  fieldMaker = geomGeant4.addVMCFields(ship_geo, '', True)
 
 # Print VMC fields and associated geometry objects
 if debug > 0:

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -2,9 +2,10 @@ import os,ROOT,shipPatRec,charmDet_conf
 import shipunit as u
 import rootUtils as ut
 
-from array import array
 import sys, os
 
+from array import array
+from ShipGeoConfig import ConfigRegistry
 
 stop  = ROOT.TVector3()
 start = ROOT.TVector3()
@@ -92,7 +93,8 @@ class MufluxDigiReco:
 # init geometry and mag. field
   gMan  = ROOT.gGeoManager
   #import geomGeant4
-  #fieldMaker = geomGeant4.addVMCFields('field/GoliathBFieldSetup.txt', False)
+  #shipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py")
+  #fieldMaker = geomGeant4.addVMCFields(shipGeo, 'field/GoliathBFieldSetup.txt', False)
   #geomGeant4.printVMCFields()
   self.bfield = ROOT.genfit.FairShipFields()
   self.fM = ROOT.genfit.FieldManager.getInstance()

--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -1,7 +1,7 @@
 import shipunit as u
 from array import array
 import hepunit as G4Unit
-import ROOT,os
+import ROOT
 # requires to have ${SIMPATH}/include/Geant4/ in PYTHONPATH
 ROOT.gROOT.ProcessLine('#include "Geant4/G4TransportationManager.hh"')
 ROOT.gROOT.ProcessLine('#include "Geant4/G4FieldManager.hh"')

--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -131,27 +131,31 @@ def printWeightsandFields(onlyWithField = True,exclude=[]):
    print 'total magnet mass',nM/1000.,'t'
    return
 
-def addVMCFields(controlFile = 'field/BFieldSetup.txt', zPos = 0.0, verbose = False):
+def addVMCFields(shipGeo, controlFile = '', verbose = False):
     '''
     Define VMC B fields, e.g. global field, field maps, local or local+global fields
     '''
-    print 'Calling addVMCFields using input control file {0}'.format(controlFile)
+    print 'Calling addVMCFields'
     
-    # consistency check of z position until there are methods to set z position for the VMC interface directly
-    ftmp = open(os.environ['FAIRSHIP']+'/'+controlFile)
-    ok = False
-    for l in ftmp.readlines():
-     if not l.find(str(zPos))<0: ok = True
-    ftmp.close()
-    if not ok: 
-     print "position in ",controlFile," does not agree with selected geometry! z=",zPos,". Stop execution."
-     exit()
+    fieldMaker = ROOT.ShipFieldMaker(verbose)
 
-    fieldMaker = ROOT.ShipFieldMaker(controlFile, verbose)
+    # Read the input control file. If this is empty then the only fields that are 
+    # defined (so far) are those within the C++ geometry classes
+    if controlFile is not '':
+      fieldMaker.readInputFile(controlFile)
 
-    # Reset the fields in the VMC to use info from the fieldMaker object
+    # Set the main spectrometer field map as a global field
+    if hasattr(shipGeo, 'Bfield'):
+      fieldMaker.defineFieldMap('MainSpecMap', 'files/MainSpectrometerField.root',
+                                ROOT.TVector3(0.0, 0.0, shipGeo.Bfield.z))
+      fieldMaker.defineGlobalField('MainSpecMap')
+
+    # Force the VMC to update/reset the fields defined by the fieldMaker object.
+    # Get the ROOT/Geant4 geometry manager
     geom = ROOT.TG4GeometryManager.Instance()
+    # Let the geometry know about the fieldMaker object
     geom.SetUserPostDetConstruction(fieldMaker)
+    # Update the fields via the overriden ShipFieldMaker::Contruct() function
     geom.ConstructSDandField()
 
     # Return the fieldMaker object, otherwise it will "go out of scope" and its


### PR DESCRIPTION
It is now possible to define volume B fields using "defineX()" function calls with the ShipFieldMaker object in python/geomGeant4.py in addition to reading in the configuration file. The addVMCFields() function in geomGeant4.py has been changed to pass the ship_geo object, which is now used to get the z position for the spectrometer field map definition. The field/README file has been updated to give details about the new features, as well as being clearer about various keywords/parameter definitions and options.

There have been some internal changes to ShipFieldMaker:

1) Changed the ShipFieldMaker constructor to only require the verbosity boolean (default = false). The configuration input file is only processed when the new readInputFile(configFileName) function is called. This allows us the option of not requiring a configuration input file to setup fields.

2) Renamed the createX() functions to defineX(), with public versions for calling via the python scripts (& C++ code) and protected versions that are used when each line in the configuration input file is processed. The protected functions simply extract the keywords and parameters from the input line and pass this information onto the public functions that do the actual work.

3) The local and regional (local+global) field names that are needed for each volume are first stored as internal fieldInfo structure (volumeName, fieldName, scalingFactor) objects in two separate vectors. The Construct() function, called by the VMC at the end of initialisation, then loops over these two vectors and sets the fields for each volume. Before, Construct() could only process the configuration input file to set the fields. Now, we can set fields using both the config file and/or function calls.