### PR TITLE
Fixing bug in ProcessHits, pointed by Thomas

### DIFF
--- a/charmdet/Box.cxx
+++ b/charmdet/Box.cxx
@@ -969,13 +969,7 @@ Bool_t  Box::ProcessHits(FairVolume* vol)
         gMC->IsTrackStop()       ||
         gMC->IsTrackDisappeared()   ) {
         fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
-        fVolumeID = vol->getMCid();
-	Int_t detID=0;
-	gMC->CurrentVolID(detID);
-
-	if (fVolumeID == detID) {
-	  return kTRUE; }
-	fVolumeID = detID;
+        gMC->CurrentVolID(fVolumeID);
 
 	//gGeoManager->PrintOverlaps();		
 	

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -203,14 +203,8 @@ Bool_t  MuonTagger::ProcessHits(FairVolume* vol)
         gMC->IsTrackStop()       ||
         gMC->IsTrackDisappeared()   ) {
         fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
-        fVolumeID = vol->getMCid();
-	Int_t detID=0;
-	gMC->CurrentVolID(detID);
-
-	if (fVolumeID == detID) {
-	  return kTRUE; }
-	fVolumeID = detID;
-
+       
+	gMC->CurrentVolID(fVolumeID);
 	//gGeoManager->PrintOverlaps();		
 	
 	if (fELoss == 0. ) { return kFALSE; }

--- a/charmdet/Spectrometer.cxx
+++ b/charmdet/Spectrometer.cxx
@@ -477,17 +477,12 @@ Bool_t  Spectrometer::ProcessHits(FairVolume* vol)
         gMC->IsTrackStop()       ||
         gMC->IsTrackDisappeared()   ) {
         fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
-	fVolumeID = vol->getMCid();
+
         if (fELoss == 0. ) { return kFALSE; }
         TParticle* p=gMC->GetStack()->GetCurrentTrack();
         Int_t pdgCode = p->GetPdgCode();
 	//Int_t fMotherID =p->GetFirstMother();
-	Int_t detID=0;
-	gMC->CurrentVolID(detID);
-
-	if (fVolumeID == detID) {
-	  return kTRUE; }
-	fVolumeID = detID;
+        gMC->CurrentVolID(fVolumeID);	
 
         TLorentzVector Pos; 
         gMC->TrackPosition(Pos); 

--- a/nutaudet/HPT.cxx
+++ b/nutaudet/HPT.cxx
@@ -263,18 +263,11 @@ Bool_t  Hpt::ProcessHits(FairVolume* vol)
         gMC->IsTrackStop()       ||
         gMC->IsTrackDisappeared()   ) {
         fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
-	fVolumeID = vol->getMCid();
         if (fELoss == 0. ) { return kFALSE; }
         TParticle* p=gMC->GetStack()->GetCurrentTrack();
         Int_t pdgCode = p->GetPdgCode();
 	//Int_t fMotherID =p->GetFirstMother();
-	Int_t detID=0;
-	gMC->CurrentVolID(detID);
-
-	if (fVolumeID == detID) {
-	  return kTRUE; }
-	fVolumeID = detID;
-
+	gMC->CurrentVolID(fVolumeID);
         TLorentzVector Pos; 
         gMC->TrackPosition(Pos); 
         Double_t xmean = (fPos.X()+Pos.X())/2. ;      

--- a/nutaudet/Target.cxx
+++ b/nutaudet/Target.cxx
@@ -545,14 +545,8 @@ Bool_t  Target::ProcessHits(FairVolume* vol)
        gMC->IsTrackDisappeared()   ) {
     fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
     //Int_t fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
-    fVolumeID = vol->getMCid();
-    Int_t detID=0;
-    gMC->CurrentVolID(detID);
-
-    if (fVolumeID == detID) {
-      return kTRUE; }
-    fVolumeID = detID;
-
+    gMC->CurrentVolID(fVolumeID);
+    Int_t detID = fVolumeID;
     //gGeoManager->PrintOverlaps();
 	
     //cout<< "detID = " << detID << endl;

--- a/nutaudet/TargetTracker.cxx
+++ b/nutaudet/TargetTracker.cxx
@@ -194,14 +194,7 @@ Bool_t TargetTracker::ProcessHits(FairVolume* vol)
         gMC->IsTrackDisappeared()   ) {
         fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
         //Int_t fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
-        fVolumeID = vol->getMCid();
-	Int_t detID=0;
-	gMC->CurrentVolID(detID);
-
-	if (fVolumeID == detID) {
-	  return kTRUE; }
-	fVolumeID = detID;
-
+        gMC->CurrentVolID(fVolumeID);
 	//gGeoManager->PrintOverlaps();
 	
 	//cout<< "detID = " << detID << endl;
@@ -214,7 +207,6 @@ Bool_t TargetTracker::ProcessHits(FairVolume* vol)
 	
 	Double_t zEnd = 0, zStart =0;
 
-	fVolumeID = detID;
 	
 	if (fELoss == 0. ) { return kFALSE; }
         TParticle* p=gMC->GetStack()->GetCurrentTrack();


### PR DESCRIPTION
Check of identity between VolumeID and DetID makes ProcessHits exit prematurely, reason of check unknown.