### PR TITLE
Place tShield in origin of SHiP coordinate frame explicitly

### DIFF
--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -826,9 +826,8 @@ void ShipMuonShield::ConstructGeometry()
       Double_t dX1 = dXIn[0];
       Double_t dY = dYIn[0];
 
-      TGeoShapeAssembly* asmbShield = dynamic_cast<TGeoShapeAssembly*>(tShield->GetShape());
-      Double_t totLength = asmbShield->GetDZ();
-      top->AddNode(tShield, 1, new TGeoTranslation(0, 0, totLength));
+      // Place in origin of SHiP coordinate system as subnodes placed correctly
+      top->AddNode(tShield, 1);
 
 // Concrete around first magnets. i.e. Tunnel
       Double_t dZ = dZ1 + dZ2;


### PR DESCRIPTION
Previously due to a bug this was the case anyway (`totLength == 0.0`), but now this is done explicitly.

I guess one could modify all positioning to be relative to the centre of the `MuonShieldArea`, but this will be a bit more work.