### PR TITLE
Implement RPC endpoints

### DIFF
--- a/charmdet/MuonTaggerHit.cxx
+++ b/charmdet/MuonTaggerHit.cxx
@@ -2,4 +2,39 @@
 
 MuonTaggerHit::MuonTaggerHit(Int_t detID, Float_t digi) : ShipHit(detID, digi) {}
 
+enum Direction { horizontal = 0, vertical = 1 };
+
+void MuonTaggerHit::EndPoints(TVector3 &vbot, TVector3 &vtop)
+{
+   // Detector ID scheme:
+   // 10000 * station + 1000 * direction + strip;
+   // sets vbot and vtop to opposing corners of the cuboid
+   int station = fDetectorID / 10000;
+   Direction direction = static_cast<Direction>((fDetectorID % 10000) / 1000);
+   int strip = fDetectorID % 1000;
+   const float STRIP_XWIDTH = 0.8625; // internal STRIP V, WIDTH, in cm
+   const float EXT_STRIP_XWIDTH_L =
+      0.9625; // nominal (R&L) and Left measured external STRIP V, WIDTH, in cm (beam along z, out from the V plane)
+   const float EXT_STRIP_XWIDTH_R =
+      0.86; // measured Right external STRIP V, WIDTH, in cm (beam along z, out from the V plane)
+   const float STRIP_YWIDTH = 0.8625;  // internal STRIP H, WIDTH, in cm
+   const float EXT_STRIP_YWIDTH = 0.3; // measured external STRIP H, WIDTH, in cm (nominal 0.4375)
+   /* gGeoManager-> */                 // Get Z position
+   const float total_width = 182 * STRIP_XWIDTH + EXT_STRIP_XWIDTH_L + EXT_STRIP_XWIDTH_R;
+   const float total_height = 114 * STRIP_YWIDTH + 2 * EXT_STRIP_YWIDTH;
+   const float x_start = -(total_width - EXT_STRIP_XWIDTH_R + EXT_STRIP_XWIDTH_L) / 2;
+   const float y_start = total_height / 2;
+   const float Z = 0; //TODO
+   switch (direction) {
+   case horizontal:
+      vbot.SetXYZ(x_start, y_start, Z); // TODO
+      vtop.SetXYZ(x_start + total_width, y_start, Z); // TODO
+      break;
+   case vertical:
+      vbot.SetXYZ(x_start , y_start - total_height, Z); // TODO
+      vtop.SetXYZ(x_start , y_start, Z); // TODO
+      break;
+   }
+}
+
 ClassImp(MuonTaggerHit)

--- a/charmdet/MuonTaggerHit.cxx
+++ b/charmdet/MuonTaggerHit.cxx
@@ -1,4 +1,5 @@
 #include "MuonTaggerHit.h"
+#include <iostream>
 
 MuonTaggerHit::MuonTaggerHit(Int_t detID, Float_t digi) : ShipHit(detID, digi) {}
 
@@ -24,17 +25,50 @@ void MuonTaggerHit::EndPoints(TVector3 &vbot, TVector3 &vtop)
    const float total_height = 114 * STRIP_YWIDTH + 2 * EXT_STRIP_YWIDTH;
    const float x_start = -(total_width - EXT_STRIP_XWIDTH_R + EXT_STRIP_XWIDTH_L) / 2;
    const float y_start = total_height / 2;
-   const float Z = 0; //TODO
-   switch (direction) {
-   case horizontal:
-      vbot.SetXYZ(x_start, y_start, Z); // TODO
-      vtop.SetXYZ(x_start + total_width, y_start, Z); // TODO
-      break;
-   case vertical:
-      vbot.SetXYZ(x_start , y_start - total_height, Z); // TODO
-      vtop.SetXYZ(x_start , y_start, Z); // TODO
-      break;
-   }
+   float Z = 0;
+    ///station conditions - remove once z position automated from geo file
+    if(station == 1){Z = 874.25;};
+    if(station == 2){Z = 959.25;};
+    if(station == 3){Z = 1004.25;};
+    if(station == 4){Z = 1049.25;};
+    if(station == 5){Z = 1094.25;};
+    if(station > 5){
+	std::cout << "Invalid station" << std::endl;
+
+        }
+
+
+    switch (direction) {
+    case horizontal:
+            if(strip == 1){ //1st strip (top)
+                vtop.SetXYZ(x_start, y_start, Z);
+                vbot.SetXYZ(x_start + total_width, y_start - EXT_STRIP_YWIDTH, Z);
+            }
+
+            if(strip == 116){ //last strip (bottom)
+                vtop.SetXYZ(x_start, y_start - EXT_STRIP_YWIDTH - 114*STRIP_YWIDTH, Z);
+                vbot.SetXYZ(x_start + total_width, y_start - total_height, Z);
+            }
+            else{ //all other horizontal strips
+                vtop.SetXYZ(x_start, y_start - EXT_STRIP_YWIDTH - (strip-2)*STRIP_YWIDTH, Z);
+                vbot.SetXYZ(x_start + total_width, y_start - EXT_STRIP_YWIDTH - (strip-1)*STRIP_YWIDTH, Z);
+            }
+        break;
+    case  vertical:
+            if(strip == 1){//first strip (left)
+                vtop.SetXYZ(x_start, y_start - total_height, Z);
+                vbot.SetXYZ(x_start + EXT_STRIP_XWIDTH_L, y_start, Z);
+            }
+            if(strip == 184){ //last strip (right)
+                vtop.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + 182*STRIP_XWIDTH, y_start - total_height, Z);
+                vbot.SetXYZ(x_start + total_width, y_start, Z);
+            }
+            else{ //all other vertical strips
+                vtop.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + (strip-2)*STRIP_XWIDTH, y_start - total_height, Z);
+                vbot.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + (strip-1)*STRIP_XWIDTH, y_start, Z);
+            }
+        break;
+    }
 }
 
 ClassImp(MuonTaggerHit)

--- a/charmdet/MuonTaggerHit.cxx
+++ b/charmdet/MuonTaggerHit.cxx
@@ -26,49 +26,42 @@ void MuonTaggerHit::EndPoints(TVector3 &vbot, TVector3 &vtop)
    const float x_start = -(total_width - EXT_STRIP_XWIDTH_R + EXT_STRIP_XWIDTH_L) / 2;
    const float y_start = total_height / 2;
    float Z = 0;
-    ///station conditions - remove once z position automated from geo file
-    if(station == 1){Z = 874.25;};
-    if(station == 2){Z = 959.25;};
-    if(station == 3){Z = 1004.25;};
-    if(station == 4){Z = 1049.25;};
-    if(station == 5){Z = 1094.25;};
-    if(station > 5){
-	std::cout << "Invalid station" << std::endl;
+   /// station conditions - remove once z position automated from geo file
+   switch (station) {
+   case 1: Z = 874.25; break;
+   case 2: Z = 959.25; break;
+   case 3: Z = 1004.25; break;
+   case 4: Z = 1049.25; break;
+   case 5: Z = 1094.25; break;
+   default: std::cout << "Invalid station" << std::endl;
+   };
 
-        }
-
-
-    switch (direction) {
-    case horizontal:
-            if(strip == 1){ //1st strip (top)
-                vtop.SetXYZ(x_start, y_start, Z);
-                vbot.SetXYZ(x_start + total_width, y_start - EXT_STRIP_YWIDTH, Z);
-            }
-
-            if(strip == 116){ //last strip (bottom)
-                vtop.SetXYZ(x_start, y_start - EXT_STRIP_YWIDTH - 114*STRIP_YWIDTH, Z);
-                vbot.SetXYZ(x_start + total_width, y_start - total_height, Z);
-            }
-            else{ //all other horizontal strips
-                vtop.SetXYZ(x_start, y_start - EXT_STRIP_YWIDTH - (strip-2)*STRIP_YWIDTH, Z);
-                vbot.SetXYZ(x_start + total_width, y_start - EXT_STRIP_YWIDTH - (strip-1)*STRIP_YWIDTH, Z);
-            }
-        break;
-    case  vertical:
-            if(strip == 1){//first strip (left)
-                vtop.SetXYZ(x_start, y_start - total_height, Z);
-                vbot.SetXYZ(x_start + EXT_STRIP_XWIDTH_L, y_start, Z);
-            }
-            if(strip == 184){ //last strip (right)
-                vtop.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + 182*STRIP_XWIDTH, y_start - total_height, Z);
-                vbot.SetXYZ(x_start + total_width, y_start, Z);
-            }
-            else{ //all other vertical strips
-                vtop.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + (strip-2)*STRIP_XWIDTH, y_start - total_height, Z);
-                vbot.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + (strip-1)*STRIP_XWIDTH, y_start, Z);
-            }
-        break;
-    }
+   switch (direction) {
+   case horizontal:
+      if (strip == 1) { // 1st strip (top)
+         vtop.SetXYZ(x_start, y_start, Z);
+         vbot.SetXYZ(x_start + total_width, y_start - EXT_STRIP_YWIDTH, Z);
+      } else if (strip == 116) { // last strip (bottom)
+         vtop.SetXYZ(x_start, y_start - EXT_STRIP_YWIDTH - 114 * STRIP_YWIDTH, Z);
+         vbot.SetXYZ(x_start + total_width, y_start - total_height, Z);
+      } else { // all other horizontal strips
+         vtop.SetXYZ(x_start, y_start - EXT_STRIP_YWIDTH - (strip - 2) * STRIP_YWIDTH, Z);
+         vbot.SetXYZ(x_start + total_width, y_start - EXT_STRIP_YWIDTH - (strip - 1) * STRIP_YWIDTH, Z);
+      }
+      break;
+   case vertical:
+      if (strip == 1) { // first strip (left)
+         vtop.SetXYZ(x_start, y_start - total_height, Z);
+         vbot.SetXYZ(x_start + EXT_STRIP_XWIDTH_L, y_start, Z);
+      } else if (strip == 184) { // last strip (right)
+         vtop.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + 182 * STRIP_XWIDTH, y_start - total_height, Z);
+         vbot.SetXYZ(x_start + total_width, y_start, Z);
+      } else { // all other vertical strips
+         vtop.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + (strip - 2) * STRIP_XWIDTH, y_start - total_height, Z);
+         vbot.SetXYZ(x_start + EXT_STRIP_XWIDTH_L + (strip - 1) * STRIP_XWIDTH, y_start, Z);
+      }
+      break;
+   }
 }
 
 ClassImp(MuonTaggerHit)

--- a/charmdet/MuonTaggerHit.h
+++ b/charmdet/MuonTaggerHit.h
@@ -8,6 +8,7 @@ public:
    MuonTaggerHit() : ShipHit() {}
    ~MuonTaggerHit() = default;
    MuonTaggerHit(Int_t detID, Float_t digi);
+   void EndPoints(TVector3 &vbot, TVector3 &vtop);
 
 private:
     MuonTaggerHit(const MuonTaggerHit& other); 


### PR DESCRIPTION
Add method to `MuonTaggerHit` to lookup strip endpoints.

Currently z positions are hard-coded, but plan to look them up in the geometry in future.

We will try changing `drifttubeMonitoring.py` to make use of it.

@hushchyn-mikhail Could you test this and let us know whether it works for the pattern recognition?