### PR TITLE
Fix option parsing

### DIFF
--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -41,18 +41,18 @@ try:
            ["ecalDebugDraw","inputFile=","geoFile=","nEvents=","noStrawSmearing","noVertexing","saveDisk","realPR","withT0", "withNTaggerHits=", "withDist2Wire"])
 except getopt.GetoptError:
         # print help information and exit:
-        print ' enter --inputFile=  --geoFile= --nEvents=  --firstEvent=,' 
-        print ' noStrawSmearing: no smearing of distance to wire, default on' 
-        print ' outputfile will have same name with _rec added'   
+        print ' enter --inputFile=  --geoFile= --nEvents=  --firstEvent=,'
+        print ' noStrawSmearing: no smearing of distance to wire, default on'
+        print ' outputfile will have same name with _rec added'
         sys.exit()
 for o, a in opts:
-        if o in ("noVertexing"):
+        if o in ("--noVertexing",):
             vertexing = False
-        if o in ("noStrawSmearing"):
+        if o in ("--noStrawSmearing",):
             withNoStrawSmearing = True
-        if o in ("--withT0"):
+        if o in ("--withT0",):
             withT0 = True
-        if o in ("--withDist2Wire"):
+        if o in ("--withDist2Wire",):
             withDist2Wire = True
         if o in ("-t", "--withNTaggerHits"):
             withNTaggerHits = int(a)
@@ -62,13 +62,13 @@ for o, a in opts:
             geoFile = a
         if o in ("-n", "--nEvents="):
             nEvents = int(a)
-        if o in ("-Y"): 
+        if o in ("-Y",):
             dy = float(a)
-        if o in ("--ecalDebugDraw"):
+        if o in ("--ecalDebugDraw",):
             EcalDebugDraw = True
-        if o in ("--saveDisk"):
+        if o in ("--saveDisk",):
             saveDisk = True
-	if o in ("--realPR"):
+        if o in ("--realPR",):
             realPR = "_PR"
 
 

--- a/macro/getGeoInformation.py
+++ b/macro/getGeoInformation.py
@@ -3,8 +3,8 @@
 #WARNING: printing the entire geometry takes a lot of time
 #24-02-2015 comments to EvH
 
-import operator, sys, getopt
-from optparse import OptionParser
+import operator, sys
+from argparse import ArgumentParser
 from array import array
 import os,ROOT
 
@@ -89,18 +89,17 @@ def print_info(path, node, level, currentlevel, print_sub_det_info=False):
       print_sub_det_info = False
 
 
-from optparse import OptionParser
-parser = OptionParser()
-parser.add_option("-g","--geometry", dest="geometry", help="input geometry file",
-                  default='$FAIRSHIP/geofile_full.10.0.Pythia8-TGeant4.root')
-parser.add_option("-l","--level", dest="level", help="max subnode level", default=0)
-parser.add_option("-v","--volume", dest="volume", help="name of volume to expand",default="")
-parser.add_option("-X","--moreInfo", dest="moreInfo", help="print weight and capacity",default=False)
+parser = ArgumentParser()
+parser.add_argument("-g", "--geometry", dest="geometry", help="input geometry file",
+                    required=True)
+parser.add_argument("-l", "--level", dest="level", help="max subnode level", default=0)
+parser.add_argument("-v", "--volume", dest="volume", help="name of volume to expand", default="")
+parser.add_argument("-X", "--moreInfo", dest="moreInfo", help="print weight and capacity", default=False)
 
-(options, args) = parser.parse_args()
+options = parser.parse_args()
 fname = options.geometry
-if not fname.find('eos') < 0: 
-  fname = os.environ['EOSSHIP'] + fname
+if fname.startswith('/eos/'):
+    fname = os.environ['EOSSHIP'] + fname
 fgeom = ROOT.TFile.Open(fname)
 fGeo = fgeom.FAIRGeom
 top = fGeo.GetTopVolume()


### PR DESCRIPTION
These commits fix option parsing in `MufluxReco.py` and `getGeoInformation`:

- In `MufluxReco.py` there were commata missing, causing ambiguous parsing and surprising behaviour when using some of the short options (e.g. `-t`).
- In `getGeoInformation.py` `getopt` was included but unused, using instead the deprecated `optparse`, which has been `deprecated` in favour of `argparse`. Migrating to `argparse` luckily is *very* straightforward. The `-g/--geometry` argument is now mandatory (the default geometry file is not usually created since we now default to `geofile_full.conical.[...].root`).
- Also, reading of files on `EOS` has been fixed: previously one *had* to omit `root://eospublic.cern.ch` for it to work.