### PR TITLE
Fix bug in TimeDetHit::Dist

### DIFF
--- a/TimeDet/TimeDetHit.cxx
+++ b/TimeDet/TimeDetHit.cxx
@@ -9,7 +9,7 @@
 #include "TGeoNode.h"
 
 #include <iostream>
-#include <math.h>
+#include <cmath>
 
 using std::cout;
 using std::endl;
@@ -88,9 +88,9 @@ std::vector<double> TimeDetHit::GetMeasurements(){
 }
 
 // distance to edges
-void TimeDetHit::Dist(Float_t x, Float_t lpos, Float_t lneg){
+void TimeDetHit::Dist(Float_t x, Float_t& lpos, Float_t& lneg){
      TGeoNode* node  = GetNode();
-     TGeoBBox* shape =  (TGeoBBox*)node->GetVolume()->GetShape();
+     auto shape =  dynamic_cast<TGeoBBox*>(node->GetVolume()->GetShape());
      TVector3 pos    = GetXYZ();
      lpos = TMath::Abs( pos.X() + shape->GetDX() - x );
      lneg = TMath::Abs( pos.X() - shape->GetDX() - x );
@@ -100,7 +100,7 @@ TVector3 TimeDetHit::GetXYZ()
 {
     TGeoNavigator* nav = gGeoManager->GetCurrentNavigator();
     TGeoNode* node = GetNode();
-    TGeoBBox* shape =  (TGeoBBox*)node->GetVolume()->GetShape();
+    auto shape =  dynamic_cast<TGeoBBox*>(node->GetVolume()->GetShape());
     Double_t origin[3] = {shape->GetOrigin()[0],shape->GetOrigin()[1],shape->GetOrigin()[2]};
     Double_t master[3] = {0,0,0};
     nav->LocalToMaster(origin,master);

--- a/TimeDet/TimeDetHit.h
+++ b/TimeDet/TimeDetHit.h
@@ -40,7 +40,7 @@ class TimeDetHit : public ShipHit
     /** Output to screen **/
     virtual void Print() const;
 
-    void Dist(Float_t x, Float_t lpos, Float_t lneg);
+    void Dist(Float_t x, Float_t& lpos, Float_t& lneg);
     Double_t Resol(Double_t x);
     void setInvalid() {flag = false;}
     void setIsValid() {flag = true;}


### PR DESCRIPTION
`Dist` needs to get references (or pointers) as arguments, so that it can return values. Previously it was essentially a no-op.

It is used in several methods used in the reconstruction.

Fix some casts as well.