### PR TITLE
expose x y z drifttube translations to python

### DIFF
--- a/charmdet/MufluxSpectrometer.cxx
+++ b/charmdet/MufluxSpectrometer.cxx
@@ -256,6 +256,28 @@ void MufluxSpectrometer::SetTStationsZ(Double_t T1z, Double_t T2z, Double_t T3z,
       fT4z=T4z;
 }
 
+void MufluxSpectrometer::SetTStationsX(Double_t T1x_x, Double_t T1u_x, Double_t T2x_x, Double_t T2v_x, Double_t T3x, Double_t T4x)
+{
+      fT1x_x=T1x_x;
+      fT1u_x=T1u_x;
+      fT2x_x=T2x_x;
+      fT2v_x=T2v_x;
+      fT3x=T3x;
+      fT4x=T4x;
+}
+
+void MufluxSpectrometer::SetTStationsY(Double_t T1x_y, Double_t T1u_y, Double_t T2x_y, Double_t T2v_y, Double_t T3y, Double_t T4y)
+{
+      fT1x_y=T1x_y;
+      fT1u_y=T1u_y;
+      fT2x_y=T2x_y;
+      fT2v_y=T2v_y;
+      fT3y=T3y;
+      fT4y=T4y;
+}
+
+
+
 void MufluxSpectrometer::ConstructGeometry()
 { 
   gGeoManager->SetVisLevel(4);
@@ -429,16 +451,16 @@ void MufluxSpectrometer::ConstructGeometry()
 				
 	//z-translate the viewframe from station z pos
 	if (angle==0.) {
-	    t5.SetTranslation(-fTubes_pitch/2., ftr12ydim/2.+eps+plate_thickness/2.+0.5*cm,(vnb-1)*fDeltaz_view);
-	    t6.SetTranslation(-fTubes_pitch/2., -ftr12ydim/2.-eps-plate_thickness/2.-0.5*cm,(vnb-1)*fDeltaz_view);
-	    t5b.SetTranslation(-fTubes_pitch/2., ftr12ydim/2.+eps+plate_thickness/2.+0.5*cm,(vnb-1)*fDeltaz_view+fdiststereo);
-	    t6b.SetTranslation(-fTubes_pitch/2., -ftr12ydim/2.-eps-plate_thickness/2.-0.5*cm,(vnb-1)*fDeltaz_view+fdiststereo);   
+	    t5.SetTranslation(fT1x_x-fTubes_pitch/2.,fT1x_y+ftr12ydim/2.+eps+plate_thickness/2.+0.5*cm,(vnb-1)*fDeltaz_view);
+	    t6.SetTranslation(fT1x_x-fTubes_pitch/2., fT1x_y-ftr12ydim/2.-eps-plate_thickness/2.-0.5*cm,(vnb-1)*fDeltaz_view);
+	    t5b.SetTranslation(fT2x_x-fTubes_pitch/2., fT2x_y+ftr12ydim/2.+eps+plate_thickness/2.+0.5*cm,(vnb-1)*fDeltaz_view+fdiststereo);
+	    t6b.SetTranslation(fT2x_x-fTubes_pitch/2., fT2x_y-ftr12ydim/2.-eps-plate_thickness/2.-0.5*cm,(vnb-1)*fDeltaz_view+fdiststereo);   
 	}
         else {
-            t5.SetTranslation(-(ftr12ydim/2.+eps+plate_thickness/2+fTubes_pitch)*sin(TMath::Pi()*abs(angle)/180.),(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),fDeltaz_view+fTubes_pitch/4.);
-	    t6.SetTranslation((ftr12ydim/2.+eps+plate_thickness/2)*sin(TMath::Pi()*abs(angle)/180.),-(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),fDeltaz_view+fTubes_pitch/4.);
-	    t5b.SetTranslation((ftr12ydim/2.+eps+plate_thickness/2)*sin(TMath::Pi()*abs(angle)/180.),(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),(vnb-1)*fDeltaz_view);
-	    t6b.SetTranslation(-(ftr12ydim/2.+eps+plate_thickness/2)*sin(TMath::Pi()*abs(angle)/180.),-(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),(vnb-1)*fDeltaz_view);	     	    	    	    	    
+            t5.SetTranslation(fT1u_x-(ftr12ydim/2.+eps+plate_thickness/2+fTubes_pitch)*sin(TMath::Pi()*abs(angle)/180.),fT1u_y+(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),fDeltaz_view+fTubes_pitch/4.);
+	    t6.SetTranslation(fT1u_x+(ftr12ydim/2.+eps+plate_thickness/2)*sin(TMath::Pi()*abs(angle)/180.),fT1u_y-(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),fDeltaz_view+fTubes_pitch/4.);
+	    t5b.SetTranslation(fT2v_x+(ftr12ydim/2.+eps+plate_thickness/2)*sin(TMath::Pi()*abs(angle)/180.),fT2v_y+(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),(vnb-1)*fDeltaz_view);
+	    t6b.SetTranslation(fT2v_x-(ftr12ydim/2.+eps+plate_thickness/2)*sin(TMath::Pi()*abs(angle)/180.),fT2v_y-(ftr12ydim/2.+eps+plate_thickness/2)*cos(TMath::Pi()*abs(angle)/180.),(vnb-1)*fDeltaz_view);	     	    	    	    	    
 	}
 	TGeoCombiTrans c5(t5, r5);
         TGeoHMatrix *h5 = new TGeoHMatrix(c5);	
@@ -471,18 +493,18 @@ void MufluxSpectrometer::ConstructGeometry()
           TGeoTranslation t3;
 	  if (statnb==1){
 	    if (angle==0.){
-               t3.SetTranslation(0, 0,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12);	
+               t3.SetTranslation(fT1x_x, fT1x_y,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12);	
 	    }
 	    else {
-	       t3.SetTranslation(0, 0,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12+fdiststereo);	
+	       t3.SetTranslation(fT1u_x, fT1u_y,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12+fdiststereo);	
 	    }  
 	  }
 	  if (statnb==2){   
 	    if (angle==0.){
-               t3.SetTranslation(0, 0,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12+fdiststereo);	
+               t3.SetTranslation(fT2x_x, fT2x_y,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12+fdiststereo);	
 	    }
 	    else {
-	       t3.SetTranslation(0, 0,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12);	
+	       t3.SetTranslation(fT2v_x, fT2v_y,(vnb-1.)*(fDeltaz_view)+(pnb-1./2.)*fDeltaz_plane12);	
 	    } 	  	  	  
 	  }
 	    
@@ -825,7 +847,7 @@ void MufluxSpectrometer::ConstructGeometry()
         if (statnb==3) {
           volDriftTube3->SetVisibility(kFALSE);
 	  //move drifttubes up so they cover the Goliath aperture, not centered on the beam
-	  top->AddNode(volDriftTube3,3,new TGeoTranslation(0,fgoliathcentre_to_beam,fT3z));
+	  top->AddNode(volDriftTube3,3,new TGeoTranslation(fT3x,fT3y+fgoliathcentre_to_beam,fT3z));
           nmview_34 = "Station_3_x";
 	  nmview_top_34="Station_3_top_x";
 	  nmview_bot_34="Station_3_bot_x";	 
@@ -834,7 +856,7 @@ void MufluxSpectrometer::ConstructGeometry()
         if (statnb==4) {
           volDriftTube4->SetVisibility(kFALSE);     
 	  //move drifttubes up so they cover the Goliath aperture, not centered on the beam
-	  top->AddNode(volDriftTube4,4,new TGeoTranslation(0,fgoliathcentre_to_beam,fT4z));
+	  top->AddNode(volDriftTube4,4,new TGeoTranslation(fT4x,fT4y+fgoliathcentre_to_beam,fT4z));
           nmview_34 = "Station_4_x";
 	  nmview_top_34="Station_4_top_x";
 	  nmview_bot_34="Station_4_bot_x";		  	  	  

--- a/charmdet/MufluxSpectrometer.h
+++ b/charmdet/MufluxSpectrometer.h
@@ -54,7 +54,9 @@ class MufluxSpectrometer:public FairDetector
     void SetscintillatorPlasticThickness(Double_t scintillatorPlasticThickness);
     void SetGoliathCentre(Double_t goliathcentre_to_beam);
     void SetTStationsZ(Double_t T1z, Double_t T2z, Double_t T3z, Double_t T4z);
-
+    void SetTStationsX(Double_t T1x_x, Double_t T1u_x, Double_t T2x_x, Double_t T2v_x, Double_t T3x, Double_t T4x);
+    void SetTStationsY(Double_t T1x_y, Double_t T1u_y, Double_t T2x_y, Double_t T2v_y, Double_t T3y, Double_t T4y);    
+    
 // for the digitizing step
     void SetTubeResolution(Double_t a, Double_t b) {v_drift = a; sigma_spatial=b;}
     Double_t TubeVdrift() {return v_drift;}
@@ -153,8 +155,21 @@ private:
     Double_t       fgoliathcentre_to_beam;
     Double_t       fT1z;
     Double_t       fT2z;
+    Double_t       fT1x_x;
+    Double_t       fT2x_x;
+    Double_t       fT1u_x;
+    Double_t       fT2v_x;
+    Double_t       fT1x_y;
+    Double_t       fT2x_y;
+    Double_t       fT1u_y;
+    Double_t       fT2v_y;
     Double_t       fT3z;
-    Double_t       fT4z;    
+    Double_t       fT4z;  
+    Double_t       fT3x;
+    Double_t       fT4x;  
+    Double_t       fT3y;
+    Double_t       fT4y;    
+    
     /** container for data points */
     TClonesArray*  fMufluxSpectrometerPointCollection;
     

--- a/charmdet/Scintillator.cxx
+++ b/charmdet/Scintillator.cxx
@@ -127,6 +127,21 @@ void Scintillator::SetDistT2(Float_t DistT2)
 {
      fDistT2 = DistT2;    //! distance from scintillator 2 to center of last tube
 }
+
+void Scintillator::SetS_T1coords(Float_t S_T1_x, Float_t S_T1_y)
+{
+     fS_T1_x = S_T1_x;    //! x origin of S_T1
+     fS_T1_y = S_T1_y;    //! y origin of S_T1
+}
+
+void Scintillator::SetS_T2coords(Float_t S_T2_x, Float_t S_T2_y)
+{
+     fS_T2_x = S_T2_x;    //! x origin of S_T2
+     fS_T2_y = S_T2_y;    //! y origin of S_T2     
+}
+
+
+
 //
 void Scintillator::ConstructGeometry()
 { 

--- a/charmdet/Scintillator.h
+++ b/charmdet/Scintillator.h
@@ -28,6 +28,8 @@ class Scintillator:public FairDetector
     
     void SetDistT1(Float_t DistT1);
     void SetDistT2(Float_t DistT2);
+    void SetS_T1coords(Float_t S_T1_x, Float_t S_T1_y);   
+    void SetS_T2coords(Float_t S_T2_x, Float_t S_T2_y);     
     
     //
     /**      Initialization of the detector is done here    */
@@ -90,7 +92,11 @@ private:
     Float_t     fScoring1Y;            //height of 1st scintillator
     Float_t     fDistT1;            //distance from scintillator to center of first tube   
     Float_t     fDistT2;            //distance from scintillator 2 to center of last tube   
-     
+    Float_t     fS_T1_x;            //
+    Float_t     fS_T1_y;            //  
+    Float_t     fS_T2_x;            //
+    Float_t     fS_T2_y;            //      
+       
     /** container for data points */
     TClonesArray*  fScintillatorPointCollection;
     

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -173,8 +173,8 @@ with ConfigRegistry.register_config("basic") as c:
     c.MufluxSpectrometer.sigma_spatial = 0.027*u.cm # from Daniel 8feb2018
     
     c.MufluxSpectrometer.TubeLength         = 160.*u.cm
-    c.MufluxSpectrometer.TubeLength12       = 100.*u.cm    
-    c.MufluxSpectrometer.tr12ydim           = 100.*u.cm
+    c.MufluxSpectrometer.TubeLength12       = 110.*u.cm    
+    c.MufluxSpectrometer.tr12ydim           = 110.*u.cm
     c.MufluxSpectrometer.tr34xdim           = 200.*u.cm
     c.MufluxSpectrometer.tr12xdim           = 50.*u.cm
     c.MufluxSpectrometer.tr34ydim           = 160.*u.cm
@@ -193,7 +193,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.MufluxSpectrometer.WireThickness      = 0.0045*u.cm
     c.MufluxSpectrometer.DeltazView         = 15.*u.cm
     
-    c.MufluxSpectrometer.diststereo         = 16.25*u.cm  
+    c.MufluxSpectrometer.diststereo         = 16.25*u.cm    
     c.MufluxSpectrometer.distT1T2           = 11.*u.cm   
     if c.MufluxSpectrometer.muflux == True:
        c.MufluxSpectrometer.distT3T4           = 1.6*u.m       
@@ -201,10 +201,25 @@ with ConfigRegistry.register_config("basic") as c:
        c.MufluxSpectrometer.distT3T4 = 1.0*u.m   
             
     c.MufluxSpectrometer.goliathcentre_to_beam = 178.6*u.mm
-    c.MufluxSpectrometer.T1z=38.875 *u.cm
-    c.MufluxSpectrometer.T2z=107.625*u.cm
-    c.MufluxSpectrometer.T3z=584.25*u.cm
-    c.MufluxSpectrometer.T4z=747.25*u.cm       
+   
+    c.MufluxSpectrometer.T1x_x=4.2*u.cm
+    c.MufluxSpectrometer.T1x_y=-1.995*u.cm
+    c.MufluxSpectrometer.T1z=38.875*u.cm
+    c.MufluxSpectrometer.T1u_x=7.79*u.cm
+    c.MufluxSpectrometer.T1u_y=0.182*u.cm
+    c.MufluxSpectrometer.T2x_x=2.61*u.cm
+    c.MufluxSpectrometer.T2x_y=-2.1875*u.cm  
+    c.MufluxSpectrometer.T2z=107.625*u.cm       
+    c.MufluxSpectrometer.T2v_x=3.4804*u.cm  
+    c.MufluxSpectrometer.T2v_y=-0.5*u.cm       
+    c.MufluxSpectrometer.T3x=2.6*u.cm
+    c.MufluxSpectrometer.T3y=-7.3405*u.cm
+    c.MufluxSpectrometer.T3z=586.25*u.cm
+    c.MufluxSpectrometer.T4x=2.95*u.cm   
+    c.MufluxSpectrometer.T4y=-6.9845*u.cm 
+    c.MufluxSpectrometer.T4z=747.25*u.cm               
+
+     
     
     if c.MufluxSpectrometer.muflux == True:    
        c.Spectrometer.DX = 2.*u.m

--- a/passive/MufluxTargetStation.cxx
+++ b/passive/MufluxTargetStation.cxx
@@ -270,8 +270,8 @@ void MufluxTargetStation::ConstructGeometry()
     //TGeoNode *node = GetNode("Absorber");    
     //tTarget->ReplaceNode(node,new TGeoTube(1.,2.,10.),new TGeoTranslation(0,-100.2,12),iron); //
         
-    tTarget->AddNode(floor, 7, new TGeoTranslation(0., -210., 500.)); 
-    tTarget->AddNode(floorT34, 8, new TGeoTranslation(0., -112.5, fAbsorberZ-zPos+771.125)); 
+    tTarget->AddNode(floor, 7, new TGeoTranslation(0., -217., 500.)); 
+    tTarget->AddNode(floorT34, 8, new TGeoTranslation(0., -120., fAbsorberZ-zPos+771.125)); 
     tTarget->AddNode(floorRPC, 9, new TGeoTranslation(0., -97, fAbsorberZ-zPos+1000.));
     
     TGeoShapeAssembly* asmb = dynamic_cast<TGeoShapeAssembly*>(tTarget->GetShape());

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -87,6 +87,8 @@ def configure(run,ship_geo):
  MufluxSpectrometer.SetDistT3T4(ship_geo.MufluxSpectrometer.distT3T4)    
  MufluxSpectrometer.SetGoliathCentre(ship_geo.MufluxSpectrometer.goliathcentre_to_beam)
  MufluxSpectrometer.SetTStationsZ(ship_geo.MufluxSpectrometer.T1z,ship_geo.MufluxSpectrometer.T2z,ship_geo.MufluxSpectrometer.T3z,ship_geo.MufluxSpectrometer.T4z) 
+ MufluxSpectrometer.SetTStationsX(ship_geo.MufluxSpectrometer.T1x_x,ship_geo.MufluxSpectrometer.T1u_x,ship_geo.MufluxSpectrometer.T2x_x,ship_geo.MufluxSpectrometer.T2v_x,ship_geo.MufluxSpectrometer.T3x,ship_geo.MufluxSpectrometer.T4x) 
+ MufluxSpectrometer.SetTStationsY(ship_geo.MufluxSpectrometer.T1x_y,ship_geo.MufluxSpectrometer.T1u_y,ship_geo.MufluxSpectrometer.T2x_y,ship_geo.MufluxSpectrometer.T2v_y,ship_geo.MufluxSpectrometer.T3y,ship_geo.MufluxSpectrometer.T4y) 
        
  # for the digitizing step
  MufluxSpectrometer.SetTubeResolution(ship_geo.MufluxSpectrometer.v_drift,ship_geo.MufluxSpectrometer.sigma_spatial) 
@@ -95,7 +97,9 @@ def configure(run,ship_geo):
  Scintillator.SetScoring1XY(ship_geo.MufluxSpectrometer.tr12xdim,ship_geo.MufluxSpectrometer.tr12ydim)
  Scintillator.SetDistT1(ship_geo.Scintillator.DistT1)
  Scintillator.SetDistT2(ship_geo.Scintillator.DistT2) 
- 
+ Scintillator.SetS_T1coords(ship_geo.MufluxSpectrometer.T1x_x,ship_geo.MufluxSpectrometer.T1x_y) 
+ Scintillator.SetS_T2coords(ship_geo.MufluxSpectrometer.T2x_x,ship_geo.MufluxSpectrometer.T2x_y)  
+  
  if (ship_geo.MufluxSpectrometer.muflux==False): 
     detectorList.append(Spectrometer)
     detectorList.append(MufluxSpectrometer)


### PR DESCRIPTION
I exposed the x y z origin translations of the drifttubes to python. the charm_geometry_config.py file contains the values that give the closest possible positions of the drifttubes to those measured by the survey.