### PR TITLE
Don't write to 'dummy' files, just write to memory

### DIFF
--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -423,7 +423,7 @@ ShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py")
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine
-run.SetOutputFile("dummy")  # Output file
+run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))  # Output file
 run.SetUserConfig("g4Config_basic.C") # geant4 transport not used, only needed for creating VMC field
 rtdb = run.GetRuntimeDb()
 modules = charmDet_conf.configure(run,ShipGeo)

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -322,7 +322,7 @@ if withHists:
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine
-run.SetOutputFile("dummy")  # Output file
+run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))  # Output file
 run.SetUserConfig("g4Config_basic.C") # geant4 transport not used, only needed for creating VMC field
 rtdb = run.GetRuntimeDb()
 modules = charmDet_conf.configure(run,ShipGeo)

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -68,7 +68,7 @@ dy = ShipGeo.Yheight/u.m
 import shipDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine
-run.SetOutputFile("dummy")  # Output file
+run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))  # Output file
 run.SetUserConfig("g4Config_basic.C") # geant4 transport not used, only needed for the mag field
 rtdb = run.GetRuntimeDb()
 # -----Create geometry----------------------------------------------

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -120,7 +120,7 @@ if withHists:
 import shipDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine
-run.SetOutputFile("dummy")  # Output file
+run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))  # Output file
 run.SetUserConfig("g4Config_basic.C") # geant4 transport not used, only needed for creating VMC field
 rtdb = run.GetRuntimeDb()
 # -----Create geometry----------------------------------------------

--- a/macro/inspectGeant4Geo.py
+++ b/macro/inspectGeant4Geo.py
@@ -1,30 +1,25 @@
-import ROOT,os,sys,atexit
+import sys
+import ROOT
 from rootpyPickler import Unpickler
 import shipRoot_conf
-shipRoot_conf.configure()  
+shipRoot_conf.configure()
 
-def rmxx():
- os.system("rm x.x")
- pass
-atexit.register(rmxx)
-
-fname = "geofile_full.10.0.Pythia8-TGeant4.root"
-if len(sys.argv)>1: fname=sys.argv[1]
+fname = 'geofile_full.10.0.Pythia8-TGeant4.root'
+if len(sys.argv) > 1:
+    fname = sys.argv[1]
 
 fgeo = ROOT.TFile(fname)
 sGeo = fgeo.FAIRGeom
 import shipDet_conf
 run = ROOT.FairRunSim()
-upkl    = Unpickler(fgeo)
+upkl = Unpickler(fgeo)
 ShipGeo = upkl.load('ShipGeo')
-modules = shipDet_conf.configure(run,ShipGeo)
-run.SetUserConfig("g4Config.C")
-run.SetName("TGeant4")
-run.SetOutputFile("x.x")
+modules = shipDet_conf.configure(run, ShipGeo)
+run.SetUserConfig('g4Config.C')
+run.SetName('TGeant4')
+run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))
 run.Init()
 run.Run(0)
 import geomGeant4
 geomGeant4.printVMCFields()
 geomGeant4.printWeightsandFields()
-
-


### PR DESCRIPTION
This changes all instances where a "dummy" file is created for no reason to write a file solely in memory and never to disk.

This also allows the simplification of `macro/inspectGeant4Geo.py` as `atexit` is no longer needed.