### PR TITLE
Updating charm target geometry and Muon Tagger walls y position and transverse size

### DIFF
--- a/charmdet/Box.cxx
+++ b/charmdet/Box.cxx
@@ -97,8 +97,8 @@ void Box::Initialize()
     FairDetector::Initialize();
 }
 
-void Box::SetGapGeometry(Double_t GapPostTargetTh){ 
-  GapPostTargetThickness = GapPostTargetTh;
+void Box::SetGapGeometry(Double_t distancePassive2ECC){ 
+  distPas2ECC = distancePassive2ECC;
 }
 
 void Box::SetEmulsionParam(Double_t EmTh, Double_t EmX, Double_t EmY, Double_t PBTh, Double_t EPlW,Double_t PasSlabTh, Double_t AllPW)
@@ -242,22 +242,35 @@ void Box::ConstructGeometry()
     volPlBase->SetLineColor(kYellow-4);
 
     
-    if (fJulytarget == false){   
+    if (fJulytarget == true){   
       //begin brick part (July testbeam)
       //Int_t NPlates = 19; //Number of doublets emulsion + Pb (two interaction lengths for 3 mm lead slabs)
-      Int_t NPlates = 56; //when we consider 1 mm lead slabs
-      Int_t NBricks = nrun;
-      if (nrun > 6 || nrun == 0) NBricks = 6; //maximum number of bricks is 6, Run 0 means all active
+      Int_t NPlates[6] = {28,28,56,56,56,56}; //when we consider 1 mm lead slabs
+     
+      Int_t NBlocks[6] = {1, 2, 2, 3, 4, 5}; //last active, other passive
+      Int_t NBricks;
+
+      if (nrun > 6 || nrun == 0) NBricks = 6; //Run 0 means 6 active bricks
+      else NBricks = NBlocks[nrun-1];
+
       bool activate[NBricks];
-      if (nrun > 0){
-      for (int i = 0; i<NBricks; i++) activate[i] = false; //JUST FOR NOW
-      activate[nrun-1]=true;
+
+      if (nrun > 0){ //passive red blocks followed by an ECC brick
+      for (int i = 0; i<NBricks; i++) activate[i] = false;
+      activate[NBricks-1]=true;
       }
       else  for (int i = 0; i<NBricks; i++) activate[i] = true;      
-      Double_t zPasLead = NPlates * PassiveSlabThickness; //Parti passive prima del bersaglio    
-      if (nrun > 0) TargetZ = (NPlates * AllPlateWidth + EmPlateWidth) + zPasLead*(nrun-1);  
-      else TargetZ = (NPlates * AllPlateWidth + EmPlateWidth)*NBricks;
-      if (nrun > 6) TargetZ = zPasLead * NBricks; //all passive      
+     
+      Double_t zPasLead = NPlates[5] * PassiveSlabThickness;   
+      if (nrun == 2) zPasLead = zPasLead/2; //in CH2 only half of a passive block      
+
+      //computing target z for the different configurations
+
+      if (nrun == 1) TargetZ = NPlates[nrun-1] * AllPlateWidth + EmPlateWidth; //CH1
+      else if (nrun == 2) TargetZ = zPasLead + NPlates[nrun-1] * AllPlateWidth + EmPlateWidth; //CH2
+      else if (nrun > 2 && nrun <= 6) TargetZ = NPlates[nrun-1] * AllPlateWidth + EmPlateWidth + zPasLead*(nrun-2) + distPas2ECC;//CH3-CH6      
+      else if (nrun > 6) TargetZ = zPasLead * NBricks; //all passive 
+      else TargetZ = (NPlates[5] * AllPlateWidth + EmPlateWidth)*NBricks;          
 
       TGeoBBox *Brick = new TGeoBBox("brick", TargetX/2, TargetY/2, TargetZ/2);
       TGeoVolume *volTarget = new TGeoVolume("volTarget",Brick,vacuum);
@@ -271,33 +284,40 @@ void Box::ConstructGeometry()
       TGeoBBox *PasLead = new TGeoBBox("PasLead", EmulsionX/2, EmulsionY/2, zPasLead/2);
       volPasLead = new TGeoVolume("volPasLead",PasLead,lead);
       volPasLead->SetTransparency(1);
-      volPasLead->SetLineColor(kGray);
+      volPasLead->SetLineColor(kRed);
       }
+    
       TGeoBBox *Leadslab = new TGeoBBox("Leadslab", EmulsionX/2, EmulsionY/2, PassiveSlabThickness/2);
       TGeoVolume *volLeadslab = new TGeoVolume("volLeadslab",Leadslab,lead);
- //     TGeoVolume *volLeadslab = new TGeoVolume("volLeadslab",Leadslab,molybdenum); //I need to see the difference
       volLeadslab->SetTransparency(1);
       volLeadslab->SetLineColor(kGray);
       
-      Int_t nfilm = 1, nlead = 1;
+      Int_t nfilm = 1, nlead = 1, nleadslab = 1;
       Double_t zpoint = -TargetZ/2;
-      for (Int_t irun = 0; irun < NBricks; irun++){
-        if (activate[irun]){	  
-	  for(Int_t n=0; n<NPlates+1; n++)
+
+      for (Int_t irun = 0; irun < NBricks; irun++){ //irun is the index, nrun is the number of the configuration run
+        if (activate[irun]){
+         
+         if (nrun > 2) zpoint = zpoint + distPas2ECC;	  
+	 
+         for(Int_t n=0; n<NPlates[nrun]+1; n++) //adding emulsions
 	    {
 	      AddEmulsionFilm(zpoint + n*AllPlateWidth, nfilm, volTarget, volEmulsionFilm, volEmulsionFilm2, volPlBase);
 	      nfilm++;
 	    }
-	  for(Int_t n=0; n<NPlates; n++)
+           
+	 for(Int_t n=0; n<NPlates[nrun]; n++) //adding 1 mm lead plates
 	    {
-              volTarget->AddNode(volLeadslab, n, new TGeoTranslation(0,0,zpoint + EmPlateWidth + PassiveSlabThickness/2 + n*AllPlateWidth));
+              volTarget->AddNode(volLeadslab, nleadslab, new TGeoTranslation(0,0,zpoint + EmPlateWidth + PassiveSlabThickness/2 + n*AllPlateWidth));
+              nleadslab++;
 	    }	
-	  zpoint = zpoint + NPlates *AllPlateWidth + EmPlateWidth;
+	 zpoint = zpoint + NPlates[nrun] *AllPlateWidth + EmPlateWidth;
 	}
-	else if (volPasLead != NULL){ //only passive layer of lead
-	  volTarget->AddNode(volPasLead,nlead,new TGeoTranslation(0,0,zpoint + zPasLead/2));
-	  zpoint = zpoint + zPasLead;
-          nlead++;
+
+	else if (volPasLead != NULL && ((irun > 0) || (NBricks == 2))) { //only passive layer of lead, first is skipped
+	 volTarget->AddNode(volPasLead,nlead,new TGeoTranslation(0,0,zpoint + zPasLead/2));
+	 zpoint = zpoint + zPasLead;
+         nlead++;
 	}
 	
       }    

--- a/charmdet/Box.h
+++ b/charmdet/Box.h
@@ -43,7 +43,7 @@ public:
     void SetCoolingParam(Double_t CoolX, Double_t CoolY, Double_t CoolZ);
     void SetCoatingParam(Double_t CoatX, Double_t CoatY, Double_t CoatZ);
 
-    void SetGapGeometry(Double_t GapPostTargetTh);
+    void SetGapGeometry(Double_t distancePassive2ECC); //distance between passive and ECC
     
     /**      Initialization of the detector is done here    */
     virtual void Initialize();
@@ -135,6 +135,8 @@ protected:
     Double_t Pas3mmZ;
     Double_t Pas2mmZ;
     Double_t Pas1mmZ;
+
+    Double_t distPas2ECC;
          
     //attributes for the cooling system( water )
     Double_t CoolingX;

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -157,7 +157,9 @@ void MuonTagger::ConstructGeometry()
   TGeoVolume *VMuonBox = new TGeoVolume("VMuonBox", MuonBox,air);
   VMuonBox->SetTransparency(1);
   Double_t goliathcentre_to_beam = 178.6; //mm    
-  
+
+  Double_t walldisalignment = 15; //mm, all walls but one were disaligned with respect to the nominal beam position  
+
   top->AddNode(VMuonBox, 1, new TGeoTranslation(0, goliathcentre_to_beam*mm, zBoxPosition));
 
   //begin muon filter part
@@ -202,7 +204,7 @@ void MuonTagger::ConstructGeometry()
   
   for (int n = 0; n < npassive; n++){
     zpassive = n * PasThickness + PasThickness/2. + n* SensThickness;
-    VMuonBox->AddNode(VPassive, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm - 15 *mm,-BoxZ/2 + zpassive));
+    VMuonBox->AddNode(VPassive, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm - walldisalignment*mm,-BoxZ/2 + zpassive));
 }
 
   for (int n = 0; n < nsensitive1; n++){
@@ -212,7 +214,7 @@ void MuonTagger::ConstructGeometry()
 
   for (int n = 0; n < npassiveshort; n++){
     zpassive = 2 * PasThickness + 2*SensThickness + n * PasThickness1 + n * SensThickness + PasThickness1/2;
-    if (n < npassiveshort - 1) VMuonBox->AddNode(VPassive1, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm - 15 *mm,-BoxZ/2 + zpassive));
+    if (n < npassiveshort - 1) VMuonBox->AddNode(VPassive1, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm - walldisalignment*mm,-BoxZ/2 + zpassive));
     else  VMuonBox->AddNode(VPassive1, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm,-BoxZ/2 + zpassive));
 }
 

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -188,8 +188,6 @@ void MuonTagger::ConstructGeometry()
   
   //sensitive layers
   TGeoBBox * Sensitive = new TGeoBBox(SensX/2, SensY/2, SensThickness/2);
-  Sensitive->SetName("S");
-  TGeoCompositeShape *SubtractionSensitive = new TGeoCompositeShape("SubtractionSensitive", "S-T");
 
   TGeoVolume * VSensitive = new TGeoVolume("VSensitive", Sensitive, RPCmat);
   VSensitive->SetLineColor(kOrange-5);
@@ -204,7 +202,7 @@ void MuonTagger::ConstructGeometry()
   
   for (int n = 0; n < npassive; n++){
     zpassive = n * PasThickness + PasThickness/2. + n* SensThickness;
-    VMuonBox->AddNode(VPassive, n, new TGeoTranslation(0,0,-BoxZ/2 + zpassive));
+    VMuonBox->AddNode(VPassive, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm - 15 *mm,-BoxZ/2 + zpassive));
 }
 
   for (int n = 0; n < nsensitive1; n++){
@@ -214,7 +212,8 @@ void MuonTagger::ConstructGeometry()
 
   for (int n = 0; n < npassiveshort; n++){
     zpassive = 2 * PasThickness + 2*SensThickness + n * PasThickness1 + n * SensThickness + PasThickness1/2;
-    VMuonBox->AddNode(VPassive1, n, new TGeoTranslation(0,0,-BoxZ/2 + zpassive));
+    if (n < npassiveshort - 1) VMuonBox->AddNode(VPassive1, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm - 15 *mm,-BoxZ/2 + zpassive));
+    else  VMuonBox->AddNode(VPassive1, n, new TGeoTranslation(0,-goliathcentre_to_beam*mm,-BoxZ/2 + zpassive));
 }
 
   for (int n = 0; n < nsensitive2; n++){ 

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -89,13 +89,15 @@ with ConfigRegistry.register_config("basic") as c:
     c.Box.Passive2mmZ = 0.2 * u.cm
     c.Box.Passive1mmZ = 0.1 * u.cm
 
+    #Distance between passive bricks and ECC brick
+    c.Box.distancePassive2ECC = 3.0 *u.cm
+
     #OPTIONS FOR CHARM XSEC DETECTOR
     c.Box.gausbeam = True
-    c.Box.Julytarget = False
-    #c.Box.GapPostTargetTh = 5 * u.cm #gap between charm target and T1 station
-    c.Box.GapPostTargetTh = 0.73 * u.cm     
-    #c.Box.GapPostTargetTh = 0*u.cm
-    c.Box.RunNumber =  3 #run configuration for charm
+    c.Box.Julytarget = True
+    c.Box.GapPostTargetTh = 0.73 * u.cm #gap between charm target and T1 station    
+    
+    c.Box.RunNumber = 3 #run configuration for charm
 
     # target absorber muon shield setup, decayVolume.length = nominal EOI length, only kept to define z=0
     c.decayVolume            =  AttrDict(z=0*u.cm)
@@ -294,8 +296,8 @@ with ConfigRegistry.register_config("basic") as c:
     c.MuonTagger.PTh = 80 * u.cm;
     c.MuonTagger.PTh1 = 40 * u.cm #last 3 slabs' thickness
     c.MuonTagger.STh = 5.0 * u.cm
-    c.MuonTagger.BX = 1.936725 * u.m
-    c.MuonTagger.BY = 1.215312 * u.m
+    c.MuonTagger.BX = 2.40 * u.m
+    c.MuonTagger.BY = 2.20 * u.m + 2*c.MufluxSpectrometer.goliathcentre_to_beam + 30 *u.mm
     c.MuonTagger.BZ = c.MuonTagger.PTh * 2 + c.MuonTagger.PTh1 * 3 + c.MuonTagger.STh * 5
     
     if c.MufluxSpectrometer.muflux == True:
@@ -309,8 +311,8 @@ with ConfigRegistry.register_config("basic") as c:
 
     c.MuonTagger.PX = c.MuonTagger.BX
     c.MuonTagger.PY = c.MuonTagger.BY
-    c.MuonTagger.SX = c.MuonTagger.BX
-    c.MuonTagger.SY = c.MuonTagger.BY
+    c.MuonTagger.SX = 1.936725 * u.m
+    c.MuonTagger.SY = 1.215312 * u.m
     c.MuonTagger.HX = 5 * u.cm #dimensions of central hole
     c.MuonTagger.HY = 5 * u.cm
 

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -309,8 +309,8 @@ with ConfigRegistry.register_config("basic") as c:
        #c.MuonTagger.zBox = c.Spectrometer.SZ+ c.MuonTagger.BZ/2 + 5*u.cm
        c.MuonTagger.zBox = c.Spectrometer.zBox + c.Spectrometer.DimZpixelbox/2. + PixeltoGoliath + c.Spectrometer.TS + 261*u.cm + c.MuonTagger.BZ/2. #real position of MuonTagger
 
-    c.MuonTagger.PX = c.MuonTagger.BX
-    c.MuonTagger.PY = c.MuonTagger.BY
+    c.MuonTagger.PX = 2.40 *u.m
+    c.MuonTagger.PY = 2.20 *u.m
     c.MuonTagger.SX = 1.936725 * u.m
     c.MuonTagger.SY = 1.215312 * u.m
     c.MuonTagger.HX = 5 * u.cm #dimensions of central hole

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -37,7 +37,7 @@ def configure(run,ship_geo):
  Box.SetPassiveSampling(ship_geo.Box.Passive3mmZ, ship_geo.Box.Passive2mmZ, ship_geo.Box.Passive1mmZ)
  Box.SetCoolingParam(ship_geo.Box.CoolX, ship_geo.Box.CoolY, ship_geo.Box.CoolZ)
  Box.SetCoatingParam(ship_geo.Box.CoatX, ship_geo.Box.CoatY, ship_geo.Box.CoatZ)
- Box.SetGapGeometry(ship_geo.Box.GapPostTargetTh)
+ Box.SetGapGeometry(ship_geo.Box.distancePassive2ECC)
  Box.SetTargetDesign(ship_geo.Box.Julytarget)
  Box.SetRunNumber(ship_geo.Box.RunNumber)
 


### PR DESCRIPTION
Hi,

I have inserted the six target configurations used in July exposures (CHARM1 - CHARM6).

I have increased wall sizes in MuonTagger.cxx, as in presentation https://indico.cern.ch/event/724780/contributions/2981501/attachments/1654268/2647421/RPC_23MAY2018.pdf. 
Also, walls are centered not to Goliath centre as in RPC, but to beam position in order for the non interacting proton beam to enter holes (except for a 15 mm disalignment).

I did not change RPC sizes or positions, so this should not create issues for people doing data analysis and digitization.

Waiting for your kind opinions.
Best regards,
Antonio