### PR TITLE
Fix field map file opening

### DIFF
--- a/field/ShipGoliathField.cxx
+++ b/field/ShipGoliathField.cxx
@@ -64,7 +64,7 @@ ShipGoliathField::~ShipGoliathField() { }
 
 void ShipGoliathField::Init(const char* fieldfile){
 
-  TFile *fieldmap = new TFile(fieldfile); 
+  fieldmap = TFile::Open(fieldfile);
   
   
   TH3D* histbx= (TH3D*)fieldmap->Get("Bx");


### PR DESCRIPTION
The definition of a new `TFile*` shadows the class member `fieldmap`. This is fixed. Additionally the `new TFile` is replaced with `TFile::Open` which is in most cases better, as it also supports remote files.