### PR TITLE
Charm restore commit

### DIFF
--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -91,12 +91,14 @@ with ConfigRegistry.register_config("basic") as c:
     c.Box.Passive2mmZ = 0.2 * u.cm
     c.Box.Passive1mmZ = 0.1 * u.cm
 
+    #Distance between passive bricks and ECC brick
+    c.Box.distancePassive2ECC = 3.0 *u.cm
+
+
     #OPTIONS FOR CHARM XSEC DETECTOR
     c.Box.gausbeam = True
-    c.Box.Julytarget = False
-    #c.Box.GapPostTargetTh = 5 * u.cm #gap between charm target and T1 station
+    c.Box.Julytarget = True
     c.Box.GapPostTargetTh = 0.73 * u.cm     
-    #c.Box.GapPostTargetTh = 0*u.cm
     c.Box.RunNumber =  3 #run configuration for charm
 
     # target absorber muon shield setup, decayVolume.length = nominal EOI length, only kept to define z=0

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -37,7 +37,7 @@ def configure(run,ship_geo):
  Box.SetPassiveSampling(ship_geo.Box.Passive3mmZ, ship_geo.Box.Passive2mmZ, ship_geo.Box.Passive1mmZ)
  Box.SetCoolingParam(ship_geo.Box.CoolX, ship_geo.Box.CoolY, ship_geo.Box.CoolZ)
  Box.SetCoatingParam(ship_geo.Box.CoatX, ship_geo.Box.CoatY, ship_geo.Box.CoatZ)
- Box.SetGapGeometry(ship_geo.Box.GapPostTargetTh)
+ Box.SetGapGeometry(ship_geo.Box.distancePassive2ECC)
  Box.SetTargetDesign(ship_geo.Box.Julytarget)
  Box.SetRunNumber(ship_geo.Box.RunNumber)
 


### PR DESCRIPTION
Dear all,

during the second to latest commit to charm-geometry_config.py ("New muflux rpc"), some geometrical parameters for the charm setup set in my previous commit have been removed:

 July target as default;
 distance between pre-shower and ECC.

Since they regard the Box class, I do not think they should create conflict with the other commits. But of course I could be wrong.

Waiting for your kind answer,
Antonio