### PR TITLE
Adding options to makeGenieEvents.py

### DIFF
--- a/macro/makeGenieEvents.py
+++ b/macro/makeGenieEvents.py
@@ -5,9 +5,10 @@ import shipRoot_conf
 import argparse
 shipRoot_conf.configure()
 # 
-xsec = "Nu_splines.xml"
-#hfile = "pythia8_Geant4-withCharm_onlyNeutrinos.root"
+xsec = "xsec_splines-iron-nu_e-nu_mu.xml"
 hfile = "pythia8_Geant4_1.0_withCharm_nu.root" #2018 background generation
+#xsec = "Nu_splines.xml"
+#hfile = "pythia8_Geant4-withCharm_onlyNeutrinos.root"
 #put the above files in folder linked by the environment variables GENIEXSECPATH and NUFLUXPATH
 
 splines   = os.environ['XSECPATH']+'/'+xsec #path of splines

--- a/macro/makeGenieEvents.py
+++ b/macro/makeGenieEvents.py
@@ -20,7 +20,7 @@ def init(): #available options
       description='Run GENIE neutrino" simulation')
   ap.add_argument('-s', '--seed', type=int, dest='seed', default=65539) #default seed in $GENIE/src/Conventions/Controls.h
   ap.add_argument('-o','--output'    , type=str, help="output directory", dest='work_dir', default=None)
-  ap.add_argument('-t', '--target', type=str, help="target material", dest='target', default='lead')
+  ap.add_argument('-t', '--target', type=str, help="target material", dest='target', default='iron')
   args = ap.parse_args()
   return args
 

--- a/macro/makeGenieEvents.py
+++ b/macro/makeGenieEvents.py
@@ -2,11 +2,44 @@
 import ROOT,os,sys,getopt,time
 import shipunit as u
 import shipRoot_conf
+import argparse
 shipRoot_conf.configure()
-# location of these files on eos: eos/ship/data/
 # 
-xsec = "xsec_splines-iron-nu_e-nu_mu.xml"
-hfile = "pythia8_Geant4-withCharm_onlyNeutrinos.root"
+xsec = "Nu_splines.xml"
+#hfile = "pythia8_Geant4-withCharm_onlyNeutrinos.root"
+hfile = "pythia8_Geant4_1.0_withCharm_nu.root" #2018 background generation
+#put the above files in folder linked by the environment variables GENIEXSECPATH and NUFLUXPATH
+
+splines   = os.environ['XSECPATH']+'/'+xsec #path of splines
+neutrinos = os.environ['NUFLUXPATH']+'/'+hfile #path of flux
+
+def init(): #available options  
+
+  ap = argparse.ArgumentParser(
+      description='Run GENIE neutrino" simulation')
+  ap.add_argument('-s', '--seed', type=int, dest='seed', default=65539) #default seed in $GENIE/src/Conventions/Controls.h
+  ap.add_argument('-o','--output'    , type=str, help="output directory", dest='work_dir', default=None)
+  ap.add_argument('-t', '--target', type=str, help="target material", dest='target', default='lead')
+  args = ap.parse_args()
+  return args
+
+args = init() #getting options
+
+work_dir = args.work_dir
+target = args.target
+seed = args.seed
+
+print 'Target type: ', target
+print 'Seed used in this generation: ', seed
+print 'Splines file used', xsec 
+
+if target == 'iron':
+ targetcode = '1000260560'
+elif target == 'lead':
+ targetcode = '1000822040[0.014],1000822060[0.241],1000822070[0.221],1000822080[0.524]'
+else:
+ print 'only iron and lead target available'
+ 1/0
 
 pdg  = ROOT.TDatabasePDG()
 pDict = {}
@@ -22,6 +55,15 @@ for x in [14,12]:
  nuOverNubar[x] = f.Get(pDict[x]).GetSumOfWeights()/f.Get(pDict[-x]).GetSumOfWeights()
 f.Close()
 
+work_dir = args.work_dir 
+
+if os.path.exists(work_dir): #if the directory is already there, leave a warning, otherwise create it
+    print 'output directory already exists.'
+else:
+    os.makedirs(work_dir)
+
+os.chdir(work_dir)
+
 def makeSplines():
 # first step, make cross section splines if not exist
  if not xsec in os.listdir('.'):
@@ -30,8 +72,6 @@ def makeSplines():
 
 def makeEvents(nevents = 100):
  run = 11
- splines   = os.path.abspath('.')+'/xsec_splines-iron-nu_e-nu_mu.xml'
- neutrinos = os.path.abspath('.')+'/'+hfile
  for p in pDict:
   if p<0: print "scale number of "+sDict[p]+" events with %5.2F"%(1./nuOverNubar[abs(p)])
   if not sDict[p] in os.listdir('.'): os.system('mkdir '+sDict[p])
@@ -44,8 +84,8 @@ def makeEvents(nevents = 100):
   # interacting than those at higher energy. pmaxLow(E=386.715)=2.157e-13 and  pmaxHigh(E=388.044)=2.15623e-13"
   N = nevents
   if p<0: N = int(nevents / nuOverNubar[abs(p)])
-  cmd = "gevgen -n "+str(N)+"  -p "+str(p)+" -t 1000260560 -e  0.5,350  --run "+str(run)+" -f "+neutrinos+","+pDict[p]+ \
-            " --cross-sections "+splines+" --message-thresholds $GENIE/config/Messenger_laconic.xml"
+  cmd = "gevgen -n "+str(N)+" -p "+str(p)+" -t "+targetcode +" -e  0.5,350  --run "+str(run)+" -f "+neutrinos+","+pDict[p]+ \
+            " --cross-sections "+splines+" --message-thresholds $GENIE/config/Messenger_laconic.xml" +" --seed "+str(seed)
   print "start genie ",cmd
   os.system(cmd+" > log"+sDict[p]+" &")
   run +=1
@@ -55,14 +95,14 @@ def makeNtuples():
   os.chdir('./'+sDict[p])
   os.system("gntpc -i gntp.0.ghep.root -f gst --message-thresholds $GENIE/config/Messenger_laconic.xml")
 # add p/pt histogram
-  fp = ROOT.TFile(hfile) 
+  fp = ROOT.TFile(neutrinos) 
   fn = ROOT.TFile("gntp.0.gst.root","update")
   fp.Get(pDict[p].replace('0','2')).Write()
   fn.Close()
   os.system("mv gntp.0.gst.root genie-"+sDict[p]+".root")
   os.chdir('../')
 def addHists():
- fp = ROOT.TFile(hfile) 
+ fp = ROOT.TFile(neutrinos) 
  for p in pDict:
   os.chdir('./'+sDict[p])
   fn = ROOT.TFile("genie-"+sDict[p]+".root","update")


### PR DESCRIPTION
To whom it may concern,

I have added some options to makeGenieEvents, that allow the user to set seed, target and output directory for gevgen. This should allow an easier usage of the script, especially when launching multiple jobs in parallel.

Also, I have changed the request for the path of the splines file and the neutrino files to two environment variables, instead of using local path as before.

Please tell me if there are any issues.

Best regards,
Antonio