### PR TITLE
Add method to expose Trigger flag

### DIFF
--- a/charmdet/MufluxSpectrometerHit.h
+++ b/charmdet/MufluxSpectrometerHit.h
@@ -38,6 +38,7 @@ public:
       return AllOK || !((flags & TDCNotOK) == TDCNotOK);
    }
    bool hasDelay() const { return !((flags & DriftTubes::NoDelay) == DriftTubes::NoDelay); }
+   bool hasTrigger() const { return !((flags & DriftTubes::NoTrigger) == DriftTubes::NoTrigger); }
    bool hasTimeOverThreshold() const { return !((flags & DriftTubes::NoWidth) == DriftTubes::NoWidth); }
    Float_t GetTimeOverThreshold() const { return time_over_threshold; }
    std::vector<int> StationInfo();


### PR DESCRIPTION
This exposes a flag in the data which returns whether there was a trigger found on the TDC of the hit, i.e. if `hasTrigger() == false`, the conversion could not find the corresponding trigger.

This will work with previously converted data as well, as the flag is already there, but requires some bit-twiddling to access without this method.