### PR TITLE
Muontagger endpoints

### DIFF
--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -515,8 +515,8 @@ void MuonTagger::EndPoints(Int_t fDetectorID, TVector3 &vbot, TVector3 &vtop) {
      vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,Gtop[2]);      
   }     
   if (orientationnb ==1) {
-     vtop.SetXYZ((Gbot[0]+Gbot[1])/2.,Gtop[1],Gbot[2]);    
-     vbot.SetXYZ((Gbot[0]+Gbot[1])/2.,Gbot[1],Gtop[2]);      
+     vtop.SetXYZ((Gbot[0]+Gtop[0])/2.,Gtop[1],Gbot[2]);    
+     vbot.SetXYZ((Gbot[0]+Gtop[0])/2.,Gbot[1],Gtop[2]);      
   }          
 }
 

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -511,12 +511,12 @@ void MuonTagger::EndPoints(Int_t fDetectorID, TVector3 &vbot, TVector3 &vtop) {
   nav->LocalToMaster(top, Gtop);
   nav->LocalToMaster(bot, Gbot);
   if (orientationnb ==0) {
-     vtop.SetXYZ(Gbot[0],(Gbot[1]+Gtop[1])/2.,Gbot[2]);    
-     vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,Gtop[2]);      
+     vtop.SetXYZ(Gbot[0],(Gbot[1]+Gtop[1])/2.,(Gtop[2]+Gbot[2])/2.);    
+     vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,(Gtop[2]+Gbot[2])/2.);      
   }     
   if (orientationnb ==1) {
-     vtop.SetXYZ((Gbot[0]+Gtop[0])/2.,Gtop[1],Gbot[2]);    
-     vbot.SetXYZ((Gbot[0]+Gtop[0])/2.,Gbot[1],Gtop[2]);      
+     vtop.SetXYZ((Gbot[0]+Gtop[0])/2.,Gtop[1],(Gtop[2]+Gbot[2])/2.);    
+     vbot.SetXYZ((Gbot[0]+Gtop[0])/2.,Gbot[1],(Gtop[2]+Gbot[2])/2.);      
   }          
 }
 

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -510,8 +510,14 @@ void MuonTagger::EndPoints(Int_t fDetectorID, TVector3 &vbot, TVector3 &vtop) {
   Double_t Gtop[3],Gbot[3];
   nav->LocalToMaster(top, Gtop);
   nav->LocalToMaster(bot, Gbot);
-  vtop.SetXYZ(Gbot[0],Gbot[1],Gbot[2]);   
-  vbot.SetXYZ(Gtop[0],Gtop[1],Gtop[2]);        
+  if (orientationnb ==0) {
+     vtop.SetXYZ(Gbot[0],(Gbot[1]+Gtop[1])/2.,Gbot[2]);    
+     vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,Gtop[2]);      
+  }     
+  if (orientationnb ==1) {
+     vtop.SetXYZ((Gbot[0]+Gbot[1])/2.,Gtop[1],Gbot[2]);    
+     vbot.SetXYZ((Gbot[0]+Gbot[1])/2.,Gbot[1],Gtop[2]);      
+  }          
 }
 
 ClassImp(MuonTagger)

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -515,9 +515,9 @@ void MuonTagger::EndPoints(Int_t fDetectorID, TVector3 &vbot, TVector3 &vtop) {
      vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,(Gtop[2]+Gbot[2])/2.);      
   }     
   if (orientationnb ==1) {
-     vtop.SetXYZ((Gbot[0]+Gtop[0])/2.,Gtop[1],(Gtop[2]+Gbot[2])/2.);    
-     vbot.SetXYZ((Gbot[0]+Gtop[0])/2.,Gbot[1],(Gtop[2]+Gbot[2])/2.);      
-  }          
+     vtop.SetXYZ((Gtop[0]+Gbot[0])/2.,Gbot[1],(Gtop[2]+Gbot[2])/2.);    
+     vbot.SetXYZ((Gtop[0]+Gbot[0])/2.,Gtop[1],(Gtop[2]+Gbot[2])/2.);      
+  }       
 }
 
 ClassImp(MuonTagger)

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -505,8 +505,8 @@ void MuonTagger::EndPoints(Int_t fDetectorID, TVector3 &vbot, TVector3 &vtop) {
   }  
   TGeoNode* W = nav->GetCurrentNode();
   TGeoBBox* S = dynamic_cast<TGeoBBox*>(W->GetVolume()->GetShape());
-  Double_t top[3] = {0,0,S->GetDZ()};
-  Double_t bot[3] = {0,0,-S->GetDZ()};
+  Double_t top[3] = {S->GetDX(),S->GetDY(),S->GetDZ()};
+  Double_t bot[3] = {-S->GetDX(),-S->GetDY(),-S->GetDZ()};
   Double_t Gtop[3],Gbot[3];
   nav->LocalToMaster(top, Gtop);
   nav->LocalToMaster(bot, Gbot);

--- a/charmdet/MuonTaggerHit.cxx
+++ b/charmdet/MuonTaggerHit.cxx
@@ -41,8 +41,14 @@ void MuonTaggerHit::EndPoints(TVector3 &vbot, TVector3 &vtop) {
   Double_t Gtop[3],Gbot[3];
   nav->LocalToMaster(top, Gtop);
   nav->LocalToMaster(bot, Gbot);
-  vtop.SetXYZ(Gbot[0],Gbot[1],Gbot[2]);   
-  vbot.SetXYZ(Gtop[0],Gtop[1],Gtop[2]);        
+  if (orientationnb ==0) {
+     vtop.SetXYZ(Gbot[0],(Gbot[1]+Gtop[1])/2.,Gbot[2]);    
+     vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,Gtop[2]);      
+  }     
+  if (orientationnb ==1) {
+     vtop.SetXYZ((Gbot[0]+Gbot[1])/2.,Gtop[1],Gbot[2]);    
+     vbot.SetXYZ((Gbot[0]+Gbot[1])/2.,Gbot[1],Gtop[2]);      
+  }      
 }
 
 ClassImp(MuonTaggerHit)

--- a/charmdet/MuonTaggerHit.cxx
+++ b/charmdet/MuonTaggerHit.cxx
@@ -36,8 +36,8 @@ void MuonTaggerHit::EndPoints(TVector3 &vbot, TVector3 &vtop) {
   }  
   TGeoNode* W = nav->GetCurrentNode();
   TGeoBBox* S = dynamic_cast<TGeoBBox*>(W->GetVolume()->GetShape());
-  Double_t top[3] = {0,0,S->GetDZ()};
-  Double_t bot[3] = {0,0,-S->GetDZ()};
+  Double_t top[3] = {S->GetDX(),S->GetDY(),S->GetDZ()};
+  Double_t bot[3] = {-S->GetDX(),-S->GetDY(),-S->GetDZ()};
   Double_t Gtop[3],Gbot[3];
   nav->LocalToMaster(top, Gtop);
   nav->LocalToMaster(bot, Gbot);

--- a/charmdet/MuonTaggerHit.cxx
+++ b/charmdet/MuonTaggerHit.cxx
@@ -46,8 +46,8 @@ void MuonTaggerHit::EndPoints(TVector3 &vbot, TVector3 &vtop) {
      vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,Gtop[2]);      
   }     
   if (orientationnb ==1) {
-     vtop.SetXYZ((Gbot[0]+Gbot[1])/2.,Gtop[1],Gbot[2]);    
-     vbot.SetXYZ((Gbot[0]+Gbot[1])/2.,Gbot[1],Gtop[2]);      
+     vtop.SetXYZ((Gbot[0]+Gtop[0])/2.,Gtop[1],Gbot[2]);    
+     vbot.SetXYZ((Gbot[0]+Gtop[0])/2.,Gbot[1],Gtop[2]);      
   }      
 }
 

--- a/charmdet/MuonTaggerHit.cxx
+++ b/charmdet/MuonTaggerHit.cxx
@@ -42,12 +42,12 @@ void MuonTaggerHit::EndPoints(TVector3 &vbot, TVector3 &vtop) {
   nav->LocalToMaster(top, Gtop);
   nav->LocalToMaster(bot, Gbot);
   if (orientationnb ==0) {
-     vtop.SetXYZ(Gbot[0],(Gbot[1]+Gtop[1])/2.,Gbot[2]);    
-     vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,Gtop[2]);      
+     vtop.SetXYZ(Gbot[0],(Gbot[1]+Gtop[1])/2.,(Gtop[2]+Gbot[2])/2.);    
+     vbot.SetXYZ(Gtop[0],(Gbot[1]+Gtop[1])/2.,(Gtop[2]+Gbot[2])/2.);      
   }     
   if (orientationnb ==1) {
-     vtop.SetXYZ((Gbot[0]+Gtop[0])/2.,Gtop[1],Gbot[2]);    
-     vbot.SetXYZ((Gbot[0]+Gtop[0])/2.,Gbot[1],Gtop[2]);      
+     vtop.SetXYZ((Gbot[0]+Gtop[0])/2.,Gtop[1],(Gtop[2]+Gbot[2])/2.);    
+     vbot.SetXYZ((Gbot[0]+Gtop[0])/2.,Gbot[1],(Gtop[2]+Gbot[2])/2.);      
   }      
 }
 


### PR DESCRIPTION
Fix MuonTagger and MuonTaggerHit endpoints routines.
For horizontal strips: return x(top,left),x(bot,right), y average (top,left), y average (bot,right), z average (top,left), z average (bot,right)
For vertical strips: return x average(top,left), x average (bot,right), y (top,left), y (bot,right), z average (top,left), z average (bot,right)

