### PR TITLE
Fix the overlap between the layers in strawdesign 10

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -150,7 +150,7 @@ with ConfigRegistry.register_config("basic") as c:
     elif strawDesign==10:  # 10 - baseline for 2018 
      c.strawtubes.InnerStrawDiameter = 1.975*u.cm
      c.strawtubes.StrawPitch         = 3.60*u.cm  
-     c.strawtubes.DeltazLayer        = 1.6*u.cm   
+     c.strawtubes.DeltazLayer        = 2.1*u.cm   
      c.strawtubes.DeltazPlane        = 4.2*u.cm   
      c.strawtubes.YLayerOffset = 1.9*u.cm        
      c.strawtubes.YPlaneOffset = 1.3*u.cm

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -482,7 +482,7 @@ void strawtubes::ConstructGeometry()
 	 //plane loop
          TString nmplane_veto = nmveto+"_plane_"; nmplane_veto += pnb;
 	 //width of the planes: z distance between layers + outer straw diameter
-	 TGeoBBox *plane_veto = new TGeoBBox("plane box", fStraw_length_veto+eps/2., fvetoydim+eps/2., planewidth/2.+eps/2.);
+	 TGeoBBox *plane_veto = new TGeoBBox("plane box", fStraw_length_veto+eps/2., fvetoydim+eps/2., planewidth/2.+3.*eps/2.);
          TGeoVolume *planebox_veto = new TGeoVolume(nmplane_veto, plane_veto, med);
 	 //the planebox sits in the viewframe
 	 //hence z translate the plane wrt to the view
@@ -624,7 +624,7 @@ void strawtubes::ConstructGeometry()
 	      //plane loop	   
 	      TString nmplane_12 = nmview_12+"_plane_"; 
 	      nmplane_12 += pnb;
-	      TGeoBBox *plane_12 = new TGeoBBox("plane box_12", fStraw_length_12+eps/2, ftr12ydim+eps/2, planewidth/2.+eps/2);	   	   
+	      TGeoBBox *plane_12 = new TGeoBBox("plane box_12", fStraw_length_12+eps/2, ftr12ydim+eps/2, planewidth/2.+3.*eps/2);	   	   
  	      TGeoVolume *planebox_12 = new TGeoVolume(nmplane_12, plane_12, med);          
 	   
 	      //the planebox sits in the viewframe
@@ -721,7 +721,7 @@ void strawtubes::ConstructGeometry()
 	      //plane loop	   
 	      TString nmplane = nmview+"_plane_"; 
 	      nmplane += pnb;
-	      TGeoBBox *plane = new TGeoBBox("plane box", fStraw_length+eps/2, ftr34ydim+eps/2, planewidth/2.+eps/2);	   	   
+	      TGeoBBox *plane = new TGeoBBox("plane box", fStraw_length+eps/2, ftr34ydim+eps/2, planewidth/2.+3.*eps/2);	   	   
  	      TGeoVolume *planebox = new TGeoVolume(nmplane, plane, med);          
 	   
 	      //the planebox sits in the viewframe


### PR DESCRIPTION
There were overlaps between layers, which were not detected by overlap checking tool. I made calculations for the volume dimensions and propose the following value for the distance between layers. Also I changed the plane width by 0.5eps to fit properly the layers inside.