### PR TITLE
Minor change to script charmdet/runReconstruction.py

### DIFF
--- a/charmdet/runReconstruction.py
+++ b/charmdet/runReconstruction.py
@@ -1,10 +1,13 @@
 import os,subprocess,ROOT,time,multiprocessing
-ncpus = multiprocessing.cpu_count()*3./4.
+import pwd
+ncpus = int(multiprocessing.cpu_count()*3./4.)
 
 pathToMacro = '' # $SHIPBUILD/FairShip/charmdet/
 def count_python_processes(macroName):
+ username = pwd.getpwuid(os.getuid()).pw_name
+ callstring = "ps -f -u " + username
 # only works if screen is wide enough to print full name!
- status = subprocess.check_output('ps -f -u truf',shell=True)
+ status = subprocess.check_output(callstring,shell=True)
  n=0
  for x in status.split('\n'):
    if not x.find(macroName)<0 and not x.find('python') <0: n+=1


### PR DESCRIPTION
# Purpose
So far, the above mentioned script counts python processes for a hardcoded username. When this script will regularly be called by different users, it is more convenient, if the script reads the username itself.

# Included commit messages
Read below for the included commit messages:
Changed script charmdet/runReconstruction to use username of script caller instead of hardcoded one.

Changed script charmdet/runReconstruction to ensure an integer value of CPU threads will be requested.