### PR TITLE
Dark Photon production: fix in pbrem and qcd production, addition of rate calculation tools

### DIFF
--- a/python/dpProductionRates.py
+++ b/python/dpProductionRates.py
@@ -1,0 +1,98 @@
+import ROOT,os,sys,getopt,math
+import shipunit as u
+import proton_bremsstrahlung
+
+
+PDG = ROOT.TDatabasePDG.Instance()
+protonFlux = 2e20
+
+
+def isDP(pdg):
+    if (pdg==9900015 or pdg==4900023): 
+        return True
+    return False
+
+def pbremProdRate(mass,epsilon,doprint=False):
+    xswg = proton_bremsstrahlung.prodRate(mass, epsilon)
+    if doprint: print "A' production rate per p.o.t: \t %.8g"%(xswg)
+    penalty = proton_bremsstrahlung.penaltyFactor(mass)
+    if doprint: print "A' penalty factor: \t %.8g"%penalty
+    if doprint: print "A' rescaled production rate per p.o.t:\t %.8g"%(xswg*penalty)
+    return xswg*penalty
+
+#obtained with Pythia8: average number of meson expected per p.o.t from inclusive pp to X production, 100k events produced
+def getAverageMesonRate(mumPdg):
+    if (mumPdg==111): return 6.166
+    if (mumPdg==221): return 0.7012
+    if (mumPdg==223): return 0.8295
+    if (mumPdg==331): return 0.07825
+    print " -- ERROR, unknown mother pdgId %d"%mumPdg
+    return 0
+
+#from the PDG, decay to photon channels available for mixing with DP
+def mesonBRtoPhoton(mumPdg,doprint=False):
+    br = 1
+    if (mumPdg==111): br = 0.9879900
+    if (mumPdg==221): br = 0.3931181
+    if (mumPdg==223): br = 0.0834941
+    if (mumPdg==331): br = 0.0219297
+    if (doprint==True): print "BR of %d meson to photons: %.8g"%(mumPdg,br)
+    return br 
+
+def brMesonToGammaDP(mass,epsilon,mumPdg,doprint=False):
+    mMeson = PDG.GetParticle(mumPdg).Mass()
+    if (doprint==True): print "Mass of mother %d meson is %3.3f"%(mumPdg,mMeson)
+    if (mass<mMeson): br = 2*epsilon**2*pow((1-mass**2/mMeson**2),3)*mesonBRtoPhoton(mumPdg,doprint)
+    else: br = 0
+    if (doprint==True): print "Branching ratio of %d meson to DP is %.8g"%(mumPdg,br)
+    return br
+
+def brMesonToMesonDP(mass,epsilon,mumPdg,dauPdg,doprint=False):
+    mMeson = PDG.GetParticle(mumPdg).Mass()
+    mDaughterMeson = PDG.GetParticle(dauPdg).Mass()
+    if (doprint==True): print "Mass of mother %d meson is %3.3f"%(mumPdg,mMeson)
+    if (doprint==True): print "Mass of daughter %d meson is %3.3f"%(dauPdg,mDaughterMeson)
+    fac1 = (mMeson**2-mass**2-mDaughterMeson**2)**2
+    fac2 = ROOT.TMath.Sqrt((mMeson**2-mass**2+mDaughterMeson**2)**2 - 4*mMeson**2*mDaughterMeson**2)
+    fac3 = pow(mMeson**2-mass**2,3)
+    massfactor = fac1*fac2/fac3
+    if (mass<(mMeson-mDaughterMeson)): br = epsilon**2*mesonBRtoPhoton(mumPdg,doprint)*massfactor
+    else: br = 0
+    if (doprint==True): print "Branching ratio of %d meson to DP is %.8g"%(mumPdg,br)
+    return br
+
+def brMesonToDP(mass,epsilon,mumPdg,doprint=False):
+    if mumPdg==223: return brMesonToMesonDP(mass,epsilon,mumPdg,111,doprint)
+    elif (mumPdg==111 or mumPdg==221 or mumPdg==331): return brMesonToGammaDP(mass,epsilon,mumPdg,doprint)
+    else: 
+        print "Warning! Unknown mother pdgId %d, not implemented. Setting br to 0."%mumPdg
+        return 1
+
+def mesonProdRate(mass,epsilon,mumPdg,doprint=False):
+    #print "avgrate %.8g, brmeson %.8g"%(getAverageMesonRate(mumPdg),brMesonToDP(mass,epsilon,mumPdg,doprint))
+    avgMeson = getAverageMesonRate(mumPdg)*brMesonToDP(mass,epsilon,mumPdg,doprint)
+    if doprint==True: print "Average %d meson production rate per p.o.t: %.8g"%(mumPdg,avgMeson)
+    return avgMeson
+
+#from interpolation of Pythia XS, normalised to epsilon^2
+def qcdprodRate(mass,epsilon,doprint=False):
+    xs = 0
+    if (mass > 3):
+        xs = math.exp(-5.673-0.8869*mass)
+    elif (mass > 1.4):
+        xs = math.exp(-3.802-1.532*mass)
+    else:
+        xs = 0.0586-0.09037*mass + 0.0360743*mass*mass
+    return xs*epsilon*epsilon
+
+def getDPprodRate(mass,epsilon,prodMode,mumPdg,doprint=False):
+    if ('pbrem' in prodMode):
+        return pbremProdRate(mass,epsilon,doprint)
+    elif ('meson' in prodMode):
+        return mesonProdRate(mass,epsilon,mumPdg,doprint)
+    elif ('qcd' in prodMode):
+        return qcdprodRate(mass,epsilon,doprint)
+    else:
+        print "Unknown production mode! Choose among pbrem, meson or qcd."
+        return 1
+

--- a/python/proton_bremsstrahlung.py
+++ b/python/proton_bremsstrahlung.py
@@ -16,6 +16,13 @@ def energy(p,m):
     """ Compute energy from momentum and mass """
     return math.sqrt(p*p + m*m)
 
+def penaltyFactor(m):
+    """ Penalty factor for high masses - dipole form factor in the proton-A' vertex """
+    """ m in GeV """
+    if m*m>0.71:
+        return math.pow(m*m/0.71,-4)
+    else:
+        return 1
 
 def zeta(p, theta):
     """ Fraction of the proton momentum carried away by the paraphoton in the beam direction """
@@ -164,8 +171,9 @@ def hProdPDF(mDarkPhoton, epsilon, norm, binsp, binstheta, tmin = -0.5 * math.pi
             hPDFp.Fill(p,w)
     hPdfFilename = sys.modules['__main__'].outputDir+"/ParaPhoton_eps%s_m%s%s.root"%(epsilon,mDarkPhoton,suffix)
     outfile = r.TFile(hPdfFilename,"recreate")
-    weight = hPDF.Integral("width")
-    hPDF.Scale(1./weight)
+    #weight = hPDF.Integral("width")
+    #print "Weight = %3.3f"%weight
+    #hPDF.Scale(1./weight)
     hPDF.Write()
     hPDFp.Write()
     hPDFtheta.Write()

--- a/python/pythia8darkphoton_conf.py
+++ b/python/pythia8darkphoton_conf.py
@@ -100,7 +100,7 @@ def configure(P8gen, mass, epsilon, inclusive, deepCopy=False):
 
     elif inclusive=="qcd":
         P8gen.SetDY()
-        P8gen.SetMinDPMass(0.5)
+        P8gen.SetMinDPMass(0.7)
 
         if (mass<P8gen.MinDPMass()): 
             print "WARNING! Mass is too small, minimum is set to %3.3f GeV."%P8gen.MinDPMass()
@@ -161,10 +161,11 @@ def configure(P8gen, mass, epsilon, inclusive, deepCopy=False):
     else:
         P8gen.SetParameters(str(P8gen.GetDPId())+":new = A A 3 0 0 "+str(mass)+" 0.0 0.0 0.0 "+str(ctau/u.mm)+"  0   1   0   1   0") 
         if debug: cf.write('P8gen.SetParameters("'+str(P8gen.GetDPId())+':new = A A 3 0 0 '+str(mass)+' 0.0 0.0 0.0 '+str(ctau/u.mm)+'  0   1   0   1   0") \n')
-        if (inclusive=="pbrem"): 
-            P8gen.SetParameters(str(P8gen.GetDPId())+":isResonance = true")
-            P8gen.SetParameters(str(P8gen.GetDPId())+":mWidth = "+str(u.hbarc/ctau))
-            P8gen.SetParameters(str(P8gen.GetDPId())+":mMin = 0.001")
+        #if (inclusive=="pbrem"): 
+        ### Do not set as resonance: decays to hadron doesn't work properly below 0.7 GeV.
+        #   P8gen.SetParameters(str(P8gen.GetDPId())+":isResonance = true")
+        #   P8gen.SetParameters(str(P8gen.GetDPId())+":mWidth = "+str(u.hbarc/ctau))
+        #   P8gen.SetParameters(str(P8gen.GetDPId())+":mMin = 0.001")
     
     P8gen.SetParameters("Next:numberCount    =  0")
     if debug: cf.write('P8gen.SetParameters("Next:numberCount    =  0")\n')

--- a/python/readDecayTable.py
+++ b/python/readDecayTable.py
@@ -83,7 +83,7 @@ def addDarkPhotondecayChannels(P8gen,DP,conffile=os.path.expandvars('$FAIRSHIP/p
     - P8gen: an instance of ROOT.HNLPythia8Generator()
     - conffile: a file listing the channels one wishes to activate
     """
-    isResonant = (P8gen.GetDPId()==4900023 or P8gen.IsPbrem())
+    isResonant = (P8gen.GetDPId()==4900023)# or P8gen.IsPbrem())
     # First fetch the list of kinematically allowed decays
     allowed = DP.allowedChannels()
     # Then fetch the list of desired channels to activate
@@ -101,7 +101,7 @@ def addDarkPhotondecayChannels(P8gen,DP,conffile=os.path.expandvars('$FAIRSHIP/p
             BR = DP.findBranchingRatio(dec)
             
             meMode = 0
-            if isResonant: meMode = 102
+            if isResonant: meMode = 103
             if 'hadrons' in dec:
                 #P8gen.SetDecayToHadrons()
                 print "debug readdecay table hadrons BR ",BR


### PR DESCRIPTION
- addition of a python file to calculate overall rates in different DP production modes
- fix in Pythia parameters, to allow proper decay of the DP for masses below 0.7 GeV in pbrem mode. The DP is now declared as non-resonant (there is a hardcoded limit in mass for resonant particles at 0.4 GeV -> OK for QCD, for which the DP has to be a resonance, and which is generated anyway for DP masses above 1.4 GeV.
- For QCD, the decay channels were declared with meMode = 102, but further investigations seem to indicate strange behaviour in the choice of decay channels (substantially more decays to ee,mumu compared to what is hardcoded in the BR given as input), closer to the input values for meMode=103.