### PR TITLE
Option to choose Emulsion Target

### DIFF
--- a/charmdet/Box.h
+++ b/charmdet/Box.h
@@ -32,7 +32,7 @@ public:
     void AddEmulsionFilm(Double_t zposition, Int_t nreplica, TGeoVolume * volTarget, TGeoVolume * volEmulsionFilm, TGeoVolume * volEmulsionFilm2, TGeoVolume * volPlBase); 
   
     void SetTargetDesign(Bool_t Julytarget);
-    void SetRunNumber(Int_t RunNumber);
+    void SetTargetNumber(Int_t CharmTargetNumber);
 
     void SetBrickParam(Double_t BrX, Double_t BrY, Double_t BrZ, Double_t BrPackX, Double_t BrPackY, Double_t BrPackZ);
     void SetEmulsionParam(Double_t EmTh, Double_t EmX, Double_t EmY, Double_t PBTh,Double_t EPlW, Double_t PasSlabTh, Double_t AllPW);
@@ -80,7 +80,7 @@ public:
     Box(const Box&);
     Box& operator=(const Box&);
     
-    ClassDef(Box,1)
+    ClassDef(Box,2)
     
 private:
     
@@ -107,6 +107,7 @@ protected:
     Int_t InitMedium(const char* name);
 
     Bool_t fJulytarget; //Lead ECC vs SHiP ECC
+    Bool_t ch1r6; //special case, CH1 run with a tungsten target
     //Number of the simulated run
     Int_t nrun;
     

--- a/charmdet/README.md
+++ b/charmdet/README.md
@@ -31,12 +31,23 @@ In general:
 Option `--CharmdetSetup 1` activates charm cross section geometry, while
 `--CharmdetSetup 0` activates muon flux geometry.
 
+Option `--CharmTarget ntarget` allows to choose the emulsion target.
+ntarget can assume the following values:
+
+* 1: A brick of 29 emulsions, interleaved with 28 1 mm-thick slabs of lead;
+* 2: 1 passive lead block of 28 mm, followed by a brick of 29 emulsions, interleaved with 28 1 mm-thick slabs of lead;
+* 3: 1 passive lead block of 56 mm, followed by a brick of 57 emulsions, interleaved with 56 1 mm-thick slabs of lead;
+* 4: 2 passive lead blocks of 56 mm, followed by a brick of 57 emulsions, interleaved with 56 1 mm-thick slabs of lead;
+* 5: 3 passive lead blocks of 56 mm, followed by a brick of 57 emulsions, interleaved with 56 1 mm-thick slabs of lead;
+* 6: 4 passive lead blocks of 56 mm, followed by a brick of 57 emulsions, interleaved with 56 1 mm-thick slabs of lead;
+* 16: same as 1, but with tungsten as a material for passive slabs instead of lead (CH1-R6 exposure)
+
 Only the most useful options have been explained here. For the complete list of
 available options please refer to the related scripts.
 
 Charm production simulations are done from `macro/run_simScript.py`. Example
 syntax:  `python $FAIRSHIP/macro/run_simScript.py --charm 1 -A charmonly
---CharmdetSetup 1 -f Cascadefile -n 1000 -o outputfolder`
+--CharmdetSetup 1 --CharmTarget 1 -f Cascadefile -n 1000 -o outputfolder`
 
 Useful options:
 * `--charm 1`: activates `charmdet` configuration instead of SHiP standard (both
@@ -54,7 +65,7 @@ General POT simulations are done from
 `muonShieldOptimization/run_MufluxfixedTarget.py`. Example of syntax:
  
  `python $FAIRSHIP/muonShieldOptimization/run_MufluxfixedTarget.py
- --CharmdetSetup 1 -G -e 0.001 -n 1000 -o outputfolder`
+ --CharmdetSetup 1 --CharmTarget 1 -G -e 0.001 -n 1000 -o outputfolder`
  
  It is a derivation of the fixed target simulation used in SHiP, applied to
  `charmdet` geometry.

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -13,6 +13,9 @@ with ConfigRegistry.register_config("basic") as c:
     if "Setup" not in globals(): #muon flux or charm xsec measurement
       Setup = 0    
 
+    if "cTarget" not in globals():
+      cTarget = 3
+
     if Setup == 0: 
      c.MufluxSpectrometer.muflux = True
     else: 
@@ -99,7 +102,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.Box.gausbeam = True
     c.Box.Julytarget = True
     c.Box.GapPostTargetTh = 0.73 * u.cm #distance between end of the emulsion target and start of pixel box (Pixel origin)     
-    c.Box.RunNumber =  3 #run configuration for charm
+    c.Box.CharmTargetNumber =  cTarget #run configuration for charm
 
     # target absorber muon shield setup, decayVolume.length = nominal EOI length, only kept to define z=0
     c.decayVolume            =  AttrDict(z=0*u.cm)

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -239,7 +239,11 @@ if charm == 0: ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_con
 else: 
  ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = CharmdetSetup, cTarget = CharmTarget)
  if CharmdetSetup == 0: print "Setup for muon flux measurement has been set"
- else: print "Setup for charm cross section measurement has been set"
+ else: 
+  print "Setup for charm cross section measurement has been set"
+  if (((CharmTarget > 6) or (CharmTarget < 0)) and (CharmTarget != 16)): #check if proper option for emulsion target has been set
+   print "ERROR: unavailable option for CharmTarget. Currently implemented options: 1,2,3,4,5,6,16"
+   1/0
 # switch off magnetic field to measure muon flux
 #ship_geo.muShield.Field = 0.
 #ship_geo.EmuMagnet.B = 0.

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -13,6 +13,7 @@ debug = 0  # 1 print weights and field
 dryrun = False # True: just setup Pythia and exit
 
 CharmdetSetup = 0 # 1 charm cross section setup, 0 muon flux setup
+CharmTarget = 3 #six different configurations used in July 2018 exposure for charm
 # Default HNL parameters
 theMass = 1.0*u.GeV
 theCouplings = [0.447e-9, 7.15e-9, 1.88e-9] # ctau=53.3km  TP default for HNL
@@ -74,8 +75,8 @@ try:
                                    "PG","pID=","Muflux","Pythia6","Pythia8","Genie","MuDIS","Ntuple","Nuage","MuonBack","FollowMuon","FastMuon",\
                                    "Cosmics=","nEvents=", "display", "seed=", "firstEvent=", "phiRandom", "mass=", "couplings=", "coupling=", "epsilon=",\
                                    "output=","tankDesign=","muShieldDesign=","NuRadio","test",\
-                                   "DarkPhoton","RpvSusy","SusyBench=","sameSeed=","charm=","CharmdetSetup=","nuTauTargetDesign=","caloDesign=","strawDesign=","Estart=","Eend=",\
-                                   "production-couplings=","decay-couplings=","dry-run"])
+                                   "DarkPhoton","RpvSusy","SusyBench=","sameSeed=","charm=","CharmdetSetup=","CharmTarget=","nuTauTargetDesign=","caloDesign=","strawDesign=","Estart=",\
+                                   "Eend=","production-couplings=","decay-couplings=","dry-run"])
 
 except getopt.GetoptError:
         # print help information and exit:
@@ -179,6 +180,8 @@ for o, a in opts:
             charm = int(a)
         if o in ("--CharmdetSetup",):
             CharmdetSetup = int(a)
+        if o in ("--CharmTarget",):
+            CharmTarget = int(a)
         if o in ("-F",):
             deepCopy = True
         if o in ("--RpvSusy",):
@@ -234,7 +237,7 @@ shipRoot_conf.configure(0)     # load basic libraries, prepare atexit for python
 if charm == 0: ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_config.py", Yheight = dy, tankDesign = dv, \
                                                 muShieldDesign = ds, nuTauTargetDesign=nud, CaloDesign=caloDesign, strawDesign=strawDesign, muShieldGeo=geofile)
 else: 
- ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = CharmdetSetup)
+ ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = CharmdetSetup, cTarget = CharmTarget)
  if CharmdetSetup == 0: print "Setup for muon flux measurement has been set"
  else: print "Setup for charm cross section measurement has been set"
 # switch off magnetic field to measure muon flux

--- a/muonShieldOptimization/run_MufluxfixedTarget.py
+++ b/muonShieldOptimization/run_MufluxfixedTarget.py
@@ -67,6 +67,7 @@ def init():
   ap.add_argument('-d', '--debug', action='store_true', dest='debug')
   ap.add_argument('-f', '--force', action='store_true', help="force overwriting output directory")
   ap.add_argument('-cs', '--CharmdetSetup', type=int, dest='CharmdetSetup',help="setting detector setup", default=0)
+  ap.add_argument('-ct', '--CharmTarget', type=int, dest='CharmTarget',help="choosing target configuration for charm exposure", default=1)
   ap.add_argument('-r', '--run-number', type=int, dest='runnr', default=runnr)
   ap.add_argument('-e', '--ecut', type=float, help="energy cut", dest='ecut', default=ecut)
   ap.add_argument('-n', '--num-events', type=int, help="number of events to generate", dest='nev', default=nev)
@@ -148,7 +149,7 @@ os.chdir(work_dir)
 ROOT.gRandom.SetSeed(theSeed)  # this should be propagated via ROOT to Pythia8 and Geant4VMC
 shipRoot_conf.configure()      # load basic libraries, prepare atexit for python
 #this is for the muon flux geometry
-ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = args.CharmdetSetup)
+ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = args.CharmdetSetup, cTarget = args.CharmTarget)
 
 txt = 'pythia8_Geant4_'
 if withEvtGen: txt = 'pythia8_evtgen_Geant4_'

--- a/muonShieldOptimization/run_MufluxfixedTarget.py
+++ b/muonShieldOptimization/run_MufluxfixedTarget.py
@@ -67,7 +67,7 @@ def init():
   ap.add_argument('-d', '--debug', action='store_true', dest='debug')
   ap.add_argument('-f', '--force', action='store_true', help="force overwriting output directory")
   ap.add_argument('-cs', '--CharmdetSetup', type=int, dest='CharmdetSetup',help="setting detector setup", default=0)
-  ap.add_argument('-ct', '--CharmTarget', type=int, dest='CharmTarget',help="choosing target configuration for charm exposure", default=1)
+  ap.add_argument('-ct', '--CharmTarget', type=int, dest='CharmTarget',help="choosing target configuration for charm exposure", default=3)
   ap.add_argument('-r', '--run-number', type=int, dest='runnr', default=runnr)
   ap.add_argument('-e', '--ecut', type=float, help="energy cut", dest='ecut', default=ecut)
   ap.add_argument('-n', '--num-events', type=int, help="number of events to generate", dest='nev', default=nev)

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -39,9 +39,7 @@ def configure(run,ship_geo):
  Box.SetCoatingParam(ship_geo.Box.CoatX, ship_geo.Box.CoatY, ship_geo.Box.CoatZ)
  Box.SetGapGeometry(ship_geo.Box.distancePassive2ECC)
  Box.SetTargetDesign(ship_geo.Box.Julytarget)
- Box.SetRunNumber(ship_geo.Box.RunNumber)
- 
-
+ Box.SetTargetNumber(ship_geo.Box.CharmTargetNumber)
 
  if (ship_geo.MufluxSpectrometer.muflux==False): 
     PixelModules = ROOT.PixelModules("PixelModules",ship_geo.PixelModules.DX, ship_geo.PixelModules.DY, ship_geo.PixelModules.DZ,ROOT.kTRUE)


### PR DESCRIPTION
Dear all,

I have added an option --CharmTarget to choose the emulsion target to be used in the charm and pot simulations in the geometry used on July 2018. Thus, the user is not forced to change the geometry configuration file every time.
 
The option uses the naming scheme we commonly refer to for the emulsion target configurations:
1-6: from CH1 to CH6, increasing thickness of lead slabs.
16: same thickness of CH1, but with tungsten instead of lead as passive material. This allows to simulate the material of  CH1-R6 exposure.

Finally, I have also changed the detectorID for one of the two layers of each emulsion film. Until now, the two volumes of each pair had the same ID, making them identical for the analysis without resorting to the geometry file information.

Best regards,
Antonio


