### PR TITLE
Fix of compatibility issue of CharmTarget option

### DIFF
--- a/charmdet/Box.cxx
+++ b/charmdet/Box.cxx
@@ -164,9 +164,9 @@ void Box::SetTargetDesign(Bool_t Julytarget){
   fJulytarget = Julytarget;
 }
 
-void Box::SetTargetNumber(Int_t CharmTargetNumber){		
-  nrun = CharmTargetNumber;
-  if (CharmTargetNumber==16){ //special case, CH1 run with a tungsten target
+void Box::SetRunNumber(Int_t RunNumber){		
+  nrun = RunNumber;
+  if (RunNumber==16){ //special case, CH1 run with a tungsten target
     nrun = 1;
     ch1r6 = true;
   }		

--- a/charmdet/Box.h
+++ b/charmdet/Box.h
@@ -32,7 +32,7 @@ public:
     void AddEmulsionFilm(Double_t zposition, Int_t nreplica, TGeoVolume * volTarget, TGeoVolume * volEmulsionFilm, TGeoVolume * volEmulsionFilm2, TGeoVolume * volPlBase); 
   
     void SetTargetDesign(Bool_t Julytarget);
-    void SetTargetNumber(Int_t CharmTargetNumber);
+    void SetRunNumber(Int_t RunNumber);
 
     void SetBrickParam(Double_t BrX, Double_t BrY, Double_t BrZ, Double_t BrPackX, Double_t BrPackY, Double_t BrPackZ);
     void SetEmulsionParam(Double_t EmTh, Double_t EmX, Double_t EmY, Double_t PBTh,Double_t EPlW, Double_t PasSlabTh, Double_t AllPW);
@@ -80,7 +80,7 @@ public:
     Box(const Box&);
     Box& operator=(const Box&);
     
-    ClassDef(Box,2)
+    ClassDef(Box,3)
     
 private:
     

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -102,7 +102,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.Box.gausbeam = True
     c.Box.Julytarget = True
     c.Box.GapPostTargetTh = 0.73 * u.cm #distance between end of the emulsion target and start of pixel box (Pixel origin)     
-    c.Box.CharmTargetNumber =  cTarget #run configuration for charm
+    c.Box.RunNumber =  cTarget #run configuration for charm
 
     # target absorber muon shield setup, decayVolume.length = nominal EOI length, only kept to define z=0
     c.decayVolume            =  AttrDict(z=0*u.cm)

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -39,7 +39,7 @@ def configure(run,ship_geo):
  Box.SetCoatingParam(ship_geo.Box.CoatX, ship_geo.Box.CoatY, ship_geo.Box.CoatZ)
  Box.SetGapGeometry(ship_geo.Box.distancePassive2ECC)
  Box.SetTargetDesign(ship_geo.Box.Julytarget)
- Box.SetTargetNumber(ship_geo.Box.CharmTargetNumber)
+ Box.SetRunNumber(ship_geo.Box.RunNumber)
 
  if (ship_geo.MufluxSpectrometer.muflux==False): 
 # === SciFi modules

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -29,19 +29,21 @@ def configure(run,ship_geo):
  cave.SetGeometryFileName("caveWithAir.geo")
  detectorList.append(cave)
     
- Box = ROOT.Box("Box",ship_geo.Box.BrX, ship_geo.Box.BrY, ship_geo.Box.BrZ, ship_geo.Box.zBox,ROOT.kTRUE)
- Box.SetEmulsionParam(ship_geo.Box.EmTh, ship_geo.Box.EmX, ship_geo.Box.EmY, ship_geo.Box.PBTh,ship_geo.Box.EPlW, ship_geo.Box.PasSlabTh, ship_geo.Box.AllPW);
- Box.SetBrickParam(ship_geo.Box.BrX, ship_geo.Box.BrY, ship_geo.Box.BrZ, ship_geo.Box.BrPackX, ship_geo.Box.BrPackY, ship_geo.Box.BrPackZ);
- Box.SetTargetParam(ship_geo.Box.TX, ship_geo.Box.TY, ship_geo.Box.TZ);
- Box.SetPassiveComposition(ship_geo.Box.Molblock1Z, ship_geo.Box.Molblock2Z, ship_geo.Box.Molblock3Z, ship_geo.Box.Molblock4Z, ship_geo.Box.Wblock1Z, ship_geo.Box.Wblock2Z, ship_geo.Box.Wblock3Z, ship_geo.Box.Wblock3_5Z, ship_geo.Box.Wblock4Z)
- Box.SetPassiveSampling(ship_geo.Box.Passive3mmZ, ship_geo.Box.Passive2mmZ, ship_geo.Box.Passive1mmZ)
- Box.SetCoolingParam(ship_geo.Box.CoolX, ship_geo.Box.CoolY, ship_geo.Box.CoolZ)
- Box.SetCoatingParam(ship_geo.Box.CoatX, ship_geo.Box.CoatY, ship_geo.Box.CoatZ)
- Box.SetGapGeometry(ship_geo.Box.distancePassive2ECC)
- Box.SetTargetDesign(ship_geo.Box.Julytarget)
- Box.SetRunNumber(ship_geo.Box.RunNumber)
 
- if (ship_geo.MufluxSpectrometer.muflux==False): 
+ if (ship_geo.MufluxSpectrometer.muflux==False):
+# === Emulsion Target 
+    Box = ROOT.Box("Box",ship_geo.Box.BrX, ship_geo.Box.BrY, ship_geo.Box.BrZ, ship_geo.Box.zBox,ROOT.kTRUE)
+    Box.SetEmulsionParam(ship_geo.Box.EmTh, ship_geo.Box.EmX, ship_geo.Box.EmY, ship_geo.Box.PBTh,ship_geo.Box.EPlW, ship_geo.Box.PasSlabTh, ship_geo.Box.AllPW);
+    Box.SetBrickParam(ship_geo.Box.BrX, ship_geo.Box.BrY, ship_geo.Box.BrZ, ship_geo.Box.BrPackX, ship_geo.Box.BrPackY, ship_geo.Box.BrPackZ);
+    Box.SetTargetParam(ship_geo.Box.TX, ship_geo.Box.TY, ship_geo.Box.TZ);
+    Box.SetPassiveComposition(ship_geo.Box.Molblock1Z, ship_geo.Box.Molblock2Z, ship_geo.Box.Molblock3Z, ship_geo.Box.Molblock4Z, ship_geo.Box.Wblock1Z, ship_geo.Box.Wblock2Z, ship_geo.Box.Wblock3Z, ship_geo.Box.Wblock3_5Z, ship_geo.Box.Wblock4Z)
+    Box.SetPassiveSampling(ship_geo.Box.Passive3mmZ, ship_geo.Box.Passive2mmZ, ship_geo.Box.Passive1mmZ)
+    Box.SetCoolingParam(ship_geo.Box.CoolX, ship_geo.Box.CoolY, ship_geo.Box.CoolZ)
+    Box.SetCoatingParam(ship_geo.Box.CoatX, ship_geo.Box.CoatY, ship_geo.Box.CoatZ)
+    Box.SetGapGeometry(ship_geo.Box.distancePassive2ECC)
+    Box.SetTargetDesign(ship_geo.Box.Julytarget)
+    Box.SetRunNumber(ship_geo.Box.RunNumber)
+    detectorList.append(Box)
 # === SciFi modules
     SciFi = ROOT.SciFi("SciFi",ship_geo.SciFi.DX, ship_geo.SciFi.DY, ship_geo.SciFi.DZ,ROOT.kTRUE)
     SciFi.SetBoxParam(ship_geo.SciFi.DX,ship_geo.SciFi.DY,ship_geo.SciFi.DZ, ship_geo.SciFi.zBox)
@@ -53,8 +55,6 @@ def configure(run,ship_geo):
     PixelModules = ROOT.PixelModules("PixelModules",ship_geo.PixelModules.DX, ship_geo.PixelModules.DY, ship_geo.PixelModules.DZ,ROOT.kTRUE)
     PixelModules.SetBoxParam(ship_geo.PixelModules.DX,ship_geo.PixelModules.DY,ship_geo.PixelModules.DZ, ship_geo.PixelModules.zBox, ship_geo.PixelModules.DimZpixelbox, ship_geo.PixelModules.D1short, ship_geo.PixelModules.D1long)
     PixelModules.SetSiliconDZ(ship_geo.PixelModules.DimZSi)
-# === Box
-    detectorList.append(Box)
 # === SciFi modules
     detectorList.append(SciFi)
 # === Pixel modules


### PR DESCRIPTION
Dear all,

in the recent CharmTarget commit I have done the error of changing a name of a method, thus ruining backward compatibility with previous simulations. 

I am truly sorry for the inconvenience, and this patch should fix it. Also, since Box class is not used in the MuonFlux configuration, I propose to call its methods only for the Charmdet configuration. This should avoid future conflicts between the two configurations.

Best regards,
Antonio