### PR TITLE
changing default value of variable ConstField, as pointed by Thomas

### DIFF
--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -148,7 +148,7 @@ def addVMCFields(shipGeo, controlFile = '', verbose = False, withVirtualMC = Tru
     if hasattr(shipGeo, 'Bfield'):
       fieldMaker.defineFieldMap('MainSpecMap', 'files/MainSpectrometerField.root',
                                 ROOT.TVector3(0.0, 0.0, shipGeo.Bfield.z))      
-      withConstFieldNuTauDet = False
+      withConstFieldNuTauDet = True
       if hasattr(shipGeo.EmuMagnet,'WithConstField'): withConstFieldNuTauDet = shipGeo.EmuMagnet.WithConstField
       if not withConstFieldNuTauDet:
        fieldMaker.defineFieldMap('NuMap','files/nuTauDetField.root', ROOT.TVector3(0.0,0.0,shipGeo.EmuMagnet.zC))       


### PR DESCRIPTION
Dear all,

Thomas noticed a logical incongruency in the default value of the option which chooses between the field map and the constant field option.

If no map is present, the default value is taken, therefore it should be the value for constant (in the sense of uniform) magnetic field.

This modification should change nothing in current simulations, where the field map is present.

Best regards,
Antonio
