### PR TITLE
All Pixel Modules Sliced in preparation for Digitization

### DIFF
--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -143,9 +143,14 @@ void PixelModules::SetSiliconStationAngles(Int_t nstation, Double_t anglex, Doub
  zangle[nstation] = anglez;
 }
 
+void PixelModules::SetSiliconSlicesNumber(Int_t nSl)
+{
+nSlices=nSl;
+}
 
-
-
+void PixelModules::ComputeDimZSlice(){
+DimZSlice=DimZSi/nSlices;
+}
 
 
 //
@@ -187,20 +192,55 @@ void PixelModules::ConstructGeometry()
     top->AddNode(volPixelBox, 1, new TGeoTranslation(0,0,zBoxPosition+ inimodZoffset)); //volume moved in
     
 
-    TGeoBBox *Pixely = new TGeoBBox("Pixely", Dim1Short/2, Dim1Long/2, DimZSi/2); //long along y
+    TGeoBBox *Pixely = new TGeoBBox("Pixely", Dim1Short/2, Dim1Long/2, DimZSlice/2); //long along y
     TGeoVolume *volPixely = new TGeoVolume("volPixely",Pixely,Silicon); 
     volPixely->SetLineColor(kBlue-5);
     AddSensitiveVolume(volPixely);
 
-    TGeoBBox *Pixelx = new TGeoBBox("Pixelx", (Dim1Long)/2, (Dim1Short)/2, DimZSi/2); //long along x
+    TGeoBBox *Pixelx = new TGeoBBox("Pixelx", (Dim1Long)/2, (Dim1Short)/2, DimZSlice/2); //long along x
     TGeoVolume *volPixelx = new TGeoVolume("volPixelx",Pixelx,Silicon); 
     volPixelx->SetLineColor(kBlue-5);
     AddSensitiveVolume(volPixelx);
 
     //id convention: 1{a}{b}, a = number of pair (from 1 to 6), b = element of the pair (1 or 2)
-    Int_t PixelIDlist[nSi] = {111,112,121,122,131,132,141,142,151,1520,1521,1522,1523,1524,1525,1526,1527,1528,1529,161,162}; 
+    int chi=0;
+    Int_t PixelIDlist[nSi];
+    for(int i=1110;i<1130;i++){
+    PixelIDlist[chi]=i;
+    chi++;
+    }
+    
+    for(int i=1210;i<1230;i++){
+    PixelIDlist[chi]=i;
+    chi++;
+    }
+
+    for(int i=1310;i<1330;i++){
+    PixelIDlist[chi]=i;
+    chi++;
+    }
+    for(int i=1410;i<1430;i++){
+    PixelIDlist[chi]=i;
+    chi++;
+    }
+    for(int i=1510;i<1530;i++){
+    PixelIDlist[chi]=i;
+    chi++;
+    }
+    for(int i=1610;i<1630;i++){
+    PixelIDlist[chi]=i;
+    chi++;
+    }
     //Alternated pixel stations optimized for y and x measurements
-    Bool_t vertical[nSi] = {kTRUE,kTRUE,kFALSE,kFALSE,kTRUE,kTRUE,kFALSE,kFALSE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kFALSE,kFALSE}; 
+    Bool_t vertical[nSi];
+    for(int i=0;i<nSi;i++){
+	vertical[i]=kFALSE;
+	}
+    for(int i=0;i<3;i++){
+    	for(int j =0;j<20;j++){
+	vertical[i*40+j]=kTRUE;
+	}
+    }
 
     for (int ipixel = 0; ipixel < nSi; ipixel++){
       if (vertical[ipixel]) volPixelBox->AddNode(volPixely, PixelIDlist[ipixel], new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset)); //compensation for the Node offset

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -49,6 +49,7 @@ using namespace ShipUnit;
 
 PixelModules::PixelModules()
   : FairDetector("HighPrecisionTrackers",kTRUE, kPixelModules),
+    numSi(nSi),
     fTrackID(-1),
     fPdgCode(),
     fVolumeID(-1),
@@ -63,6 +64,7 @@ PixelModules::PixelModules()
 
 PixelModules::PixelModules(const char* name, const Double_t DX, const Double_t DY, const Double_t DZ, Bool_t Active,const char* Title)
   : FairDetector(name, Active, kPixelModules),
+    numSi(nSi),
     fTrackID(-1),
     fPdgCode(),
     fVolumeID(-1),

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -143,11 +143,6 @@ void PixelModules::SetSiliconStationAngles(Int_t nstation, Double_t anglex, Doub
  zangle[nstation] = anglez;
 }
 
-void PixelModules::SetSiliconDetNumber(Int_t nSilicon)
-{
- nSi = nSilicon;
-}
-
 
 
 
@@ -181,7 +176,7 @@ void PixelModules::ConstructGeometry()
 
     //computing the largest offsets in order to set PixelBox dimensions correctly
     Double_t offsetxmax = 0., offsetymax = 0.;
-    for (int istation = 0; istation < 12; istation++){
+    for (int istation = 0; istation < nSi; istation++){
      if (TMath::Abs(xs[istation]) > offsetxmax) offsetxmax = TMath::Abs(xs[istation]);
      if (TMath::Abs(ys[istation]) > offsetymax) offsetymax = TMath::Abs(ys[istation]);
     }
@@ -203,11 +198,11 @@ void PixelModules::ConstructGeometry()
     AddSensitiveVolume(volPixelx);
 
     //id convention: 1{a}{b}, a = number of pair (from 1 to 6), b = element of the pair (1 or 2)
-    Int_t PixelIDlist[12] = {111,112,121,122,131,132,141,142,151,152,161,162}; 
+    Int_t PixelIDlist[nSi] = {111,112,121,122,131,132,141,142,151,1520,1521,1522,1523,1524,1525,1526,1527,1528,1529,161,162}; 
     //Alternated pixel stations optimized for y and x measurements
-    Bool_t vertical[12] = {kTRUE,kTRUE,kFALSE,kFALSE,kTRUE,kTRUE,kFALSE,kFALSE,kTRUE,kTRUE,kFALSE,kFALSE}; 
+    Bool_t vertical[nSi] = {kTRUE,kTRUE,kFALSE,kFALSE,kTRUE,kTRUE,kFALSE,kFALSE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kTRUE,kFALSE,kFALSE}; 
 
-    for (int ipixel = 0; ipixel < 12; ipixel++){
+    for (int ipixel = 0; ipixel < nSi; ipixel++){
       if (vertical[ipixel]) volPixelBox->AddNode(volPixely, PixelIDlist[ipixel], new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset)); //compensation for the Node offset
       else volPixelBox->AddNode(volPixelx, PixelIDlist[ipixel], new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset));
     }

--- a/charmdet/PixelModules.h
+++ b/charmdet/PixelModules.h
@@ -117,6 +117,7 @@ protected:
     Double_t DimZPixelBox;
 
     static const Int_t nSi=120;
+    Int_t numSi;
     Double_t DimZSi;
     Double_t DimZSlice;
     Double_t xs[nSi], ys[nSi], zs[nSi];

--- a/charmdet/PixelModules.h
+++ b/charmdet/PixelModules.h
@@ -115,11 +115,11 @@ protected:
     Double_t overlap;
     Double_t DimZPixelBox;
 
-    Int_t nSi;
+    static const Int_t nSi=21;
     Double_t DimZSi;
 
-    Double_t xs[12], ys[12], zs[12];
-    Double_t xangle[12], yangle[12], zangle[12];
+    Double_t xs[nSi], ys[nSi], zs[nSi];
+    Double_t xangle[nSi], yangle[nSi], zangle[nSi];
     
     PixelModules(const PixelModules&);
     PixelModules& operator=(const PixelModules&);

--- a/charmdet/PixelModules.h
+++ b/charmdet/PixelModules.h
@@ -29,7 +29,8 @@ class PixelModules:public FairDetector
     void SetSiliconStationPositions(Int_t nstation, Double_t posx, Double_t posy, Double_t posz);
     void SetSiliconStationAngles(Int_t nstation, Double_t anglex, Double_t angley, Double_t anglez);
     void SetSiliconDetNumber(Int_t nSilicon);
-     
+    void SetSiliconSlicesNumber(Int_t nSl);
+    void ComputeDimZSlice();
     /**      Initialization of the detector is done here    */
     virtual void Initialize();
     
@@ -85,6 +86,7 @@ private:
     Double32_t     fTime;              //!  time
     Double32_t     fLength;            //!  length
     Double32_t     fELoss;             //!  energy loss
+    Int_t nSlices; 
     
     /** container for data points */
     TClonesArray*  fPixelModulesPointCollection;
@@ -97,7 +99,6 @@ protected:
     
     Double_t Dim1Short, Dim1Long;
  
-    
     Double_t SBoxX = 0;
     Double_t SBoxY = 0;
     Double_t SBoxZ = 0;
@@ -115,9 +116,9 @@ protected:
     Double_t overlap;
     Double_t DimZPixelBox;
 
-    static const Int_t nSi=21;
+    static const Int_t nSi=120;
     Double_t DimZSi;
-
+    Double_t DimZSlice;
     Double_t xs[nSi], ys[nSi], zs[nSi];
     Double_t xangle[nSi], yangle[nSi], zangle[nSi];
     

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -330,7 +330,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.PixelModules.nSlice= 10
     c.PixelModules.D1short = 3.36 * u.cm / 2.
     c.PixelModules.D1long = 4 * u.cm
-    c.PixelModules.numSi=12*c.PixelModules.nSlice
+    c.PixelModules.numSi=12*c.PixelModules.nSlice #is identical to nSi in the class, can't reuse nSi because no non-static arrays size
     
 
     #position of module centres units are cm. Geometry is given with reference to the centre of all modules for the xy plane and the front of the pixel box for the z axis, precision is given to the micron range

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -326,67 +326,80 @@ with ConfigRegistry.register_config("basic") as c:
     c.Spectrometer.D1Long = 4 * u.cm;
     c.Spectrometer.SX = c.Spectrometer.DX
     c.Spectrometer.SY = c.Spectrometer.DY
-    c.PixelModules.DimZSi = 0.00200 * u.cm
+    c.PixelModules.DimZSi = 0.0200 * u.cm
+    c.PixelModules.nSlice= 10
     c.PixelModules.D1short = 3.36 * u.cm / 2.
     c.PixelModules.D1long = 4 * u.cm
-
+    
 
     #position of module centres units are cm. Geometry is given with reference to the centre of all modules for the xy plane and the front of the pixel box for the z axis, precision is given to the micron range
-    #module position naming: "axis"Si"Telescope number"
+    #module position naming: "axis"Si"Module number"
     
 		#measured values
     c.PixelModules.xSi = []
     c.PixelModules.ySi = []
     c.PixelModules.zSi = []
-    #Module 0
-    c.PixelModules.xSi.append(1.53912)
-    c.PixelModules.ySi.append(-0.002332)
-    c.PixelModules.zSi.append(-0.13)
-    #Module 1
-    c.PixelModules.xSi.append(-0.229076)
-    c.PixelModules.ySi.append(0.005328)
-    c.PixelModules.zSi.append(0.52)
-    #Module 2
-    c.PixelModules.xSi.append(0.704924)
-    c.PixelModules.ySi.append(0.808437)
-    c.PixelModules.zSi.append(2.412)
-    #Module 3
-    c.PixelModules.xSi.append(0.705433)
-    c.PixelModules.ySi.append(-0.879224)
-    c.PixelModules.zSi.append(3.09)
-    #Module 4 (Didn't work)
-    c.PixelModules.xSi.append(1.54963)
-    c.PixelModules.ySi.append(-0.003912)
-    c.PixelModules.zSi.append(5.17)
-    #Module 5
-    c.PixelModules.xSi.append(-0.221577)
-    c.PixelModules.ySi.append(-0.023944)
-    c.PixelModules.zSi.append(5.79)
-    #Module 6
-    c.PixelModules.xSi.append(0.690749)
-    c.PixelModules.ySi.append(0.769728)
-    c.PixelModules.zSi.append(7.77)
-    #Module 7
-    c.PixelModules.xSi.append(0.702302)
-    c.PixelModules.ySi.append(-0.874356)
-    c.PixelModules.zSi.append(8.46)
-    #Module 8
-    c.PixelModules.xSi.append(1.58271)
-    c.PixelModules.ySi.append(-0.0030432)
-    c.PixelModules.zSi.append(10.462)
-    #Module 9
-    for i in range(-5,5):
+    	#Module 0
+    for i in range(10):
+    	c.PixelModules.xSi.append(1.53912)
+    	c.PixelModules.ySi.append(-0.002332)
+    	#c.PixelModules.zSi.append(-0.13+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	c.PixelModules.zSi.append(-0.13+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 1
+    for i in range(10):
+    	c.PixelModules.xSi.append(-0.229076)
+    	c.PixelModules.ySi.append(0.005328)
+    	c.PixelModules.zSi.append(0.52+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 2
+    for i in range(10):
+    	c.PixelModules.xSi.append(0.704924)
+    	c.PixelModules.ySi.append(0.808437)
+    	c.PixelModules.zSi.append(2.412+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 3
+    for i in range(10):
+    	c.PixelModules.xSi.append(0.705433)
+    	c.PixelModules.ySi.append(-0.879224)
+    	c.PixelModules.zSi.append(3.09+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 4 (Didn't work)
+    for i in range(10):
+    	c.PixelModules.xSi.append(1.54963)
+    	c.PixelModules.ySi.append(-0.003912)
+    	c.PixelModules.zSi.append(5.17+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 5
+    for i in range(10):
+    	c.PixelModules.xSi.append(-0.221577)
+    	c.PixelModules.ySi.append(-0.023944)
+    	c.PixelModules.zSi.append(5.79+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 6
+    for i in range(10):
+    	c.PixelModules.xSi.append(0.690749)
+    	c.PixelModules.ySi.append(0.769728)
+    	c.PixelModules.zSi.append(7.77+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 7
+    for i in range(10):
+    	c.PixelModules.xSi.append(0.702302)
+    	c.PixelModules.ySi.append(-0.874356)
+    	c.PixelModules.zSi.append(8.46+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 8
+    for i in range(10):
+    	c.PixelModules.xSi.append(1.58271)
+    	c.PixelModules.ySi.append(-0.0030432)
+    	c.PixelModules.zSi.append(10.462+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 9
+    for i in range(10):
 	    c.PixelModules.xSi.append(-0.209171)
 	    c.PixelModules.ySi.append(0.002488)
-	    c.PixelModules.zSi.append(11.17+i*c.PixelModules.DimZSi)
-    #Module 10
-    c.PixelModules.xSi.append(0.694199)
-    c.PixelModules.ySi.append(0.850237)
-    c.PixelModules.zSi.append(13.162)
-    #Module 11
-    c.PixelModules.xSi.append(0.683245)
-    c.PixelModules.ySi.append(-0.79636)
-    c.PixelModules.zSi.append(13.85)
+	    c.PixelModules.zSi.append(11.16+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 10
+    for i in range(10):
+    	c.PixelModules.xSi.append(0.694199)
+    	c.PixelModules.ySi.append(0.850237)
+    	c.PixelModules.zSi.append(13.162+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    	#Module 11
+    for i in range(10):
+    	c.PixelModules.xSi.append(0.683245)
+    	c.PixelModules.ySi.append(-0.79636)
+    	c.PixelModules.zSi.append(13.85+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
 
     #SciFi Modules
     c.SciFi = AttrDict(z = 0*u.cm)

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -330,6 +330,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.PixelModules.nSlice= 10
     c.PixelModules.D1short = 3.36 * u.cm / 2.
     c.PixelModules.D1long = 4 * u.cm
+    c.PixelModules.numSi=12*c.PixelModules.nSlice
     
 
     #position of module centres units are cm. Geometry is given with reference to the centre of all modules for the xy plane and the front of the pixel box for the z axis, precision is given to the micron range
@@ -464,9 +465,9 @@ with ConfigRegistry.register_config("basic") as c:
     #c.Scintillator.DistT2              = 135.25*u.cm
     c.Scintillator.DistT2              = 136.26*u.cm 
                   
-    c.Spectrometer.SZ = c.Spectrometer.DZ*2 + c.PixelModules.zSi[11] - c.PixelModules.zSi[0] + c.PixelModules.DimZSi + 80 *u.cm + 4.5*u.m #4.5 m is the Goliath length
+    c.Spectrometer.SZ = c.Spectrometer.DZ*2 + c.PixelModules.zSi[c.PixelModules.numSi-1] - c.PixelModules.zSi[0] + c.PixelModules.DimZSi + 80 *u.cm + 4.5*u.m #4.5 m is the Goliath length
    
-    c.PixelModules.DimZpixelbox = c.PixelModules.zSi[11] - c.PixelModules.zSi[0] + c.PixelModules.DimZSi    
+    c.PixelModules.DimZpixelbox = c.PixelModules.zSi[c.PixelModules.numSi-1] - c.PixelModules.zSi[0] + c.PixelModules.DimZSi    
 
     PixeltoGoliath = 30.45 *u.cm #25.45 + 5cm different goliath dz
     c.Spectrometer.zBox = 350.75 - c.Spectrometer.TS/2 - PixeltoGoliath - c.PixelModules.DimZpixelbox/2.

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -341,63 +341,62 @@ with ConfigRegistry.register_config("basic") as c:
     c.PixelModules.ySi = []
     c.PixelModules.zSi = []
     	#Module 0
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(1.53912)
     	c.PixelModules.ySi.append(-0.002332)
-    	#c.PixelModules.zSi.append(-0.13+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	c.PixelModules.zSi.append(-0.13+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 1
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(-0.229076)
     	c.PixelModules.ySi.append(0.005328)
     	c.PixelModules.zSi.append(0.52+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 2
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(0.704924)
     	c.PixelModules.ySi.append(0.808437)
     	c.PixelModules.zSi.append(2.412+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 3
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(0.705433)
     	c.PixelModules.ySi.append(-0.879224)
     	c.PixelModules.zSi.append(3.09+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 4 (Didn't work)
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(1.54963)
     	c.PixelModules.ySi.append(-0.003912)
     	c.PixelModules.zSi.append(5.17+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 5
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(-0.221577)
     	c.PixelModules.ySi.append(-0.023944)
     	c.PixelModules.zSi.append(5.79+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 6
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(0.690749)
     	c.PixelModules.ySi.append(0.769728)
     	c.PixelModules.zSi.append(7.77+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 7
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(0.702302)
     	c.PixelModules.ySi.append(-0.874356)
     	c.PixelModules.zSi.append(8.46+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 8
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(1.58271)
     	c.PixelModules.ySi.append(-0.0030432)
     	c.PixelModules.zSi.append(10.462+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 9
-    for i in range(10):
-	    c.PixelModules.xSi.append(-0.209171)
-	    c.PixelModules.ySi.append(0.002488)
-	    c.PixelModules.zSi.append(11.16+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
+    for i in range(-9,1):
+	c.PixelModules.xSi.append(-0.209171)
+	c.PixelModules.ySi.append(0.002488)
+	c.PixelModules.zSi.append(11.16+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 10
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(0.694199)
     	c.PixelModules.ySi.append(0.850237)
     	c.PixelModules.zSi.append(13.162+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
     	#Module 11
-    for i in range(10):
+    for i in range(-9,1):
     	c.PixelModules.xSi.append(0.683245)
     	c.PixelModules.ySi.append(-0.79636)
     	c.PixelModules.zSi.append(13.85+i*c.PixelModules.DimZSi/c.PixelModules.nSlice)
@@ -465,9 +464,9 @@ with ConfigRegistry.register_config("basic") as c:
     #c.Scintillator.DistT2              = 135.25*u.cm
     c.Scintillator.DistT2              = 136.26*u.cm 
                   
-    c.Spectrometer.SZ = c.Spectrometer.DZ*2 + c.PixelModules.zSi[c.PixelModules.numSi-1] - c.PixelModules.zSi[0] + c.PixelModules.DimZSi + 80 *u.cm + 4.5*u.m #4.5 m is the Goliath length
+    c.Spectrometer.SZ = c.Spectrometer.DZ*2 + c.PixelModules.zSi[c.PixelModules.nSlice-1] - c.PixelModules.zSi[9] + c.PixelModules.DimZSi + 80 *u.cm + 4.5*u.m #4.5 m is the Goliath length
    
-    c.PixelModules.DimZpixelbox = c.PixelModules.zSi[c.PixelModules.numSi-1] - c.PixelModules.zSi[0] + c.PixelModules.DimZSi    
+    c.PixelModules.DimZpixelbox = c.PixelModules.zSi[c.PixelModules.numSi-1] - c.PixelModules.zSi[c.PixelModules.nSlice-1] + c.PixelModules.DimZSi   
 
     PixeltoGoliath = 30.45 *u.cm #25.45 + 5cm different goliath dz
     c.Spectrometer.zBox = 350.75 - c.Spectrometer.TS/2 - PixeltoGoliath - c.PixelModules.DimZpixelbox/2.

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -326,7 +326,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.Spectrometer.D1Long = 4 * u.cm;
     c.Spectrometer.SX = c.Spectrometer.DX
     c.Spectrometer.SY = c.Spectrometer.DY
-    c.PixelModules.DimZSi = 0.0200 * u.cm
+    c.PixelModules.DimZSi = 0.00200 * u.cm
     c.PixelModules.D1short = 3.36 * u.cm / 2.
     c.PixelModules.D1long = 4 * u.cm
 
@@ -375,9 +375,10 @@ with ConfigRegistry.register_config("basic") as c:
     c.PixelModules.ySi.append(-0.0030432)
     c.PixelModules.zSi.append(10.462)
     #Module 9
-    c.PixelModules.xSi.append(-0.209171)
-    c.PixelModules.ySi.append(0.002488)
-    c.PixelModules.zSi.append(11.17)
+    for i in range(-5,5):
+	    c.PixelModules.xSi.append(-0.209171)
+	    c.PixelModules.ySi.append(0.002488)
+	    c.PixelModules.zSi.append(11.17+i*c.PixelModules.DimZSi)
     #Module 10
     c.PixelModules.xSi.append(0.694199)
     c.PixelModules.ySi.append(0.850237)

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -55,6 +55,8 @@ def configure(run,ship_geo,Gfield=''):
     PixelModules = ROOT.PixelModules("PixelModules",ship_geo.PixelModules.DX, ship_geo.PixelModules.DY, ship_geo.PixelModules.DZ,ROOT.kTRUE)
     PixelModules.SetBoxParam(ship_geo.PixelModules.DX,ship_geo.PixelModules.DY,ship_geo.PixelModules.DZ, ship_geo.PixelModules.zBox, ship_geo.PixelModules.DimZpixelbox, ship_geo.PixelModules.D1short, ship_geo.PixelModules.D1long)
     PixelModules.SetSiliconDZ(ship_geo.PixelModules.DimZSi)
+    PixelModules.SetSiliconSlicesNumber(ship_geo.PixelModules.nSlice)
+    PixelModules.ComputeDimZSlice()
 # === SciFi modules
     detectorList.append(SciFi)
 # === Pixel modules


### PR DESCRIPTION
In order to digitize the PixelModules, several energy depositions are required in the Z direction for each module. To perform this, each module was sliced in 10 since no way of changing the GEANT4 step was found. Some general code cosmetics were also changed.