### PR TITLE
Fix pixel library crash

### DIFF
--- a/charmdet/ShipPixelHit.cxx
+++ b/charmdet/ShipPixelHit.cxx
@@ -66,7 +66,7 @@ void ShipPixelHit::GetPixelXYZ(TVector3 &pixel, int detID) { //, std::shared_ptr
 }
 
 
-std::shared_ptr <std::unordered_map<int, TVector3>>  ShipPixelHit::MakePositionMap() {
+std::unordered_map<int, TVector3>*  ShipPixelHit::MakePositionMap() {
 // map unique detectorID to x,y,z position in LOCAL coordinate system. xy (0,0) is on the bottom left of each Front End,
 // the raw data counts columns from 1-80 from left to right and rows from 1-336 FROM TOP TO BOTTOM.
 
@@ -117,7 +117,7 @@ std::shared_ptr <std::unordered_map<int, TVector3>>  ShipPixelHit::MakePositionM
 
   const float Yref[12] { y0ref, y1ref, y2ref, y3ref, y4ref, y5ref, y6ref, y7ref, y8ref, y9ref, y10ref, y11ref};
 
-  std::unordered_map<int, TVector3> positionMap;
+  auto positionMap = new std::unordered_map<int, TVector3>{};
 
   int map_index = 0;
   int moduleID = 0;
@@ -172,14 +172,15 @@ std::shared_ptr <std::unordered_map<int, TVector3>>  ShipPixelHit::MakePositionM
             x = -x_local;
             y = y_local;
           }
-          positionMap[map_index].SetX(x - Xref[moduleID]);
-          positionMap[map_index].SetY(y - Yref[moduleID]);
-          positionMap[map_index].SetZ(Zref[moduleID]);
+          (*positionMap)[map_index] = TVector3{
+            x - Xref[moduleID],
+            y - Yref[moduleID],
+            Zref[moduleID]};
         }
       }
     }
   }
-  return std::make_shared<std::unordered_map<int, TVector3>>(positionMap);
+  return positionMap;
 }
 
 // -----   Destructor   ----------------------------------------------------
@@ -195,4 +196,6 @@ void ShipPixelHit::Print()
 }
 // -------------------------------------------------------------------------
 
- ClassImp(ShipPixelHit)
+std::unordered_map<int, TVector3>* ShipPixelHit::PixelPositionMap = nullptr;
+
+ClassImp(ShipPixelHit)

--- a/charmdet/ShipPixelHit.h
+++ b/charmdet/ShipPixelHit.h
@@ -23,13 +23,13 @@ public:
    ShipPixelHit(Int_t detID, Float_t fdigi);
    HitID GetPixel();
    int32_t GetDetectorID();
-   static std::shared_ptr <std::unordered_map<int, TVector3>> MakePositionMap();
+   static std::unordered_map<int, TVector3>* MakePositionMap();
    int32_t GetModule();
    void GetPixelXYZ(TVector3 &pixel, int detID);
    void Print();
    int32_t GetTimeOverThreshold() const {return fdigi*25 ; }
 private:
-   static std::shared_ptr <std::unordered_map<int, TVector3>> PixelPositionMap; //!
+   static std::unordered_map<int, TVector3>* PixelPositionMap; //!
    /** Copy constructor **/
    ShipPixelHit(const ShipPixelHit &other);
    ShipPixelHit operator=(const ShipPixelHit &other);
@@ -37,7 +37,7 @@ private:
    int32_t detID;
    uint16_t tot;
 
-   ClassDef(ShipPixelHit, 1);
+   ClassDef(ShipPixelHit, 2);
 };
 
 #endif


### PR DESCRIPTION
This should fix the crash when loading the charmdet library (tested on lxplus7).

My apologies for not noticing this. There is a subtely in the way static member variables need to be defined, which I was not aware of.  This explains the issue (and soution) well: https://stackoverflow.com/questions/4891067/weird-undefined-symbols-of-static-constants-inside-a-struct-class