### PR TITLE
Adding information about lxplus installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Additionally for developers:
     ```bash
     export SHIPBUILD=/cvmfs/ship.cern.ch/SHiPBuild
     ```    
-
+   on lxplus you should not follow steps 3 and 4, since the software is already installed in the previous folder.
+   The usage of lxplus6 is currently recommended.
 1. Install FairShip
     ```bash
     git clone https://github.com/ShipSoft/FairShip.git

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Additionally for developers:
     ```bash
     export SHIPBUILD=/cvmfs/ship.cern.ch/SHiPBuild
     ```    
-   on lxplus you should not follow steps 3 and 4, since the software is already installed in the previous folder.
-   The usage of lxplus6 is currently recommended.
+   On lxplus a full installation will most probably fail due to lack of memory.
+   The usage of lxplus6 is currently (May 2019) recommended if you want to use the event display.
 1. Install FairShip
     ```bash
     git clone https://github.com/ShipSoft/FairShip.git


### PR DESCRIPTION
Hi to all you FairShip developers,
today I have been contacted by a colleague who received an error, after trying to launch the full installation on lxplus. Therefore, I consider it better to clearly explain in the README that the full installation should not be done there.
Also, I have suggested the usage of lxplus6, since I noticed the display not working in lxplus7.

Best regards,
Antonio