### PR TITLE
Update minimum CMake version and policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,16 @@
 # and ShipRoot.
 
 # Check if cmake has the required version
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.9.4 FATAL_ERROR)
+
+foreach(p
+  CMP0028 # double colon for imported and alias targets
+  CMP0074 # use _ROOT env variables
+  )
+  if(POLICY ${p})
+  cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
 
 # Set name of our project to "ShipRoot". Has to be done
 # after check of cmake version since this is a new feature                  
@@ -123,7 +132,7 @@ CHECK_EXTERNAL_PACKAGE_INSTALL_DIR()
 # For example the framework can run without GEANT4, but ROOT is
 # mandatory
 
-find_package(ROOT 5.34.00 REQUIRED)
+find_package(ROOT 6.10.06 REQUIRED)
 find_package(Pythia8 REQUIRED)
 find_package(EvtGen REQUIRED)
 find_package(GENERATORS REQUIRED)


### PR DESCRIPTION
This updates the CMake version to be in line with the one required in shipdist.

Additionally, CMake is configured to use the correct policies CMP0028 (needed by FairLogger in future) and CMP0074 (allows it to find dependencies via the _ROOT variables set by aliBuild).

I also update the ROOT version to something slightly less ancient.