### PR TITLE
Use CMake from SHiPBuild

### DIFF
--- a/localBuild.sh
+++ b/localBuild.sh
@@ -20,7 +20,7 @@ fi
 echo "Setting environment for ${architecture} for $SHIPBUILD"
 echo "SHIPBUILD=$SHIPBUILD" > config.sh
 
-"$SHIPBUILD"/alibuild/alienv -a "${architecture}" -w "$SHIPBUILD"/sw printenv FairShip/latest >> config.sh
+"$SHIPBUILD"/alibuild/alienv -a "${architecture}" -w "$SHIPBUILD"/sw printenv FairShip/latest CMake/latest >> config.sh
 
 python/tweakConfig
 


### PR DESCRIPTION
On lxplus, localBuild doesn't load CMake from SHiPBuild, as it's only a build dependency of FairShip, but not a dependency.

This loads CMake explicitly. Ideally we'd load all *build* dependencies automatically as well.

@antonioiuliano2 