### PR TITLE
[LINT] Unused variable (DO NOT MERGE)

### DIFF
--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -196,9 +196,9 @@ def RPCPosition():
         hit = ROOT.MuonTaggerHit(detID,0)
         a,b = correctAlignmentRPC(hit,v)
         RPCPositionsBotTop[detID] = [a.Clone(),b.Clone()]
-        x = (a[0]+b[0])/2.
-        y = (a[1]+b[1])/2.
-        z = (a[2]+b[2])/2.
+        (a[0]+b[0])/2.
+        (a[1]+b[1])/2.
+        (a[2]+b[2])/2.
        # print "Postion for view {} and channel {}: ({}, {},{})".format(v,c,x,y,z)
 
 def GetRPCPosition(s,v,c):
@@ -260,8 +260,8 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
   if fittedtracks:
    mH,bH = getSlopes(clustersH,0) 
    mV,bV = getSlopes(clustersV,1)   
-   trackH = ROOT.RPCTrack(mH,bH)
-   trackV = ROOT.RPCTrack(mV,bV)
+   ROOT.RPCTrack(mH,bH)
+   ROOT.RPCTrack(mV,bV)
   #print "Line equation along horizontal: {}*z + {}".format(mH,bH)
   #print "Line equation along vertical: {}*z + {}".format(mV,bV)
    theta = ROOT.TMath.ATan(pow((mH**2+mV**2),0.5))

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -1,5 +1,8 @@
 #import yep
-import ROOT,os,time,sys,operator,atexit
+import ROOT
+import operator
+import os
+import time
 ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 
 from decorators import *
@@ -810,8 +813,8 @@ def compareAlignment():
    print "%s %i x/y pos from Daniel %7.4F %7.4F %7.4F %7.4F %7.4F  from FairShip  %7.4F %7.4F %7.4F %7.4F %7.4F diff %5.4F zdiff %5.4F"\
                 %(txt,d,x0D,angleD,vbotD[1],vtopD[1],vbotD[2],x0,angle,vtop[1],vbot[1],vbot[2],(x0D-x0)*10.,(z-vbotD[2])*10)
    if abs(vbot[2]-vtop[2])>0.1: print "!!! z tilt",vbot[2],vtop[2]
-   rc = h['alignCompare'].Fill(x0D,x0)
-   rc = h['alignCompareDiffs'].Fill(x0D-x0)
+   h['alignCompare'].Fill(x0D,x0)
+   h['alignCompareDiffs'].Fill(x0D-x0)
  z0_D = zpos['T1X']/10.
  test = ROOT.MufluxSpectrometerHit(10002001,0.)
  test.MufluxSpectrometerEndPoints(vbot,vtop)
@@ -870,7 +873,7 @@ def surveyVSfairship():
  test = ROOT.MufluxSpectrometerHit(11002012,0.)
  test.MufluxSpectrometerEndPoints(vbot,vtop)
  z1b = (surveyXYZ['T1_MB_01'][2]+surveyXYZ['T1_MB_04'][2])/2.-3.03-3.64-4.06-3.64
- z1bF = vtop[2]
+ vtop[2]
  m = (surveyXYZ['T1_MB_01'][1]-surveyXYZ['T1_MB_04'][1])/(surveyXYZ['T1_MB_01'][0]-surveyXYZ['T1_MB_04'][0])
  b = surveyXYZ['T1_MB_01'][1] - m*surveyXYZ['T1_MB_01'][0]
  xposAty0 = -b/m
@@ -985,7 +988,7 @@ def displayDTLayers():
     if view=='_x' and statnb>1: y+=8
     h['upstreamG'].SetPoint(n,nr,y)
     n+=1
- tc = h['layerDisplay'].cd(1)
+ h['layerDisplay'].cd(1)
  h['upstream'].Draw()
  h['upstreamG'].Draw('sameP')
 
@@ -1030,7 +1033,7 @@ def plotEvent(n=-1):
      channelID = hit.GetDetectorID()
      statnb = channelID/10000
      view   = (channelID-10000*statnb)/1000
-     channel = channelID%1000
+     channelID%1000
      vbot,vtop = RPCPositionsBotTop[channelID]
      if view == 1:
       x,z =  (vtop[0]+vbot[0])/2.,(vtop[2]+vbot[2])/2.
@@ -1047,7 +1050,7 @@ def plotEvent(n=-1):
    for c in h['hitCollection']: rc=h['hitCollection'][c][1].SetMarkerStyle(30)
    for c in h['hitCollection']:
      if h['hitCollection'][c][1].GetN()<1: continue
-     rc=h['hitCollection'][c][1].Draw('sameP')
+     h['hitCollection'][c][1].Draw('sameP')
      h['display:'+c]=h['hitCollection'][c][1]
    for g in h['stereoHits']:
      g.SetLineWidth(2)
@@ -1166,8 +1169,8 @@ def MakeKeysToDThits(minToT=-999):
    detID=hit.GetDetectorID()
    if detID<0: continue # feature for converted data in February'19
    if keysToDThits.has_key(detID):
-     prevTDC = sTree.Digi_MufluxSpectrometerHits[keysToDThits[detID][0]].GetDigi()
-     prevToT = sTree.Digi_MufluxSpectrometerHits[keysToDThits[detID][0]].GetTimeOverThreshold()
+     sTree.Digi_MufluxSpectrometerHits[keysToDThits[detID][0]].GetDigi()
+     sTree.Digi_MufluxSpectrometerHits[keysToDThits[detID][0]].GetTimeOverThreshold()
      # print "MakeKeysToDThits, non unique Digi_MufluxSpectrometerHits",detID,hit.GetDigi(),hit.GetTimeOverThreshold(),hit.hasTimeOverThreshold(),prevTDC,prevToT
      if hit.hasTimeOverThreshold(): keysToDThits[detID]=[key]
    else:
@@ -1196,11 +1199,11 @@ def studyLateDTHits(nevents=1000,nStart=0):
      if keysToDThits[channel][0]<0: rc=h['multLateDTHits'].Fill(-1)
      else: 
       nHits+=1
-      rc=h['multLateDTHits'].Fill(len(keysToDThits[channel])-1)
+      h['multLateDTHits'].Fill(len(keysToDThits[channel])-1)
       for n in range(1,len(keysToDThits[channel])):
         key = keysToDThits[channel][n]
         aHit = sTree.Digi_LateMufluxSpectrometerHits[key]
-        rc=h['ToverTvsTDC'].Fill( aHit.GetTimeOverThreshold() ,aHit.GetDigi())
+        h['ToverTvsTDC'].Fill( aHit.GetTimeOverThreshold() ,aHit.GetDigi())
  ROOT.gROOT.FindObject('c1').cd()
  h['multLateDTHits'].Draw()
  print "nHits",nHits
@@ -1250,7 +1253,7 @@ def hitMapsFromFittedTracks():
     detID = trInfo.detId(n)
     hit = ROOT.MufluxSpectrometerHit(detID,0)
     s,v,p,l,view,channelID,tdcId,mdoduleId = stationInfo(hit)
-    rc = xLayers[s][p][l][view].Fill(channelID)
+    xLayers[s][p][l][view].Fill(channelID)
  ut.writeHists(h,'histos-HitmapsFromFittedTracks-'+rname)
 def plotHitMapsOld(onlyPlotting=False):
  noisyChannels = []
@@ -1266,17 +1269,17 @@ def plotHitMapsOld(onlyPlotting=False):
     tot = ''
     if not hit.hasTimeOverThreshold(): tot='_noToT'
     try:
-     rc = xLayers[s][p][l][view].Fill(channelNr)
+     xLayers[s][p][l][view].Fill(channelNr)
     except:
      print "plotHitMaps error",hit.GetDetectorID(),s,v,p,l,view,channelNr,tdcId
      continue
     if hit.GetDetectorID() not in noisyChannels:
      t0 = 0
      if MCdata: t0 = sTree.ShipEventHeader.GetEventTime()
-     rc = h['TDC'+str(nRT)+tot].Fill(hit.GetDigi()-t0)
+     h['TDC'+str(nRT)+tot].Fill(hit.GetDigi()-t0)
     channel = 'TDC'+str(hit.GetDetectorID())
     if not h.has_key(channel+tot): h[channel+tot]=h['TDC'+str(nRT)+tot].Clone(channel)
-    rc = h[channel+tot].Fill(hit.GetDigi()-t0)
+    h[channel+tot].Fill(hit.GetDigi()-t0)
  if not h.has_key('hitMapsX'): ut.bookCanvas(h,key='hitMapsX',title='Hit Maps All Layers',nx=1600,ny=1200,cx=4,cy=6)
  if not h.has_key('TDCMapsX'): ut.bookCanvas(h,key='TDCMapsX',title='TDC Maps All Layers',nx=1600,ny=1200,cx=5,cy=10)
  if not h.has_key('TDCMapsX_noToT'): ut.bookCanvas(h,key='TDCMapsX_noToT',title='TDC Maps All Layers noToT',nx=1600,ny=1200,cx=5,cy=10)
@@ -1290,7 +1293,7 @@ def plotHitMapsOld(onlyPlotting=False):
      if s>2 and view != '_x': continue
      if s==1 and view == '_v'or s==2 and view == '_u': continue
      j+=1
-     rc = h['hitMapsX'].cd(j)
+     h['hitMapsX'].cd(j)
      xLayers[s][p][l][view].Draw()
      mean = xLayers[s][p][l][view].GetEntries()/channels[s][p][l][view]
      v = 0
@@ -1327,7 +1330,7 @@ def printScalers():
    ut.bookHist(h,'rate','rate',100,-0.5,99.5)
    ut.bookHist(h,'scalers','rate',100,-0.5,99.5)
    if not h.has_key('rates'): ut.bookCanvas(h,key='rates',title='Rates',nx=800,ny=400,cx=2,cy=1)
-   rc = h['rates'].cd(1)
+   h['rates'].cd(1)
    scalers = sTree.GetCurrentFile().Get('scalers')
    if not scalers:
      print "no scalers in this file"
@@ -1339,18 +1342,18 @@ def printScalers():
     s = eval('scalers.'+name)
     if name!='slices': 
       print "%20s :%8i"%(name,s)
-      rc=h['scalers'].Fill(ns,s)
+      h['scalers'].Fill(ns,s)
       ns+=1
     else:
       r0 = 0
       for n in range(s.size()):
         r0 = s[n] - r0
         if r0<0: r0 = s[n]
-        rc=h['rate'].Fill(n,r0)
-        rc=h['integratedrate'].Fill(n,s[n])
+        h['rate'].Fill(n,r0)
+        h['integratedrate'].Fill(n,s[n])
         r0 = s[n]
    h['rate'].Draw('hist')
-   rc = h['rates'].cd(2)
+   h['rates'].cd(2)
    h['integratedrate'].Draw('hist')
 
 ut.bookHist(h,'delx','delta x',200,-50.,50.)
@@ -1366,18 +1369,18 @@ def plotRPCHitmap():
  for event in sTree:
     for m in event.Digi_MuonTaggerHits:
       layer = m.GetDetectorID()/1000
-      rc = h['rpcHitmap'].Fill(layer)
+      h['rpcHitmap'].Fill(layer)
       channel = m.GetDetectorID()%1000
-      rc = h['rpcHitmap'+str(layer)].Fill(channel)
+      h['rpcHitmap'+str(layer)].Fill(channel)
  if not h.has_key('rpcPlot'): ut.bookCanvas(h,key='rpcPlot',title='RPC Hitmaps',nx=1200,ny=600,cx=4,cy=3)
  j=0
  for n in range(1,6):
   for l in range(2):
     j+=1
-    rc = h['rpcPlot'].cd(j)
+    h['rpcPlot'].cd(j)
     h['rpcHitmap'+str(n)+str(l)].Draw()
  j+=1
- rc = h['rpcPlot'].cd(j)
+ h['rpcPlot'].cd(j)
  h['rpcHitmap'].Draw()
 
 def plotTimeOverThreshold(N,Debug=False):
@@ -1385,17 +1388,17 @@ def plotTimeOverThreshold(N,Debug=False):
  ut.bookHist(h,'endTime','End Time',100,0.,2000.)
  ut.bookHist(h,'tdc','tdc',100,-200.,2000.)
  for n in range(N):
-  rc = sTree.GetEvent(n)
+  sTree.GetEvent(n)
   flag = False
   for aHit in sTree.Digi_MufluxSpectrometerHits:
    detID=hit.GetDetectorID()
    if detID<0: continue # feature for converted data in February'19
    if not aHit.hasTimeOverThreshold():
-    rc=h['ToverT'].Fill( -999. )
+    h['ToverT'].Fill( -999. )
     continue
-   rc=h['ToverT'].Fill( aHit.GetTimeOverThreshold() )
-   rc=h['tdc'].Fill( aHit.GetDigi())
-   rc=h['endTime'].Fill( aHit.GetDigi()+aHit.GetTimeOverThreshold() )
+   h['ToverT'].Fill( aHit.GetTimeOverThreshold() )
+   h['tdc'].Fill( aHit.GetDigi())
+   h['endTime'].Fill( aHit.GetDigi()+aHit.GetTimeOverThreshold() )
    if aHit.GetTimeOverThreshold() < 10: flag = True
   if flag and Debug:
      print n
@@ -1450,10 +1453,9 @@ def extractMinAndMax():
        break
      tmp = x.Clone('tmp')
      tmp.Rebin(10)
-     runningMean = 0
      mean = tmp.GetBinContent(tmp.FindBin(tmp.GetMean()))
      for m in range(tmp.GetNbinsX()-1,0,-1):
-      runningMean=max(tmp.Integral(m,tmp.GetNbinsX()) / float(tmp.GetNbinsX()-m),2)
+      max(tmp.Integral(m,tmp.GetNbinsX()) / float(tmp.GetNbinsX()-m),2)
       if tmp.GetBinContent(m)>mean/5.:
        tmax = tmp.GetBinCenter(m)
        break
@@ -1537,7 +1539,7 @@ def checkMCSmearing():
  ut.bookHist(h,'nMeasMC','number of hits per track',50,-0.5,49.5)
  for i in range(sTree.GetEntries()):
   trackID = {}
-  rc = sTree.GetEvent(i)
+  sTree.GetEvent(i)
   if sTree.Digi_MufluxSpectrometerHits.GetEntries() != sTree.MufluxSpectrometerPoint.GetEntries():
     print "digi does not agree with MC, break"
     break
@@ -1550,21 +1552,21 @@ def checkMCSmearing():
    t = p.GetDigi()
    # r = (t-sTree.ShipEventHeader.GetEventTime())*ShipGeo.MufluxSpectrometer.v_drift
    r = RT(p,t)
-   rc = h['spr'].Fill(r-pmc.dist2Wire())
+   h['spr'].Fill(r-pmc.dist2Wire())
    vbot,vtop = strawPositionsBotTop[p.GetDetectorID()]
-   rc = h['MCposX'].Fill(pmc.GetX()-vbot[0]+r)
-   rc = h['MCposX'].Fill(pmc.GetX()-vbot[0]-r)
+   h['MCposX'].Fill(pmc.GetX()-vbot[0]+r)
+   h['MCposX'].Fill(pmc.GetX()-vbot[0]-r)
    if not trackID.has_key(mcp): trackID[mcp]=[]
    trackID[mcp].append(n)
   for mcp in trackID:
-   rc=h['nMeasMC'].Fill(len(trackID[mcp]))
+   h['nMeasMC'].Fill(len(trackID[mcp]))
 
 def originMCmuons():
  ut.bookHist(h,'origin z/r','origin of muons, z vs r',1000,-600.,600.,100,0.,10.)
  for i in range(sTree.GetEntries()):
-  rc = sTree.GetEvent(i)
+  sTree.GetEvent(i)
   r = ROOT.TMath.Sqrt(sTree.MCTrack[0].GetStartX()**2+sTree.MCTrack[0].GetStartY()**2)
-  rc = h['origin z/r'].Fill(sTree.MCTrack[0].GetStartZ(),r)
+  h['origin z/r'].Fill(sTree.MCTrack[0].GetStartZ(),r)
 # from TrackExtrapolateTool
 parallelToZ = ROOT.TVector3(0., 0., 1.) 
 def extrapolateToPlane(fT,z,cplusplus=True):
@@ -1576,7 +1578,7 @@ def extrapolateToPlane(fT,z,cplusplus=True):
    pos = ROOT.TVector3()
    mom = ROOT.TVector3()
    try:
-    trackLength = muflux_Reco.extrapolateToPlane(fT,z,pos,mom)
+    muflux_Reco.extrapolateToPlane(fT,z,pos,mom)
     rc = True
    except:
     rc = False
@@ -1902,8 +1904,6 @@ def bestTracks():
 def fitTrack(hitlist,Pstart=3.):
 # need measurements
    global fitter
-   hitPosLists={}
-   trID = 0
    posM = ROOT.TVector3(0, 0, 20.)
    momM = ROOT.TVector3(0,0,Pstart*u.GeV)
 # approximate covariance
@@ -1976,7 +1976,7 @@ def fitTrack(hitlist,Pstart=3.):
       theTrack.Delete()
       return -1
    if Debug: 
-     chi2 = fitStatus.getChi2()/fitStatus.getNdf()
+     fitStatus.getChi2()/fitStatus.getNdf()
      fittedState = theTrack.getFittedState()
      P = fittedState.getMomMag()
      print "track fitted Ndf #Meas P",fitStatus.getNdf(), theTrack.getNumPointsWithMeasurement(),P
@@ -2086,7 +2086,7 @@ def testPR(onlyHits=False):
   hitlist[k]=[]
   # if len(track_hits[nTrack]['34'])<5 or len(track_hits[nTrack]['y12'])<5: continue
   for dets in ['34','stereo12','y12']:
-   rc = h['tracklets'+dets].Fill(len(track_hits[nTrack][dets]))
+   h['tracklets'+dets].Fill(len(track_hits[nTrack][dets]))
    for aHit in  track_hits[nTrack][dets]:
     hitlist[k].append( aHit['digiHit'])
   aTrack = fitTrack(hitlist[k],abs(track_hits[nTrack]['p']))
@@ -2106,7 +2106,7 @@ def plotTracklets(track_hits):
     if detID>2: detID-=2
     clus[detID].append([0,(hits['xtop']+hits['xbot'])/2.,hits['z']])
    slopeA,bA = getSlopes(clus[1],clus[2])
-   x1 = zgoliath*slopeA+bA
+   zgoliath*slopeA+bA
    nt = len(h['dispTrackSeg'])
    h['dispTrackSeg'].append( ROOT.TGraph(2) )
    if upStream:
@@ -2154,7 +2154,7 @@ def findDTClusters(removeBigClusters=True):
        for Acl in clustersPerLayer[l]:
         if len(clustersPerLayer[l][Acl])>cuts['maxClusterSize']: # kill cross talk brute force
            for x in clustersPerLayer[l][Acl]:
-            dead = allHits[l].pop(x)
+            allHits[l].pop(x)
             if Debug: print "pop",s,viewC[view],l,x
      ncl=0
      tmp={}
@@ -2234,7 +2234,7 @@ def findDTClusters(removeBigClusters=True):
          if len(clusters[s][view][ncl])==0:
            clusters[s][view].pop(ncl)
          else: ncl+=1
-     rc = h['clsN'].Fill(ncl)
+     h['clsN'].Fill(ncl)
 # eventually split too big clusters for stero layers:
    for s in [1,2]:
     for view in viewsI[s]:
@@ -2600,7 +2600,7 @@ def testClusters(nEvent=-1,nTot=1000):
 
 def printResiduals(aTrack):
    if not aTrack.getNumPointsWithMeasurement()>0: return
-   sta = aTrack.getFittedState(0)
+   aTrack.getFittedState(0)
    txt = {}
    tmpList={}
    k=0
@@ -2697,7 +2697,7 @@ def plotBiasedResiduals(nEvent=-1,nTot=1000,PR=1,onlyPlotting=False,minP=3.):
            z = (vbot[2]+vtop[2])/2.
            timer.Start()
           # rc,pos,mom = extrapolateToPlane(aTrack,z)
-           trackLength = muflux_Reco.extrapolateToPlane(aTrack,z,pos,mom)
+           muflux_Reco.extrapolateToPlane(aTrack,z,pos,mom)
            timerStats['extrapTrack']+=timer.RealTime()
            timer.Start()
            if not rc:
@@ -2753,7 +2753,7 @@ def plotBiasedResiduals(nEvent=-1,nTot=1000,PR=1,onlyPlotting=False,minP=3.):
            firstWire = s*10000000+v+2000+(l%2)*10000+(l/2)*100000+1
            vbot,vtop = strawPositionsBotTop[firstWire]
            z = (vbot[2]+vtop[2])/2.
-           trackLength = muflux_Reco.extrapolateToPlane(aTrack,z,pos,mom)
+           muflux_Reco.extrapolateToPlane(aTrack,z,pos,mom)
            minDist = 10000.
            for n in range(Nchannels[s]):
             vbot,vtop = strawPositionsBotTop[firstWire+n]
@@ -2913,7 +2913,7 @@ def calculateRTcorrection():
      N+=1
   if not h.has_key('RTCorrection'): 
       ut.bookCanvas(h,key='RTCorrection',title='RTCorrection',nx=1200,ny=1400,cx=1,cy=2)
-  tc = h['RTCorrection'].cd(1)
+  h['RTCorrection'].cd(1)
   h['RTcorr'].SetLineColor(ROOT.kMagenta)
   h['RTcorr'].SetLineWidth(2)
   h['hRTCorrection']=h['resVsDr'].Clone('hRTCorrection')
@@ -2927,7 +2927,7 @@ def calculateRTcorrection():
   for x in h:
    if x.find('RTcorr')!=0: continue
    h[x].Draw()
-  tc = h['RTCorrection'].cd(2)
+  h['RTCorrection'].cd(2)
   h['resVsDr'].SetLineColor(ROOT.kMagenta)
   h['resVsDr'].SetLineWidth(2)
   h['resVsDr'].SetMaximum(0.2)
@@ -2987,7 +2987,7 @@ def plot2dResiduals(minEntries=-1):
      print s,view,l,h[hname].GetEntries()
      for p in ['X','Y']:
       hname = 'biasRes'+p+'_'+str(s)+view+str(l)
-      rc = h['biasedResiduals2d'+p].cd(j)
+      h['biasedResiduals2d'+p].cd(j)
       if minEntries >0: h[hname].SetMinimum(minEntries)
       h[hname].Draw('box')
      j+=1
@@ -3040,7 +3040,7 @@ def DTeffWithRPCTracks(Nevents=0,onlyPlotting=False):
          z = (vbot[2]+vtop[2])/2.
          x = (vbot[0]+vtop[0])/2.
          xExtr = mu.m()*z + mu.b()
-         diff = x-xExtr + align2RPC[s][0]
+         x-xExtr + align2RPC[s][0]
          if abs(x-xExtr)<align2RPC[s][1]: candidates[s][l].append(hit)
          rc = h['distX'+str(s)+str(l)].Fill(x-xExtr)
      # tagging with station tag_s, require only one candidate.
@@ -3180,7 +3180,7 @@ def efficiencyEstimates(method=0):
     if s==1 and view == '_v' or s==2 and view == '_u': continue
     effStation = 0
     for l in range(0,4):
-     tc = h['biasedResiduals'].cd(j+1)
+     h['biasedResiduals'].cd(j+1)
      if method == 0 or method == 1: hname = 'biasResDistX_'+str(s)+view+str(l)
      else:                          hname = 'biasResXL_'+str(s)+view+str(l)+'_projx'
      xmin = h[hname].GetBinCenter(1)
@@ -3420,9 +3420,9 @@ def plotLinearResiduals():
    for view in ['_x']:
     for l in range(0,4):
      hname = 'linearRes'+str(s)+view+str(l)
-     rc = h['linearResiduals2dX'].cd(j)  
+     h['linearResiduals2dX'].cd(j)  
      h[hname].Draw('box')
-     rc = h['linearResidualsX'].cd(j)  
+     h['linearResidualsX'].cd(j)  
      proj = h[hname].ProjectionX(hname+'_projx')
      proj.Draw()
      print "%s: %7.3F"%(hname, proj.GetMean())
@@ -3441,7 +3441,6 @@ def mergeHistosForMomResol():
  # 1GeV mbias,      1.8 Billion PoT 
  # 1GeV charm,     10.2 Billion PoT,  10 files
  # 10GeV MC,         65 Billion PoT 
- MCStats   = 1.8E9
  sim10fact = 1.8/(65.*(1.-0.016)) # normalize 10GeV to 1GeV stats, 1.6% of 10GeV stats not processed.
  charmNorm  = {1:0.176,10:0.424}
  beautyNorm = {1:0.,   10:0.01218}
@@ -3562,7 +3561,7 @@ def mergeHistosForMomResol():
 def hitResolution():
  ut.bookHist(h,'hitResol','hit resolution',100,-0.5,0.5)
  for n in range(sTree.GetEntries()):
-  rc = sTree.GetEvent(n)
+  sTree.GetEvent(n)
   for k in range(sTree.Digi_MufluxSpectrometerHits.GetEntries()):
     hit = sTree.Digi_MufluxSpectrometerHits[k]
     trueHit = sTree.MufluxSpectrometerPoint[k]
@@ -3838,7 +3837,7 @@ def debugRPCstrips():
 def debugRPCYCoordinate():
  ut.bookHist(h,'y1y2','y1 vs y2 of RPC',100,-100.,100.,100,-100.,100.)
  for n in range(10000):
-  rc = sTree.GetEvent(n)
+  sTree.GetEvent(n)
   if not findSimpleEvent(sTree): continue
   for hit in sTree.Digi_MuonTaggerHits:
     channelID = hit.GetDetectorID()
@@ -3854,7 +3853,7 @@ def debugRPCYCoordinate():
        if v==0 and s==2:
         hit.EndPoints(vtop,vbot)
         y2 = (vtop[1]+vbot[1])/2.
-        rc = h['y1y2'].Fill(y1,y2)
+        h['y1y2'].Fill(y1,y2)
 
 alignCorrection={}
 for p in range(32): alignCorrection[p]=[0,0,0]
@@ -3934,7 +3933,7 @@ def RPCPosition():
 def correctAlignment(hit):
  detID = hit.GetDetectorID()
  vbot,vtop = ROOT.TVector3(), ROOT.TVector3()
- rc = hit.MufluxSpectrometerEndPoints(vbot,vtop)
+ hit.MufluxSpectrometerEndPoints(vbot,vtop)
  if withDefaultAlignment and not withCorrections: return vbot,vtop
  s,v,p,l,view,channelID,tdcId,nRT = stationInfo(hit)
  if withDefaultAlignment and withCorrections:
@@ -3990,7 +3989,7 @@ def loopTracks(r,w):
     w = os.fdopen(w, 'w') 
     chisq=0
     for Nr in listOfTracks:
-     rc=sTree.GetEvent(Nr)
+     sTree.GetEvent(Nr)
      hitlist = listOfTracks[Nr]
      aTrack = fitTrack(hitlist,1.)
      if type(aTrack) != type(1):
@@ -4005,13 +4004,12 @@ def loopTracks(r,w):
 
 def FCN(npar, gin, f, par, iflag):
 #calculate chisquare
-   chisq  = 0
    for p in range(16):
      alignCorrection[p]=[par[p],0,0]
    r, w = os.pipe()
    pid  = os.fork() # bypassing memory issues with running genfit
    if pid == 0:
-      chisq = loopTracks(r,w)
+      loopTracks(r,w)
    else:
     print("In the parent process after forking the child {}".format(pid))
     finished = os.waitpid(0, 0)
@@ -4030,7 +4028,7 @@ def makeFit():
 # new idea, first loop over N events, store hits of all track candidates
 # then make loop over tracks and fit, sum track chi2
  for Nr in range(50000):
-   rc = sTree.GetEvent(Nr)
+   sTree.GetEvent(Nr)
    if not findSimpleEvent(sTree): continue
    track_hits = testPR(onlyHits=True)
    if len(track_hits)!=1: continue
@@ -4063,7 +4061,7 @@ def debugGeometrie():
  test.MufluxSpectrometerEndPoints(vbot,vtop)
  m = (vtop[1]-vbot[1])/((vtop[0]-vbot[0]))
  b = vtop[1] - m*vtop[0]
- start = -b/m
+ -b/m
  print vtop[1],vbot[1]
  statnb,vnb,pnb,lnb,view,channelID,tdcId,nRT = stationInfo(test)
  nav = ROOT.gGeoManager.GetCurrentNavigator()
@@ -4074,7 +4072,7 @@ def debugGeometrie():
  if statnb<3: wire = "gas_12_"+str(test.GetDetectorID())
  stat = "volDriftTube"+str(statnb)+"_"+str(statnb) 
  path = "/"+stat+"/"+plane+"/"+layer+"/"+wire
- rc = nav.cd(path)
+ nav.cd(path)
  W = nav.GetCurrentNode()
  S = W.GetVolume().GetShape()
  top = array('d',[0,0,S.GetDZ()])
@@ -4289,7 +4287,7 @@ def testForSameDetID(nEvent=-1,nTot=1000):
   if not nEvent<0: eventRange = [nEvent,nEvent+nTot]
   listOfTDCs = {}
   for Nr in range(eventRange[0],eventRange[1]):
-   rc = sTree.GetEvent(Nr)
+   sTree.GetEvent(Nr)
    listOfDigits={}
    for hit in sTree.Digi_MufluxSpectrometerHits:
      detID = hit.GetDetectorID()
@@ -4304,13 +4302,13 @@ def testForSameDetID(nEvent=-1,nTot=1000):
      listOfDigits[detID][0]+=1
      listOfDigits[detID][1].append(hit.GetDigi())
    for x in listOfDigits:
-    rc=h['multHits'].Fill(listOfDigits[x][0])
+    h['multHits'].Fill(listOfDigits[x][0])
     if listOfDigits[x][0]>1:
       print x
       listOfDigits[x][1].sort()
       for t in range(1,len(listOfDigits[x][1])):
-       rc=h['multHits_deltaT'].Fill(abs(t-listOfDigits[x][1][0]))
-       rc=h['multHits_deltaTz'].Fill(abs(t-listOfDigits[x][1][0]))
+       h['multHits_deltaT'].Fill(abs(t-listOfDigits[x][1][0]))
+       h['multHits_deltaTz'].Fill(abs(t-listOfDigits[x][1][0]))
   for detID in listOfTDCs:
     test = ROOT.MufluxSpectrometerHit(detID,0.)
     s,v,p,l,view,channelID,tdcId,nRT = stationInfo(test)
@@ -4326,7 +4324,7 @@ def clusterSizesPerLayer(nevents):
      for l in range(4):
        ut.bookHist(h,'multHits_'+str(s)+view+str(l),'DT cluster size',16,-0.5,15.5)
   for Nr in range(nevents):
-   rc = sTree.GetEvent(Nr)
+   sTree.GetEvent(Nr)
    spectrHitsSorted = ROOT.nestedList()
    muflux_Reco.sortHits(sTree.Digi_MufluxSpectrometerHits,spectrHitsSorted,True)
    for s in range(1,5):
@@ -4337,7 +4335,7 @@ def clusterSizesPerLayer(nevents):
          allHits.append(x.GetDetectorID()%1000)
        clustersPerLayer = dict(enumerate(grouper(allHits,1), 1))
        for Acl in clustersPerLayer:
-         rc = h['multHits_'+str(s)+viewC[view]+str(l)].Fill(len(clustersPerLayer[Acl]))
+         h['multHits_'+str(s)+viewC[view]+str(l)].Fill(len(clustersPerLayer[Acl]))
          if len(clustersPerLayer[Acl])>3:
           for aHit in spectrHitsSorted[view][s][l]: 
              #print Nr,s,view,l,aHit.GetDetectorID()%1000,aHit.GetWidth()
@@ -4363,25 +4361,23 @@ def studyDeltaRays():
  ut.bookHist(h,'deltaRayN','hits vs z',100,-1.0,1.0,50,0.0,50.)
  ut.bookHist(h,'deltaRayNvsE','hits vs E',100,0.0,10.0,50,0.0,50.)
  for n in range(sTree.GetEntries()):
-  rc=sTree.GetEvent(n)
+  sTree.GetEvent(n)
   if not (sTree.RPCTrackX.GetEntries()==1) or not (sTree.RPCTrackY.GetEntries()==1) : continue
   N=0
   spectrHitsSorted = ROOT.nestedList()
   muflux_Reco.sortHits(sTree.Digi_MufluxSpectrometerHits,spectrHitsSorted,True)
   for l in range(4):  N+= len(spectrHitsSorted[0][1][l])
-  rc = h['station1Occ'].Fill(N)
+  h['station1Occ'].Fill(N)
   if MCdata:
-   found = False
    for m in sTree.MCTrack:
     pName = m.GetProcName().Data()
     if not pName.find('Delta ray')<0:
      if m.GetStartZ()/100. < 0.05 and m.GetStartZ()/100. > -0.3: 
-        rc = h['deltaRayNvsE'].Fill(m.GetP(),N)
+        h['deltaRayNvsE'].Fill(m.GetP(),N)
         if m.GetP()>0.01:  
-           rc = h['station1OccX'].Fill(N)
-           found = True
-     rc = h['deltaRay'].Fill(m.GetStartZ()/100.,m.GetP())
-     rc = h['deltaRayN'].Fill(m.GetStartZ()/100.,N)
+           h['station1OccX'].Fill(N)
+     h['deltaRay'].Fill(m.GetStartZ()/100.,m.GetP())
+     h['deltaRayN'].Fill(m.GetStartZ()/100.,N)
    # if not found and N>8: sTree.MCTrack.Dump()
 
 def studyScintillator():
@@ -4390,11 +4386,11 @@ def studyScintillator():
  ut.bookHist(h,'sc7','sc',1000,-500.,2000.)
  ut.bookHist(h,'scmult','sc multiplicity',10,-0.5,9.5)
  for n in range(sTree.GetEntries()):
-  rc=sTree.GetEvent(n)
-  rc=h['scmult'].Fill(sTree.Digi_ScintillatorHits.GetEntries())
+  sTree.GetEvent(n)
+  h['scmult'].Fill(sTree.Digi_ScintillatorHits.GetEntries())
   for sc in sTree.Digi_ScintillatorHits:
-    rc=h['sc'].Fill(sc.GetDigi())
-    rc=h['sc'+str(sc.GetDetectorID())].Fill(sc.GetDigi())
+    h['sc'].Fill(sc.GetDigi())
+    h['sc'+str(sc.GetDetectorID())].Fill(sc.GetDigi())
 
 def myVertex(t1,t2,PosDir,xproj=False):
  # closest distance between two tracks
@@ -4463,7 +4459,7 @@ def findV0(nstart=0,nmax=-1,PR=1):
     else: rc = h['v0mass_wc'].Fill(V0Mom.M(),zv)
 def getEvent(n):
  global rname
- rc = sTree.GetEvent(n)
+ sTree.GetEvent(n)
  if sTree.GetListOfFiles().GetEntries()>1:
    temp = sTree.GetCurrentFile().GetName()
    curFile = temp[temp.rfind('/')+1:]
@@ -4571,16 +4567,16 @@ def analyzeRTrel():
     ut.bookHist(h,x+'Tmax',x+'Tmax',600,1100.,1700.)
   for fname in RTrelations:
    for x in RTrelations[fname]['tMinAndTmax']:
-    rc = h[x+'Tmin'].Fill(RTrelations[fname]['tMinAndTmax'][x][0])
-    rc = h[x+'Tmax'].Fill(RTrelations[fname]['tMinAndTmax'][x][1])
+    h[x+'Tmin'].Fill(RTrelations[fname]['tMinAndTmax'][x][0])
+    h[x+'Tmax'].Fill(RTrelations[fname]['tMinAndTmax'][x][1])
   ut.bookCanvas(h,'RTMins','RT Min',1200,900,7,5)
   ut.bookCanvas(h,'RTMaxs','RT Max',1200,900,7,5)
   keys = RTrelations[fnames[0]]['tMinAndTmax'].keys()
   keys.sort()
   for n in range(1,35):
-   tc = h['RTMins'].cd(n)
+   h['RTMins'].cd(n)
    h[keys[n-1]+'Tmin'].Draw()
-   tc = h['RTMaxs'].cd(n)
+   h['RTMaxs'].cd(n)
    h[keys[n-1]+'Tmax'].Draw()
 
 # to START
@@ -4589,7 +4585,7 @@ zeroFieldData=['SPILLDATA_8000_0515970150_20180715_220030.root']
 def init(database='muflux_RTrelations.pkl',remake=False,withReco=False):
  global withTDC,RTrelations
  if os.path.exists(database): RTrelations = pickle.load(open(database))
- N = sTree.GetEntries()
+ sTree.GetEntries()
  if not RTrelations.has_key(rname) or remake:
   withTDC = False
   sTree.SetBranchStatus("FitTracks",0)
@@ -4635,11 +4631,11 @@ def monitorMasterTrigger():
      continue
    else: rc = h['tdc#4'].Fill(tdcDict[4])
    delay = sTree.Digi_MasterTrigger[0].GetDigi() - tdcDict[4]
-   rc = h['delay'].Fill(delay)
+   h['delay'].Fill(delay)
    for hit in sTree.Digi_MufluxSpectrometerHits:
     detID=hit.GetDetectorID()
     if detID<0: continue # feature for converted data in February'19
-    rc = h['tdc'].Fill(hit.GetDigi())
+    h['tdc'].Fill(hit.GetDigi())
     if not hit.hasDelay():
      tdcID = hit.GetTDC()
      if not tdcDict.has_key(tdcID):
@@ -4649,7 +4645,7 @@ def monitorMasterTrigger():
      if not hit.hasTrigger() : print "this should not happen, trigger but hasTrigger false",n
      lt = tdcDict[tdcID]
      tdcCor = hit.GetDigi() - delay - lt - 1323.0 # default value used to make the correction during conversion
-     rc = h['tdcCor'].Fill(tdcCor)
+     h['tdcCor'].Fill(tdcCor)
 
 def disableBranches():
  # if sTree.GetBranchStatus("FitTracks"): sTree.SetBranchStatus("FitTracks",0)
@@ -4679,7 +4675,7 @@ def muonOrigin():
  doubleProc = [0,0,0]
  N = sTree.GetEntries()
  for n in range(N):
-  rc=sTree.GetEvent(n)
+  sTree.GetEvent(n)
   # if sTree.FitTracks.GetEntries()==0: continue
   muP = 0
   processed = []
@@ -4761,7 +4757,7 @@ def plotDTPoints(onlyPlotting=False):
    ut.bookHist(h,'points'+view,'points'+view,100,0,400,10,-0.5,9.5)
    ut.bookHist(h,'Fitpoints'+view,'points'+view,100,0,400,10,-0.5,9.5)
   for n in range(sTree.GetEntries()):
-   rc = sTree.GetEvent(n)
+   sTree.GetEvent(n)
    hitsPerTrack = {}
    mom = {}
    for p in sTree.MufluxSpectrometerPoint:
@@ -4779,7 +4775,7 @@ def plotDTPoints(onlyPlotting=False):
     hitsPerTrack[t][key]+=1
    for view in views:
     for t in hitsPerTrack:
-     rc = h['points'+view].Fill(mom[t],hitsPerTrack[t][view])
+     h['points'+view].Fill(mom[t],hitsPerTrack[t][view])
    n = 0
    for aTrack in sTree.FitTracks:
     fst = aTrack.getFitStatus()
@@ -4791,7 +4787,7 @@ def plotDTPoints(onlyPlotting=False):
       v = view.replace('_','')
       if v=='u1': v='u'
       if v=='v2': v='v'
-      rc = h['Fitpoints'+view].Fill(mom.Mag(),len(mStatistics[v]))
+      h['Fitpoints'+view].Fill(mom.Mag(),len(mStatistics[v]))
   ut.writeHists(h,'histos-DTPoints-'+rname)
  cases = {'FitPoints':'Fitpoints'}
  if MCdata: cases['MC-DTPoints']='points'
@@ -4977,7 +4973,7 @@ def checkMCEffTuning():
  colors = {'M0':ROOT.kRed,'M2':ROOT.kBlue,'M0rec':ROOT.kMagenta}
  t = 'MC-Comparison eff tuning'
  if not h.has_key(t): ut.bookCanvas(h,key=t,title='MC-Comparison eff tuning',nx=900,ny=600,cx=1,cy=1)
- tc = h[t].cd(1)
+ h[t].cd(1)
  h['leg'+t]=ROOT.TLegend(0.55,0.65,0.85,0.85)
  n = 0
  for m in methods: 
@@ -5456,7 +5452,7 @@ def MCchecks():
  mult={}
  mult['0']=0
  for n in range(sTree.GetEntries()):
-  rc=sTree.GetEvent(n)
+  sTree.GetEvent(n)
   if n%10000==0: print n
   muon={}
   for m in sTree.MCTrack:
@@ -5480,8 +5476,6 @@ def compareRuns(runs=[]):
  # runs = [2200,2201,2202,2203,2205,2206,2207,2208,2276]
  eventStats = {}
  noField = [2199,2200,2201]
- intermediateField = [2383,2388,2389,2390,2392,2395,2396]
- noTracks = [2334, 2335, 2336, 2337, 2345, 2389,2390]
  ROOT.gStyle.SetPalette(ROOT.kGreenPink)
  if len(runs)==0:
   keyword = 'RUN_8000_2'
@@ -5684,7 +5678,7 @@ def additionalMomSmearing():
     sig = (sigma[0]+P*sigma[1])*P
     for n in range(int(N+0.5)):
       p = rnr.Gaus(P,sig)
-      rc = h[folname].Fill(p)
+      h[folname].Fill(p)
   ut.makeIntegralDistrib(h,hname)
   h[hname].Draw()
   h[folname].SetLineColor(ROOT.kBlue)
@@ -5726,7 +5720,6 @@ def recoStep0():
   global withTDC
   withTDC = False
   disableBranches()
-  withMaterial = False
   materialEffects(False)
   plotBiasedResiduals(PR=1)
   makeRTrelations()
@@ -5752,7 +5745,7 @@ def recoStep1(PR=11):
 
   for n in range(sTree.GetEntries()):
     if n%10000==0: print "Now at event",n,"of",sTree.GetEntries(),sTree.GetCurrentFile().GetName(),time.ctime()
-    rc = sTree.GetEvent(n)
+    sTree.GetEvent(n)
     fGenFitArray.Clear()
     fTrackInfoArray.Clear()
     for x in ['X','Y']: fRPCTrackArray[x].Clear()
@@ -5807,7 +5800,7 @@ def recoMuonTaggerTracks():
    RPCTrackbranch[x] = sTree.Branch("RPCTrack"+x, fRPCTrackArray[x],32000,-1)
   for n in range(sTree.GetEntries()):
     if n%10000==0: print "Now at event",n,"of",sTree.GetEntries(),sTree.GetCurrentFile().GetName(),time.ctime()
-    rc = sTree.GetEvent(n)
+    sTree.GetEvent(n)
     for x in ['X','Y']: fRPCTrackArray[x].Clear()
     if MCdata: 
       if sTree.FitTracks.GetEntries()==0:

--- a/charmdet/runAnalysis.py
+++ b/charmdet/runAnalysis.py
@@ -1,4 +1,7 @@
-import os,subprocess,ROOT,time
+import os
+import ROOT
+import subprocess
+import time
 ncpus = 7
 pathToMacro = '$SHIPBUILD/FairShip/charmdet/'
 def count_python_processes(macroName):

--- a/charmdet/runReconstruction.py
+++ b/charmdet/runReconstruction.py
@@ -38,12 +38,12 @@ def getFilesFromEOS():
    print "problem accessing file",fname
    badFiles.append(fname)
 
- Nfiles = len(fileList)
+ len(fileList)
 
  tmp = {}
  for fname in fileList:
   newName = fname[fname.rfind('/')+1:]
-  rc = os.system("xrdcp -f $EOSSHIP"+fname+" "+newName)
+  os.system("xrdcp -f $EOSSHIP"+fname+" "+newName)
   tmp[newName]=fileList[fname]
 
  fnames = tmp.keys()
@@ -66,7 +66,7 @@ def getFilesLocal():
    print "problem accessing file",fname
    badFiles.append(fname)
 
- Nfiles = len(fileList)
+ len(fileList)
 
  fnames = fileList.keys()
  fnames.sort()
@@ -138,7 +138,7 @@ def checkMinusTwo():
   f=ROOT.TFile(fname)
   sTree = f.cbmsim
   for n in range(sTree.GetEntries()):
-   rc = sTree.GetEvent(n)
+   sTree.GetEvent(n)
    for m in sTree.Digi_MufluxSpectrometerHits:
      if m.GetDetectorID()<0: N+=1
   print sTree.GetCurrentFile(),N
@@ -227,7 +227,7 @@ def checkFilesWithTracks2(D='.'):
    elif sTree.GetBranch("FitTracks"): 
      prev = 0
      for n in range(min(20000,sTree.GetEntries())):
-        rc = sTree.GetEvent(n)
+        sTree.GetEvent(n)
         if sTree.FitTracks.GetEntries()>0:
          st = sTree.FitTracks[0].getFitStatus()
          if not st.isFitConverged(): continue
@@ -319,7 +319,7 @@ def checkRecoRun(eosLocation=eospath,local='.'):
   if not os.path.isfile(histosName): 
      print "missing histogram file",fname
 def exportRunToEos(eosLocation="/eos/experiment/ship/user/truf/muflux-reco",run=run,local="."):
- temp = os.system("xrdfs "+os.environ['EOSSHIP']+" mkdir "+eosLocation+"/"+run)
+ os.system("xrdfs "+os.environ['EOSSHIP']+" mkdir "+eosLocation+"/"+run)
  failures = []
  for x in os.listdir(local):
   if x.find('.root')<0: continue
@@ -353,7 +353,6 @@ def makeMomDistributions(run=0):
 zeroField = ['2199','2200','2201']
 noRPC = ['2144','2154','2192','2210','2217','2218','2235','2236','2237','2240','2241','2243','2291','2345','2359']
 def massProduction(keyword = 'RUN_8000_23',fnames=[],merge=False):
- pathToMacro = "$FAIRSHIP/charmdet/"
  eospathReco = '/eos/experiment/ship/user/odurhan/muflux-recodata/'
  if merge:
     for run in os.listdir('.'):
@@ -379,7 +378,6 @@ def massProduction(keyword = 'RUN_8000_23',fnames=[],merge=False):
    makeMomDistributions(run)
    os.chdir('../')
 def massProductionAlignment(keyword = 'RUN_8000_2395',fnames=[],merge=False):
-  pathToMacro = "$FAIRSHIP/charmdet/"
   eospathReco = '/eos/experiment/ship/user/odurhan/muflux-recodata/'
   if merge:
     for run in os.listdir('.'):

--- a/charmdet/runSimulation.py
+++ b/charmdet/runSimulation.py
@@ -159,7 +159,7 @@ def splitDigiFiles(splitFactor=5,fnames=[]):
      os.chdir('../')
      continue
    sTree = origin.cbmsim
-   Nentries = sTree.GetEntries()
+   sTree.GetEntries()
    N = 0
    deltaN = int(sTree.GetEntries()/float(splitFactor))
    for i in range(splitFactor):
@@ -170,8 +170,8 @@ def splitDigiFiles(splitFactor=5,fnames=[]):
      newFile = ROOT.TFile(nf,'RECREATE')
      newTree = sTree.CloneTree(0)
      for n in range(N,N+deltaN):
-       rc = sTree.GetEntry(n)
-       rc = newTree.Fill()
+       sTree.GetEntry(n)
+       newTree.Fill()
      newFile.Write()
     N+=deltaN
    os.chdir('../')
@@ -216,7 +216,7 @@ def checkFilesWithTracks(D='.',splitFactor=5,dimuon=False):
  elif D.find('1GeV')==0 or D.find('10GeV')==0: 
    fnames = getFilesEOS(D)
    eos = os.environ['EOSSHIP']
- Nfiles = len(fnames)
+ len(fnames)
  fileList=[]
  fileListPer={}
  failedList = []

--- a/charmdet/simAbsorber.py
+++ b/charmdet/simAbsorber.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT
+import shipRoot_conf
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 
 import shipunit as u
@@ -41,7 +42,7 @@ def run():
  run.SetName(mcEngine)  # Transport engine
  run.SetOutputFile(outFile)  # Output file
  run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C
- rtdb = run.GetRuntimeDb() 
+ run.GetRuntimeDb() 
 # -----Materials----------------------------------------------
  run.SetMaterials("media.geo")  
 # -----Create geometry----------------------------------------------
@@ -105,12 +106,12 @@ def analyze():
  f=ROOT.TFile(outFile)
  sTree = f.cbmsim
  for n in range(sTree.GetEntries()):
-  rc = sTree.GetEvent(n)
+  sTree.GetEvent(n)
   mu = sTree.MCTrack[0]
   Pout = -0.49
   for v in sTree.vetoPoint:
    if v.GetTrackID()==0:
     if v.LastPoint()[2]>119.9:
      Pout = v.LastMom().Mag()
-  rc = h['PinPout'].Fill(mu.GetP(),Pout)
+  h['PinPout'].Fill(mu.GetP(),Pout)
  ut.writeHists(h,'PinPout.root')

--- a/field/convertMisisMap.py
+++ b/field/convertMisisMap.py
@@ -89,7 +89,6 @@ def createRootMap(inFileName, rootFileName):
     Nx = 0
     Ny = 0
     Nz = 0
-    Nzy = 0
 
     # Field centering co-ordinates
     x0 = 0.0
@@ -128,7 +127,7 @@ def createRootMap(inFileName, rootFileName):
                 Nx = int(((rStruct.xMax - rStruct.xMin)/rStruct.dx) + 1.0)
                 Ny = int(((rStruct.yMax - rStruct.yMin)/rStruct.dy) + 1.0)
                 Nz = int(((rStruct.zMax - rStruct.zMin)/rStruct.dz) + 1.0)
-                Nzy = Nz*Ny
+                Nz*Ny
 
                 print 'Nx = {0}, Ny = {1}, Nz = {2}'.format(Nx, Ny, Nz)
 

--- a/field/convertRALMap.py
+++ b/field/convertRALMap.py
@@ -233,7 +233,6 @@ def createRootMap(inFileName, outFileName):
     Nx = 0
     Ny = 0
     Nz = 0
-    Nzy = 0
 
     with open(inFileName, 'r') as f:
 
@@ -256,7 +255,7 @@ def createRootMap(inFileName, outFileName):
                 Nx = int(((rStruct.xMax - rStruct.xMin)/rStruct.dx) + 1.0)
                 Ny = int(((rStruct.yMax - rStruct.yMin)/rStruct.dy) + 1.0)
                 Nz = int(((rStruct.zMax - rStruct.zMin)/rStruct.dz) + 1.0)
-                Nzy = Nz*Ny
+                Nz*Ny
 
                 print 'Nx = {0}, Ny = {1}, Nz = {2}'.format(Nx, Ny, Nz)
 

--- a/housekeeping/cpplint/cpplint.py
+++ b/housekeeping/cpplint/cpplint.py
@@ -968,7 +968,6 @@ class _FunctionState(object):
 
 class _IncludeError(Exception):
   """Indicates a problem with the include order in a file."""
-  pass
 
 
 class FileInfo(object):
@@ -2016,7 +2015,6 @@ class _BlockInfo(object):
       linenum: The number of the line to check.
       error: The function to call with any errors found.
     """
-    pass
 
   def CheckEnd(self, filename, clean_lines, linenum, error):
     """Run checks that applies to text after the closing brace.
@@ -2029,7 +2027,6 @@ class _BlockInfo(object):
       linenum: The number of the line to check.
       error: The function to call with any errors found.
     """
-    pass
 
   def IsBlockInfo(self):
     """Returns true if this block is a _BlockInfo.

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -216,7 +216,7 @@ def dist2InnerWall(X,Y,Z):
   start = array('d',[X,Y,Z])
   nsteps = 8
   dalpha = 2*ROOT.TMath.Pi()/nsteps
-  rsq = X**2+Y**2
+  X**2+Y**2
   minDistance = 100 *u.m
   for n in range(nsteps):
     alpha = n * dalpha
@@ -324,7 +324,7 @@ def  RedoVertexing(t1,t2):
 # as we have learned, need iterative procedure
      dz = 99999.
      reps,states,newPosDir = {},{},{}
-     parallelToZ = ROOT.TVector3(0., 0., 1.)
+     ROOT.TVector3(0., 0., 1.)
      rc = True 
      step = 0
      while dz > 0.1:
@@ -481,7 +481,7 @@ def makePlots():
      h['pi0Mass'].SetXTitle('#gamma #gamma invariant mass   [GeV/c^{2}]')
      h['pi0Mass'].SetYTitle('N/'+str(int(h['pi0Mass'].GetBinWidth(1)*1000))+'MeV')
      h['pi0Mass'].Draw()
-     fitResult = h['pi0Mass'].Fit('gaus','S','',0.08,0.19)
+     h['pi0Mass'].Fit('gaus','S','',0.08,0.19)
     cv = h['fitresults2'+x].cd(2)
     h['IP0'+x].SetXTitle('impact parameter to p-target   [cm]')
     h['IP0'+x].SetYTitle('N/1cm')
@@ -663,8 +663,8 @@ def myEventLoop(n):
    mcPartKey = sTree.fitTrack2MC[key]
    mcPart    = sTree.MCTrack[mcPartKey]
    if not mcPart : continue
-   Ptruth_start     = mcPart.GetP()
-   Ptruthz_start    = mcPart.GetPz()
+   mcPart.GetP()
+   mcPart.GetPz()
    # get p truth from first strawpoint
    Ptruth,Ptruthx,Ptruthy,Ptruthz = getPtruthFirst(sTree,mcPartKey)
    delPOverP = (Ptruth - P)/Ptruth
@@ -803,7 +803,7 @@ def HNLKinematics():
  ut.bookHist(h,'HNLmom_recTracks','momentum',100,0.,300.)
  ut.bookHist(h,'HNLmomNoW_recTracks','momentum unweighted',100,0.,300.)
  for n in range(sTree.GetEntries()): 
-  rc = sTree.GetEntry(n)
+  sTree.GetEntry(n)
   for hnlkey in [1,2]: 
    if abs(sTree.MCTrack[hnlkey].GetPdgCode()) == 9900015: 
     theHNL = sTree.MCTrack[hnlkey]

--- a/macro/dumpEvent.py
+++ b/macro/dumpEvent.py
@@ -1,5 +1,5 @@
 # example for dumping an MC event
-import ROOT,os,sys,getopt
+import ROOT
 import rootUtils as ut
 import shipunit as u
 import ShipGeoConfig

--- a/macro/evd_nextEvent.py
+++ b/macro/evd_nextEvent.py
@@ -5,6 +5,5 @@ def execute():
   SHiPDisplay = lsOfGlobals.FindObject('SHiP Displayer')
   SHiPDisplay.NextEvent()
   if ROOT.gROOT.FindObject('Root Canvas'): evd_fillEnergy.execute()
-  pass
 if __name__=="__main__":
   execute()

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -383,7 +383,6 @@ class DrawTracks(ROOT.FairTask):
    mom = fMom
    pid = fstate.getPDG()
    zs = self.z_start
-   before = True
    for i in range(self.niter):
     rc,newpos,newmom = TrackExtrapolateTool.extrapolateToPlane(fT,zs)
     if rc:
@@ -465,7 +464,7 @@ class IO():
         self.geoscene = ROOT.gEve.GetScenes().FindChild("Geometry scene")
         for v in top.GetNodes():
          x=v.GetName()
-         cmd = 'toogle("'+x+'")' 
+         'toogle("'+x+'")' 
          a = Tkinter.IntVar()
          assemb = "Assembly" in v.GetVolume().__str__() 
          if v.IsVisible() or (assemb and v.IsVisDaughters()): a.set(1)
@@ -583,7 +582,7 @@ class EventLoop(ROOT.FairTask):
           print "ecal cluster display disabled, seems only to work with 5x10m ecal geofile"
     else:  self.ecalFiller.SetUseMCPoints(ROOT.kTRUE)
     self.ecalFiller.StoreTrackInformation()
-    rc = sTree.GetEvent(0)
+    sTree.GetEvent(0)
     self.ecalStructure = self.ecalFiller.InitPython(sTree.EcalPointLite)
     self.calos  = DrawEcalCluster()
     self.calos.InitTask(self.ecalStructure)
@@ -947,7 +946,7 @@ def mydebug():
    t.GetEntry(i)
    for gTr in t.GeoTracks: 
     gTr.Print()
-    part = gTr.GetParticle()
+    gTr.GetParticle()
     lorv = ROOT.TLorentzVector()
     print 'xyz E pxpypz',gTr.GetPoint(0)[0],gTr.GetPoint(0)[1] ,gTr.GetPoint(0)[2],lorv.E(),lorv.Px(),lorv.Py(),lorv.Pz()
 # Loop over MC tracks  

--- a/macro/getGeoInformation.py
+++ b/macro/getGeoInformation.py
@@ -3,7 +3,7 @@
 #WARNING: printing the entire geometry takes a lot of time
 #24-02-2015 comments to EvH
 
-import operator, sys
+import operator
 from argparse import ArgumentParser
 from array import array
 import os,ROOT

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -1,6 +1,9 @@
 #Use Pythia8 to decay the signals (Charm/Beauty) as produced by makeCascade.
 #Output is an ntuple with muon/neutrinos 
-import ROOT,time,os,sys,random,getopt
+import ROOT
+import getopt
+import os
+import sys
 import rootUtils as ut
 ROOT.gROOT.LoadMacro("$VMCWORKDIR/gconfig/basiclibs.C")
 ROOT.basiclibs()

--- a/macro/makeGenieEvents.py
+++ b/macro/makeGenieEvents.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time
+import ROOT
+import os
 import shipunit as u
 import shipRoot_conf
 import argparse

--- a/macro/mergeMbias.py
+++ b/macro/mergeMbias.py
@@ -17,7 +17,7 @@ startOfTarget       = -50. # value used for Geant4 production
 def fillPart(t):
  particles = {}
  for n in range(t.GetEntries()):
-    rc = t.GetEvent(n)
+    t.GetEvent(n)
     if not particles.has_key(t.parentid) : 
          particles[t.parentid] = 0
     particles[t.parentid] +=1
@@ -30,7 +30,7 @@ def fillWeights():
   t = f.FindObjectAny("pythia8-Geant4")
   weights[p]={}
   for n in range(t.GetEntries()):
-    rc = t.GetEvent(n)
+    t.GetEvent(n)
     if not weights[p].has_key(t.w) : 
          weights[p][t.w] = [t.ecut,0]
     weights[p][t.w][1] +=1
@@ -165,7 +165,7 @@ def mergeMinBias(pot,norm=5.E13,opt=''):
   leaves = t.GetListOfLeaves()
   nL = leaves.GetEntries()
   for iev in range(nev) :
-     rc = t.GetEntry(temp.GetEntry(iev))
+     t.GetEntry(temp.GetEntry(iev))
      vlist = []
      k=-1
      for x in range(nL):
@@ -218,7 +218,6 @@ def mergeMinBias(pot,norm=5.E13,opt=''):
 def runProduction(opts=''):
  we = fillWeights()
  pot = {}
- norm = 5.E13
  for p in we:
   pot[p]={}
   for w in we[p]:
@@ -247,9 +246,9 @@ def removeCharm(p):
   t.SetEventList(temp) 
   nev = temp.GetN()
   leaves = t.GetListOfLeaves()
-  nL = leaves.GetEntries()
+  leaves.GetEntries()
   for iev in range(nev):
-     rc = t.GetEntry(temp.GetEntry(iev))
+     t.GetEntry(temp.GetEntry(iev))
      vlist = array('f')
      for x in range(leaves.GetEntries()):
       vlist.append( leaves.At(x).GetValue() )
@@ -268,12 +267,12 @@ def mergeWithCharm(splitOnly=False,ramOnly=False):
   newFile = ROOT.TFile("pythia8_Charm.root", 'RECREATE')
   nt = ROOT.TNtuple("pythia8-Geant4","mu/nu flux from charm","id:px:py:pz:x:y:z:opx:opy:opz:ox:oy:oz:pythiaid:parentid:w:ecut")
   for n in range(t.GetEntries()):
-      rc = t.GetEntry(n)
+      t.GetEntry(n)
       ztarget = rnr.Exp(0.16) + startOfTarget
       vlist = array('f')
       x = t.id,t.px,t.py,t.pz,0.,0.,ztarget,t.px,t.py,t.pz,0.,0.,ztarget,t.id,t.mid,t.weight,0.
       for ax in x:      vlist.append(ax)
-      rc = nt.Fill(vlist)
+      nt.Fill(vlist)
   newFile.cd()
   nt.Write()
   newFile.Close()
@@ -291,7 +290,7 @@ def mergeWithCharm(splitOnly=False,ramOnly=False):
   m=0
   allEvents = []
   for n in range(t.GetEntries()):
-   rc = t.GetEvent(n)
+   t.GetEvent(n)
    if m%1000000==0 : print 'status read',m
    m+=1
    a = event()
@@ -351,7 +350,7 @@ def mergeWithCharm(splitOnly=False,ramOnly=False):
     temp = ROOT.gROOT.FindObjectAny('temp')
     t.SetEventList(temp)
     for iev in range(temp.GetN()) :
-     rc = t.GetEntry(temp.GetEntry(iev))
+     t.GetEntry(temp.GetEntry(iev))
      vlist = array('f')
      for n in range(leaves.GetSize()):
       vlist.append(leaves.At(n).GetValue())
@@ -396,7 +395,7 @@ def compare():
   for z in ['p','pt']:
    t = z.upper()
    if x != '' : t='>'+t 
-   t1=h[t].cd(1)
+   h[t].cd(1)
    p = z+'mu'
    h['T'+p+x].SetTitle('musum')
    h['T'+p+x].Draw()
@@ -521,7 +520,7 @@ def compare():
  n = 1
  for z in ['p','pt']:
    h['Lratio'+z+x] = ROOT.TLegend(0.21,0.74,0.71,0.85)
-   tc = h['ratios'].cd(n)
+   h['ratios'].cd(n)
    n+=1
    h[z+'muRatio'+x].SetLineColor(2)
    h[z+'muRatio'+x].SetMaximum(max(h[z+'muRatio'+x].GetMaximum(),h[z+'numuRatio'+x].GetMaximum()))

--- a/macro/obsolete/ShipAnaWithVertexing.py
+++ b/macro/obsolete/ShipAnaWithVertexing.py
@@ -1,5 +1,7 @@
 # example for accessing smeared hits and fitted tracks
-import ROOT,os,sys,getopt
+import ROOT
+import getopt
+import sys
 import rootUtils as ut
 import shipunit as u
 from ShipGeoConfig import ConfigRegistry
@@ -156,7 +158,7 @@ def myVertex(t1,t2,PosDir):
 def myEventLoop(N):
  nEvents = min(sTree.GetEntries(),N)
  for n in range(nEvents): 
-  rc = sTree.GetEntry(n)
+  sTree.GetEntry(n)
   wg = sTree.MCTrack[0].GetWeight()
   if not wg>0.: wg=1.
 # make some straw hit analysis
@@ -232,8 +234,8 @@ def myEventLoop(N):
       mom = xx.getMom()
       state = ROOT.genfit.StateOnPlane(rep)
       rep.setPosMom(state, pos, mom)
-      origPlane = state.getPlane()
-      origState = ROOT.genfit.StateOnPlane(state)
+      state.getPlane()
+      ROOT.genfit.StateOnPlane(state)
       try:
        rep.extrapolateToPoint(state, HNLPos, False)
       except:
@@ -255,7 +257,7 @@ def myEventLoop(N):
      h['HNL'].Fill(HNL.M())
 # try to make it persistent
      vx = ROOT.TLorentzVector(HNLPos,0.)  # time not set
-     particle = ROOT.TParticle(9900015,0,-1,-1,t1,t2,HNL,vx)
+     ROOT.TParticle(9900015,0,-1,-1,t1,t2,HNL,vx)
 
 def access2SmearedHits():
  key = 0

--- a/macro/obsolete/genfitShip.py
+++ b/macro/obsolete/genfitShip.py
@@ -101,9 +101,9 @@ class makeHitList:
      top = ROOT.TVector3()
      bot = ROOT.TVector3()
      modules["Strawtubes"].StrawEndPoints(detID,bot,top)
-     ex = ahit.GetX()
-     ey = ahit.GetY()
-     ez = ahit.GetZ()
+     ahit.GetX()
+     ahit.GetY()
+     ahit.GetZ()
    #distance to wire, and smear it.
      dw  = ahit.dist2Wire()
      smear = 0
@@ -117,7 +117,7 @@ class makeHitList:
   
  def execute(self,n):
   if n > self.nEvents-1: return None 
-  rc    = self.sTree.GetEvent(n) 
+  self.sTree.GetEvent(n) 
   if n%1000==0: print "==> event ",n
   nShits = self.sTree.strawtubesPoint.GetEntriesFast() 
   hitPosLists = {}

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -15,7 +15,8 @@ def mem_monitor():
     pmsize = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     print "memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3)
 
-import ROOT,os,sys,getopt
+import ROOT
+import os
 import __builtin__ as builtin
 import rootUtils as ut
 import shipunit as u

--- a/macro/run_anaEcal.py
+++ b/macro/run_anaEcal.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time
+import ROOT
 import shipunit as u
 import shipRoot_conf
 import ShipGeoConfig

--- a/macro/run_simEcal.py
+++ b/macro/run_simEcal.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 momentum = 1
-import ROOT,os,sys,getopt,time
+import ROOT
+import os
+import time
 import shipunit as u
 import shipRoot_conf
 import ShipGeoConfig

--- a/macro/run_simPgun.py
+++ b/macro/run_simPgun.py
@@ -139,7 +139,7 @@ def someDebug():
  for x in trs: print x
 #
  gMC = ROOT.gMC # <ROOT.TVirtualMC* object ("TGeant4") at 0x2a5d3e8>
- fStack = gMC.GetStack()
+ gMC.GetStack()
  gMC.ProcessRun(1) # 1 event
 #
  gMC.GetMC() # <ROOT.TGeant4 object ("TGeant4")
@@ -149,4 +149,4 @@ def someDebug():
  gPrim = run.GetPrimaryGenerator()
  mch   = gPrim.GetEvent() # <ROOT.FairMCEventHeader object ("MCEventHeader.")
  print mch.GetEventID(),mch.GetZ()
- gPy8 = gPrim.GetListOfGenerators()[0]
+ gPrim.GetListOfGenerators()[0]

--- a/muonShieldOptimization/ana_ShipMuon.py
+++ b/muonShieldOptimization/ana_ShipMuon.py
@@ -379,10 +379,10 @@ def origin(sTree,it):
  if im>0: origin(sTree,im)
  if im<0: 
    # print 'does not come from muon'
-   rz_inter = -1.,0.
+   pass
  if im==0: 
    #print 'origin z',at.GetStartZ()
-   rz_inter = ROOT.TMath.Sqrt(at.GetStartX()**2+at.GetStartY()**2),at.GetStartZ()
+   ROOT.TMath.Sqrt(at.GetStartX()**2+at.GetStartY()**2),at.GetStartZ()
 
 otherPhysList = False
 noField       = False
@@ -677,7 +677,7 @@ def executeOneFile(fn,output=None,pid=None):
       else: detName = logVols[detID]
       x = ahit.GetX()
       y = ahit.GetY()
-      z = ahit.GetZ()
+      ahit.GetZ()
       E = ahit.GetEnergyLoss()
      if not h.has_key(detName): bookHist(detName)
      mu=''
@@ -717,17 +717,17 @@ def executeOneFile(fn,output=None,pid=None):
        rc = h['origin'].Fill(aTrack.GetStartZ()/u.m,r,w)
        rc = h[detName+'_origin'].Fill(aTrack.GetStartZ()/u.m,r,w)
        if abs(pdgID)== 13: rc = h[detName+'_originmu'].Fill(aTrack.GetStartZ()/u.m,r,w)
-       rc = h['borigin'].Fill(aTrack.GetStartZ()/u.m,r,w)
-       rc = aTrack.GetMomentum(mom)
-       rc = h[detName+'_OP'].Fill(mom.Mag()/u.GeV,w)
+       h['borigin'].Fill(aTrack.GetStartZ()/u.m,r,w)
+       aTrack.GetMomentum(mom)
+       h[detName+'_OP'].Fill(mom.Mag()/u.GeV,w)
        if trackID > 0: 
          origin(sTree,trackID)
-         rc = h['porigin'].Fill(aTrack.GetStartZ()/u.m,ROOT.TMath.Sqrt(aTrack.GetStartX()**2+aTrack.GetStartY()**2)/u.m,w)
-       rc = h['mu-inter'].Fill(rz_inter[1]/u.m,rz_inter[0]/u.m,w) 
+         h['porigin'].Fill(aTrack.GetStartZ()/u.m,ROOT.TMath.Sqrt(aTrack.GetStartX()**2+aTrack.GetStartY()**2)/u.m,w)
+       h['mu-inter'].Fill(rz_inter[1]/u.m,rz_inter[0]/u.m,w) 
    for detName in hitmult:
-    rc = h[detName+'_evmul'].Fill(hitmult[detName][-1],w) 
+    h[detName+'_evmul'].Fill(hitmult[detName][-1],w) 
     for tr in hitmult[detName]:
-      rc = h[detName+'_mul'].Fill(hitmult[detName][tr],w) 
+      h[detName+'_mul'].Fill(hitmult[detName][tr],w) 
   if output:
    ut.writeHists(h,'tmpHists_'+str(pid)+'.root')
    output.put('ok')
@@ -807,7 +807,6 @@ def makePlots(nstations):
  persistency()
 #
 def AnaEventLoop():
- ntot = 0
  fout = open('rareEvents.txt','w')
  for fn in fchainRec:
   f = ROOT.TFile(fn)
@@ -893,7 +892,7 @@ def analyzeConcrete():
   nEvents = sTree.GetEntries()
   ROOT.gROOT.cd()
   for n in range(nEvents):
-   rc=sTree.GetEntry(n)
+   sTree.GetEntry(n)
    if sTree.MCTrack.GetEntries() > 1: 
       wg = sTree.MCTrack[1].GetWeight() 
    else: 
@@ -939,7 +938,6 @@ def analyzeConcrete():
   h['ntuple'].Write()
 
 def rareEventEmulsion(fname = 'rareEmulsion.txt'):
- ntot = 0
  fout = open(fname,'w')
  for fn in fchainRec:
   f = ROOT.TFile(fn)
@@ -956,9 +954,9 @@ def rareEventEmulsion(fname = 'rareEmulsion.txt'):
    for ahit in sTree.vetoPoint:
      detID = ahit.GetDetectorID()
      if logVols[detID] != 'Emulsion': continue
-     x = ahit.GetX()
-     y = ahit.GetY()
-     z = ahit.GetZ()
+     ahit.GetX()
+     ahit.GetY()
+     ahit.GetZ()
      if sTree.MCTrack.GetEntries() > 1: 
       wg = sTree.MCTrack[1].GetWeight() # also works for neutrinos
      else: 
@@ -1035,7 +1033,7 @@ def extractMuCloseByEvents(single = None):
      if pos.z()<zGol : continue
      n+=1
    if n > 0:
-    rc = newTree.Fill()
+    newTree.Fill()
     # print 'filled newTree',rc
    sTree.Clear()
   newTree.AutoSave()
@@ -1126,15 +1124,15 @@ def eventsWithEntryPoints(i):
     print '-----------------------'
 def depEnergy():
  for n in range(sTree.GetEntries()):
-  rc = sTree.GetEntry(n)
+  sTree.GetEntry(n)
   for ahit in sTree.strawtubesPoint:
    dE = ahit.GetEnergyLoss()/u.keV
-   rc = ahit.Momentum(mom)
+   ahit.Momentum(mom)
    pa = PDG.GetParticle(ahit.PdgCode())
    mpa = pa.Mass()
    E = ROOT.TMath.Sqrt(mom.Mag2()+mpa**2)
    ekin = E-mpa
-   rc = h['dE'].Fill(dE,ekin/u.MeV)
+   h['dE'].Fill(dE,ekin/u.MeV)
   h['dE'].SetXTitle('keV')
   h['dE'].SetYTitle('MeV')
 

--- a/muonShieldOptimization/compactingBackgroundProduction.py
+++ b/muonShieldOptimization/compactingBackgroundProduction.py
@@ -1,4 +1,8 @@
-import os,ROOT,sys,subprocess,pickle,time,datetime
+import os
+import ROOT
+import datetime
+import pickle
+import sys
 import rootUtils as ut
 
 pdg   = ROOT.TDatabasePDG()
@@ -52,11 +56,8 @@ def GetGoodAndBadRuns(startDate,endDate):
    for x in test:
      if x.find('run_fixedTarget')>0:
       test2 = os.listdir(globalPath+str(theRun)+'/'+x)
-      bad  = True
-      tmpF = False
       f = globalPath+str(theRun)+"/"+x+"/"+fileName
       if fnames+"tmp" in test2:
-        tmpF = True 
         f = f+"tmp"
       elif fnames in test2:
         f = f
@@ -74,7 +75,6 @@ def GetGoodAndBadRuns(startDate,endDate):
            badRuns.append(theRun)
            continue
          if t.FindObjectAny('cbmsim'):
-            bad = False
             goodRuns.append(f)
             t.Close()
       except:
@@ -265,15 +265,12 @@ def makeHistos(rfile):
  h={}
  ut.bookHist(h,'pids','pid',19999,-9999.5,9999.5)
  ut.bookHist(h,'test','muon p/pt',100,0.,400.,100,0.,5.)
- diMuonDecays = [221, 223, 113, 331, 333]
- pDict = {}
- procDict = {}
  for n in range(sTree.GetEntries()):
-  rc = sTree.GetEvent(n)
+  sTree.GetEvent(n)
   for p in sTree.vetoPoint:
    t = sTree.MCTrack[p.GetTrackID()]
    pid = t.GetPdgCode()
-   rc = h['pids'].Fill(pid)
+   h['pids'].Fill(pid)
    if abs(pid)==13:
      procID = t.GetProcName().Data()
      mother = t.GetMotherId()
@@ -282,9 +279,9 @@ def makeHistos(rfile):
          name = pdg.GetParticle(moPid).GetName()
          name = procID+' '+name
          if not h.has_key(name):  h[name]=h['test'].Clone(name)
-         rc=h[name].Fill(t.GetP(),t.GetPt())
+         h[name].Fill(t.GetP(),t.GetPt())
      if not h.has_key(procID):  h[procID]=h['test'].Clone(procID)
-     rc=h[procID].Fill(t.GetP(),t.GetPt())
+     h[procID].Fill(t.GetP(),t.GetPt())
  for x in h:
   h[x].Scale(1./nTot)
  tmp = rfile.split('/')

--- a/muonShieldOptimization/extractMuonsAndUpdateWeight.py
+++ b/muonShieldOptimization/extractMuonsAndUpdateWeight.py
@@ -90,7 +90,7 @@ def processFile(fin,noCharm=True):
       sTree.GetEntry(n)
       nMu = muonUpdateWeight(sTree,diMuboost,xSecboost,noCharm)
       if nMu>0:
-       rc = newTree.Fill()
+       newTree.Fill()
     ff = f.FileHeader.Clone('Extracted Muon Background File')
     txt = ff.GetTitle()
     tmp = txt.split('=')[1]
@@ -162,8 +162,8 @@ def mergeCharm():
    fname = tmp.replace('XX',str(crun)).replace('YY',str(crun+19))
    fmu = " $EOSSHIP/eos/experiment/ship/data/Mbias/background-prod-2018/"+fname.replace('.root',"_mu.root")
    cmd += fmu
- rc = os.system(cmd)
- rc = os.system("xrdcp "+mergedFile+" $EOSSHIP/eos/experiment/ship/data/Mbias/background-prod-2018/"+mergedFile)
+ os.system(cmd)
+ os.system("xrdcp "+mergedFile+" $EOSSHIP/eos/experiment/ship/data/Mbias/background-prod-2018/"+mergedFile)
 
 def mergeMbiasAndCharm(flavour="charm"):
  done = []
@@ -187,7 +187,6 @@ def mergeMbiasAndCharm(flavour="charm"):
   nEntries[x]=f.cbmsim.GetEntries()
   Nall += nEntries[x]
  nCharm = 0
- nDone  = 0
  frac = nEntries[flavour]/float(Nall)
  print "debug",frac
  os.system('xrdcp '+pp +allFiles[flavour] +' '+allFiles[flavour])
@@ -239,7 +238,7 @@ def mergeMbiasAndCharm(flavour="charm"):
    ff = f.FileHeader.Clone('With Charm Merged Muon Background File')
   else: 
    ff = f.FileHeader.Clone('With Charm and Beauty Merged Muon Background File')
-  txt = ff.GetTitle()
+  ff.GetTitle()
   fmu.cd()
   ff.Write("FileHeader", ROOT.TObject.kSingleKey)
   fmu.Close()
@@ -256,7 +255,7 @@ def testRatio(fname):
  Nall = sTree.GetEntries()
  charm = 0
  for n in range(Nall):
-   rc = sTree.GetEvent(n)
+   sTree.GetEvent(n)
    for m in sTree.MCTrack:
     pdgID = abs(m.GetPdgCode())
     if pdgID in charmExtern:

--- a/muonShieldOptimization/extractNeutrinosAndUpdateWeight.py
+++ b/muonShieldOptimization/extractNeutrinosAndUpdateWeight.py
@@ -73,7 +73,7 @@ def run():
  global weight 
  weight = weightMbias 
  for run in range(0,67000,1000):
-   rc = processFile(tmp.replace('XX',str(run)))
+   processFile(tmp.replace('XX',str(run)))
  ut.writeHists(h,'pythia8_Geant4_10.0_c0-67000_nu.root')
 
 def run1GeV():
@@ -81,7 +81,7 @@ def run1GeV():
  global weight 
  weight = weightMbias1GeV
  for run in range(0,19000,1000):
-   rc = processFile(tmp.replace('XX',str(run)))
+   processFile(tmp.replace('XX',str(run)))
  ut.writeHists(h,'pythia8_Geant4_1.0_c0-19000_nu.root')
 
 def run4Charm():
@@ -92,14 +92,14 @@ def run4Charm():
   for run in range(0,100,20):
    crun = run+cycle*1000
    fname = tmp.replace('XX',str(crun)).replace('YY',str(crun+19))
-   rc = processFile(fname,False)
+   processFile(fname,False)
  ut.writeHists(h,'pythia8_Geant4_charm_10.0_nu.root')
 
 def run4Charm1GeV():
  fname = "pythia8_Geant4_charm_0-19_1.0.root" # renamed pythia8_Geant4_charm_XX-YY_10.0.root
  global weight
  weight = weightCharm1GeV
- rc = processFile(fname,False)
+ processFile(fname,False)
  ut.writeHists(h,'pythia8_Geant4_charm_1.0_nu.root')
 
 def run4beauty():

--- a/muonShieldOptimization/g4Ex.py
+++ b/muonShieldOptimization/g4Ex.py
@@ -198,7 +198,7 @@ class ScoreSD(G4VSensitiveDetector):
     G4VSensitiveDetector.__init__(self, Name)
 
   def ProcessHits(self, step, rohist):
-    preStepPoint = step.GetPreStepPoint()
+    step.GetPreStepPoint()
     track        = step.GetTrack()
     part         = track.GetDynamicParticle()
     pid          = part.GetPDGcode()
@@ -227,15 +227,15 @@ def ConstructGeom():
   snoopy   = G4EzVolume("Snoopy")
   snoopy.CreateTubeVolume(vac, 0., 10*m,  50.*m)
   snoopyPhys = snoopy.PlaceIt(G4ThreeVector(0.,0.,0.*m))
-  snoopyLog  = snoopyPhys.GetLogicalVolume()
+  snoopyPhys.GetLogicalVolume()
   snoopy.SetVisibility(False)
   # a target box is placed
   global target,targetPhys
   iron     = G4Material.GetMaterial("G4_Fe")
-  air      = G4Material.GetMaterial("G4_AIR")
+  G4Material.GetMaterial("G4_AIR")
   tungsten = G4Material.GetMaterial("G4_W")
-  lead     = G4Material.GetMaterial("G4_Pb")
-  alum     = G4Material.GetMaterial("G4_Al")
+  G4Material.GetMaterial("G4_Pb")
+  G4Material.GetMaterial("G4_Al")
   target   = G4EzVolume("Target")
   target.CreateTubeVolume(tungsten, 0., 25.*cm,     25.*cm)
   targetPhys = target.PlaceIt(G4ThreeVector(0.,0.,-50.*m+25.*cm),1,snoopy)

--- a/muonShieldOptimization/g4Ex_args.py
+++ b/muonShieldOptimization/g4Ex_args.py
@@ -253,7 +253,7 @@ class ScoreSD(G4VSensitiveDetector):
     G4VSensitiveDetector.__init__(self, Name)
 
   def ProcessHits(self, step, rohist):
-    preStepPoint = step.GetPreStepPoint()
+    step.GetPreStepPoint()
     track        = step.GetTrack()
     part         = track.GetDynamicParticle()
     pid          = part.GetPDGcode()
@@ -282,15 +282,15 @@ def ConstructGeom():
   snoopy   = G4EzVolume("Snoopy")
   snoopy.CreateTubeVolume(vac, 0., 10*m,  50.*m)
   snoopyPhys = snoopy.PlaceIt(G4ThreeVector(0.,0.,0.*m))
-  snoopyLog  = snoopyPhys.GetLogicalVolume()
+  snoopyPhys.GetLogicalVolume()
   snoopy.SetVisibility(False)
   # a target box is placed
   global target,targetPhys
   iron     = G4Material.GetMaterial("G4_Fe")
-  air      = G4Material.GetMaterial("G4_AIR")
+  G4Material.GetMaterial("G4_AIR")
   tungsten = G4Material.GetMaterial("G4_W")
-  lead     = G4Material.GetMaterial("G4_Pb")
-  alum     = G4Material.GetMaterial("G4_Al")
+  G4Material.GetMaterial("G4_Pb")
+  G4Material.GetMaterial("G4_Al")
   target   = G4EzVolume("Target")
   target.CreateTubeVolume(tungsten, 0., 25.*cm,     25.*cm)
   targetPhys = target.PlaceIt(G4ThreeVector(0.,0.,-50.*m+25.*cm),1,snoopy)

--- a/muonShieldOptimization/g4Ex_gap.py
+++ b/muonShieldOptimization/g4Ex_gap.py
@@ -314,7 +314,7 @@ class MyTrackingActionD(G4UserTrackingAction):
       pid          = part.GetPDGcode()
       vx           = atrack.GetVertexPosition()
       mom  = atrack.GetMomentum()
-      ekin = atrack.GetKineticEnergy()/GeV
+      atrack.GetKineticEnergy()/GeV
       pos  = atrack.GetPosition()
       w = atrack.GetWeight()
       parentid = int(w)/100000-10000
@@ -377,7 +377,7 @@ class ScoreSD(G4VSensitiveDetector):
     G4VSensitiveDetector.__init__(self, Name)
 
   def ProcessHits(self, step, rohist):
-    preStepPoint = step.GetPreStepPoint()
+    step.GetPreStepPoint()
     track        = step.GetTrack()
     part         = track.GetDynamicParticle()
     pid          = part.GetPDGcode()
@@ -387,7 +387,7 @@ class ScoreSD(G4VSensitiveDetector):
     M            = part.GetMass()
     Pvx          = ROOT.TMath.Sqrt( ekinvx*(ekinvx+2*M) )
     mom  = track.GetMomentum()
-    ekin = track.GetKineticEnergy()/GeV
+    track.GetKineticEnergy()/GeV
     pos = track.GetPosition()
 #
     # primPart = part.GetPrimaryParticle()
@@ -415,16 +415,16 @@ def ConstructGeom():
   snoopy   = G4EzVolume("Snoopy")
   snoopy.CreateTubeVolume(vac, 0.,          20*m,     world_r/2.)
   snoopyPhys = snoopy.PlaceIt(G4ThreeVector(0.,0.,0.*m))
-  snoopyLog  = snoopyPhys.GetLogicalVolume()
+  snoopyPhys.GetLogicalVolume()
   snoopy.SetVisibility(False)
   # a target box is placed
   global target,targetPhys
   iron     = G4Material.GetMaterial("G4_Fe")
-  air      = G4Material.GetMaterial("G4_AIR")
+  G4Material.GetMaterial("G4_AIR")
   water    = G4Material.GetMaterial("G4_WATER")
   tungsten = G4Material.GetMaterial("G4_W")
-  lead     = G4Material.GetMaterial("G4_Pb")
-  alum     = G4Material.GetMaterial("G4_Al")
+  G4Material.GetMaterial("G4_Pb")
+  G4Material.GetMaterial("G4_Al")
   elementMo  = G4Element("Molybdenum","Mo",42.,   95.94*g/mole)
   molybdenum = G4Material("molybdenum", 10.22*g/cm3, 1)
   molybdenum.AddElement(elementMo, 1.00)
@@ -458,7 +458,7 @@ def ConstructGeom():
   # put iron around
    moreShielding = G4EzVolume("moreShielding")
    moreShielding.CreateTubeVolume(iron, 30.*cm, 400.*cm,  targetL/2.)
-   moreShieldingPhys = moreShielding.PlaceIt(G4ThreeVector(0.,0.,z0Pos + targetL/2.),1,snoopy)
+   moreShielding.PlaceIt(G4ThreeVector(0.,0.,z0Pos + targetL/2.),1,snoopy)
 #
   else:  # new design with mixture Molybdaen and Tungsten
    slitDZ   = 0.5*cm
@@ -497,12 +497,12 @@ def ConstructGeom():
    yTot = 400.*cm
    moreShieldingTopBot = G4EzVolume("moreShieldingTopBot")
    moreShieldingTopBot.CreateBoxVolume(iron, xTot, yTot/2., targetL)
-   moreShieldingTopPhys = moreShieldingTopBot.PlaceIt(G4ThreeVector(0.,diameter/2. +spaceTopBot+yTot/4.,z0Pos + targetL/2.),1,snoopy)
-   moreShieldingBotPhys = moreShieldingTopBot.PlaceIt(G4ThreeVector(0.,-diameter/2.-spaceTopBot-yTot/4.,z0Pos + targetL/2.),1,snoopy)
+   moreShieldingTopBot.PlaceIt(G4ThreeVector(0.,diameter/2. +spaceTopBot+yTot/4.,z0Pos + targetL/2.),1,snoopy)
+   moreShieldingTopBot.PlaceIt(G4ThreeVector(0.,-diameter/2.-spaceTopBot-yTot/4.,z0Pos + targetL/2.),1,snoopy)
    moreShieldingSide = G4EzVolume("moreShieldingSide")
    moreShieldingSide.CreateBoxVolume(iron, xTot/2., diameter+1.9*spaceTopBot, targetL)
-   moreShieldingLeftPhys  = moreShieldingSide.PlaceIt(G4ThreeVector(diameter/2. +spaceSide+xTot/4.,0.,z0Pos + targetL/2.),1,snoopy)
-   moreShieldingRightPhys = moreShieldingSide.PlaceIt(G4ThreeVector(-diameter/2.-spaceSide-xTot/4.,0.,z0Pos + targetL/2.),1,snoopy)
+   moreShieldingSide.PlaceIt(G4ThreeVector(diameter/2. +spaceSide+xTot/4.,0.,z0Pos + targetL/2.),1,snoopy)
+   moreShieldingSide.PlaceIt(G4ThreeVector(-diameter/2.-spaceSide-xTot/4.,0.,z0Pos + targetL/2.),1,snoopy)
   # = 0.1m3 = 2t
   # a hadron absorber is placed
   absorberL = 2*150.*cm

--- a/muonShieldOptimization/g4Ex_gap_mergeFiles.py
+++ b/muonShieldOptimization/g4Ex_gap_mergeFiles.py
@@ -150,7 +150,7 @@ def makeFinalNtuples(norm=5.E13,opt=''):
     t.SetEventList(temp) 
     nev    = temp.GetN()
     for iev in range(nev) :
-     rc = t.GetEntry(temp.GetEntry(iev))
+     t.GetEntry(temp.GetEntry(iev))
      leaves = t.GetListOfLeaves()
      vlist = array('f')
      for x in range(leaves.GetEntries()):

--- a/muonShieldOptimization/makeMuonDIS.py
+++ b/muonShieldOptimization/makeMuonDIS.py
@@ -1,4 +1,6 @@
-import ROOT,time,os,sys
+import ROOT
+import sys
+import time
 nJob   = 2
 nMult  = 10 # number of events / muon
 muonIn = '$SHIPSOFT/data/muConcrete.root'

--- a/muonShieldOptimization/makeMuonEM.py
+++ b/muonShieldOptimization/makeMuonEM.py
@@ -1,4 +1,4 @@
-import ROOT,time,os,sys
+import ROOT
 nJob   = 1
 nMult  = 1000 # 100000 # number of events / muon
 muonIn = '/media/Data/HNL/muVetoDIS/muDISVetoCounter.root'

--- a/muonShieldOptimization/muDIS_mergeFiles.py
+++ b/muonShieldOptimization/muDIS_mergeFiles.py
@@ -37,13 +37,13 @@ def makePlots(sTree):
  ut.bookHist(h,'nOut','outgoing part',100,-0.5,99.5)
  ut.bookHist(h,'pos','position',100,-25.,100.,100,-12.,12.,100,-13.,13.)
  for n in range(sTree.GetEntries()):
-   rc = sTree.GetEvent(n)
+   sTree.GetEvent(n)
    inMu = sTree.InMuon[0]
    w = inMu[8]
    P = ROOT.TMath.Sqrt(inMu[1]**2+inMu[2]**2+inMu[3]**2)
-   rc = h['muP'].Fill(P,w)
-   rc = h['nOut'].Fill(sTree.Particles.GetEntries() )
-   rc = h['pos'].Fill(inMu[7],inMu[5],inMu[6] )
+   h['muP'].Fill(P,w)
+   h['nOut'].Fill(sTree.Particles.GetEntries() )
+   h['pos'].Fill(inMu[7],inMu[5],inMu[6] )
 def test(fn = "test.root"):
  fm    = ROOT.TFile(fn)
  sTree = fm.DIS

--- a/muonShieldOptimization/runCharmHadProd.py
+++ b/muonShieldOptimization/runCharmHadProd.py
@@ -22,7 +22,7 @@ else:
 
 def makeHadrons(run):
  for n in range(ncpus):
-  s = x.Rndm()*1000000000.
+  x.Rndm()*1000000000.
   os.system('mkdir run'+str(run))
   os.chdir('run'+str(run))
   cmd = "python $FAIRSHIP/macro/makeCascade.py -m "+msel+" -n " + str(nev) + " -t  Cascade-run"+str(run)+"-parp16-MSTP82-1-MSEL"+msel+".root"

--- a/muonShieldOptimization/run_MufluxfixedTarget.py
+++ b/muonShieldOptimization/run_MufluxfixedTarget.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT
+import os
+import shipRoot_conf
+import time
 import shipunit as u
 from ShipGeoConfig import ConfigRegistry
 

--- a/muonShieldOptimization/run_fixedTarget.py
+++ b/muonShieldOptimization/run_fixedTarget.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT
+import os
+import shipRoot_conf
 import shipunit as u
 from ShipGeoConfig import ConfigRegistry
 

--- a/muonShieldOptimization/run_reco.py
+++ b/muonShieldOptimization/run_reco.py
@@ -43,7 +43,7 @@ def execute( ncpu = 4 ):
   for x in jobs:
       if k==ncpu: k = 0
       if cpus[k].has_key('child'):
-        rc = child.communicate()[0]
+        child.communicate()[0]
         log[k]['log'].close() 
       print "change to directory ",k,x   
       os.chdir('./'+x) 
@@ -134,7 +134,7 @@ def executeSimple(prefixes,reset=False):
      try:    os.system("rm logAna") 
      except: pass
      os.system("python "+cmdAna+" -n 9999999 -f "+inputfile.replace('.root','_rec.root')+ " >> logAna &")
-     rc = proc.pop(p) 
+     proc.pop(p) 
      time.sleep(10)
     else:
      print 'Rec job not finished yet',p
@@ -144,7 +144,6 @@ def executeSimple(prefixes,reset=False):
     os.chdir('../')
      
 def executeAna(prefixes):
- cpus = {}
  log  = {} 
  for prefix in prefixes:
   jobs = getJobs(prefix)

--- a/muonShieldOptimization/study_GammaConv.py
+++ b/muonShieldOptimization/study_GammaConv.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT
+import shipRoot_conf
+import sys
+import time
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 
@@ -67,7 +70,7 @@ class Block(ROOT.pyFairModule):
     ShipMedium=media.getMedium(material)
     W = ROOT.gGeoManager.GetMedium(material)
     if not W: 
-        rc = geoBuild.createMedium(ShipMedium)
+        geoBuild.createMedium(ShipMedium)
         W = ROOT.gGeoManager.GetMedium(material)
     aBox = ROOT.gGeoManager.MakeBox("target", W, 100.*u.cm, 100.*u.cm, thickness)
     top.AddNode(aBox, 1, ROOT.TGeoTranslation(0, 0, 0 ))

--- a/muonShieldOptimization/study_muEloss.py
+++ b/muonShieldOptimization/study_muEloss.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT
+import shipRoot_conf
+import sys
+import time
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 
@@ -59,7 +62,7 @@ def run():
  if nev==0: run.SetOutputFile("dummy.root")
  else: run.SetOutputFile(outFile)  # Output file
  run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C
- rtdb = run.GetRuntimeDb() 
+ run.GetRuntimeDb() 
 # -----Materials----------------------------------------------
  run.SetMaterials("media.geo")  
 # -----Create geometry----------------------------------------------
@@ -130,15 +133,15 @@ def makePlot(f,book=True):
   ut.bookHist(h,'elossRaw','energy loss as function of momentum GeV/c',100,0,maxTheta, 10000,0.,100.)
  sTree = f.cbmsim
  for n in range(sTree.GetEntries()):
-  rc = sTree.GetEvent(n)
+  sTree.GetEvent(n)
   Ein  = sTree.MCTrack[0].GetEnergy()
-  M = sTree.MCTrack[0].GetMass()
+  sTree.MCTrack[0].GetMass()
   Eloss = 0
   for aHit in sTree.vetoPoint: 
     Eloss+=aHit.GetEnergyLoss()
     print Ein,Eloss/Ein
-  rc = h['eloss'].Fill(Ein,Eloss/Ein)
-  rc = h['elossRaw'].Fill(Ein,Eloss)
+  h['eloss'].Fill(Ein,Eloss/Ein)
+  h['elossRaw'].Fill(Ein,Eloss)
  ut.bookCanvas(h,key=s,title=s,nx=900,ny=600,cx=1,cy=1)
  tc = h[s].cd(1)
  if s=="NA62":
@@ -147,7 +150,7 @@ def makePlot(f,book=True):
   h['95'].Sumw2()
   h['0'] = h['eloss'].ProjectionX('0',1,100)
   h['0'].Sumw2()
-  rc = h['95'].Divide(h['0'] )
+  h['95'].Divide(h['0'] )
   h['95'].Draw()
   h['meanEloss'] = h['elossRaw'].ProjectionX()
   for n in range(1,h['elossRaw'].GetNbinsX()+1):
@@ -222,7 +225,7 @@ def makeSummaryPlot():
  ut.readHists(h,"/mnt/hgfs/microDisk/Data/eloss/eloss_sum.root")
  ut.readHists(h,"/mnt/hgfs/microDisk/Data/eloss/eloss_withRaw.root")
  ut.bookCanvas(h,key='summary',title=" ",nx=1200,ny=600,cx=2,cy=1)
- tc = h['summary'].cd(1)
+ h['summary'].cd(1)
  h['0'] = h['eloss'].ProjectionX('0',1,h['eloss'].GetNbinsY())
  h['0'].Sumw2()
  NA62()
@@ -231,7 +234,7 @@ def makeSummaryPlot():
   h[t].Sumw2()
   h[t].SetStats(0)
   h[t].SetMarkerStyle(24)
-  rc = h[t].Divide(h['0'] )
+  h[t].Divide(h['0'] )
   h[t].Rebin(2)
   h[t].Scale(1./2.)
   if t!=93: 
@@ -250,7 +253,7 @@ def makeSummaryPlot():
  h['lg'].AddEntry(h[95],'FairShip >95%','PL')
  h['lg'].AddEntry(h[93],'FairShip >93%','PL')
  h['lg'].Draw()
- tc = h['summary'].cd(2)
+ h['summary'].cd(2)
  h['meanEloss'] = h['elossRaw'].ProjectionX()
  for n in range(1,h['elossRaw'].GetNbinsX()+1):
     tmp = h['elossRaw'].ProjectionY('tmp',n,n)

--- a/muonShieldOptimization/study_muMSC.py
+++ b/muonShieldOptimization/study_muMSC.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT
+import shipRoot_conf
+import sys
+import time
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 
@@ -67,7 +70,7 @@ class Block(ROOT.pyFairModule):
     ShipMedium=media.getMedium(material)
     W = ROOT.gGeoManager.GetMedium(material)
     if not W: 
-        rc = geoBuild.createMedium(ShipMedium)
+        geoBuild.createMedium(ShipMedium)
         W = ROOT.gGeoManager.GetMedium(material)
     aBox = ROOT.gGeoManager.MakeBox("target", W, 100.*u.cm, 100.*u.cm, thickness)
     top.AddNode(aBox, 1, ROOT.TGeoTranslation(0, 0, 0 ))

--- a/muonShieldOptimization/study_thinTarget.py
+++ b/muonShieldOptimization/study_thinTarget.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python 
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT
+import shipRoot_conf
+import time
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 
@@ -63,7 +65,7 @@ class Block(ROOT.pyFairModule):
     ShipMedium=media.getMedium(material)
     W = ROOT.gGeoManager.GetMedium(material)
     if not W: 
-        rc = geoBuild.createMedium(ShipMedium)
+        geoBuild.createMedium(ShipMedium)
         W = ROOT.gGeoManager.GetMedium(material)
     aBox = ROOT.gGeoManager.MakeBox("target", W, 100.*u.cm, 100.*u.cm, thickness)
     top.AddNode(aBox, 1, ROOT.TGeoTranslation(0, 0, 0 ))

--- a/python/CMBG_conf.py
+++ b/python/CMBG_conf.py
@@ -1,4 +1,4 @@
-import ROOT, os
+import ROOT
 import shipunit as u
 
 def configure(CMBG, ship_geo):

--- a/python/MufluxDigi.py
+++ b/python/MufluxDigi.py
@@ -52,7 +52,7 @@ class MufluxDigi:
         self.iEvent = 0
 
         outdir=os.getcwd()
-        outfile=outdir+"/"+fout
+        outdir+"/"+fout
         self.fn = ROOT.TFile(fout,'update')
         self.sTree = self.fn.cbmsim
 
@@ -161,7 +161,6 @@ class MufluxDigi:
 
         if fake_clustering:
             # cluster size loop - plotting the cluster size distribution
-            cluster_size = list()
             DetectorID_list = list(DetectorID)  # turn set into list to allow indexing
             DetectorID_list.sort()  # sorting the list
             if len(DetectorID_list) > 1:
@@ -171,7 +170,7 @@ class MufluxDigi:
                         clusters[-1].append(x)
                     else:
                         clusters.append([x])
-                    cluster_size = [len(x) for x in clusters]
+                    [len(x) for x in clusters]
 
     def digitizeMufluxSpectrometer(self):
 

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -53,7 +53,7 @@ class MufluxDigiReco:
         self.iEvent = 0
 
         outdir=os.getcwd()
-        outfile=outdir+"/"+fout
+        outdir+"/"+fout
         self.fn = ROOT.TFile(fout,'update')
         self.sTree = self.fn.cbmsim
 
@@ -78,7 +78,7 @@ class MufluxDigiReco:
             newTree = sTree.CloneTree(0)
             for n in range(sTree.GetEntries()):
                 sTree.GetEntry(n)
-                rc = newTree.Fill()
+                newTree.Fill()
             sTree.Clear()
             newTree.AutoSave()
             f.Close()
@@ -139,7 +139,7 @@ class MufluxDigiReco:
                 os.mkdir(output_dir)
 
     def reconstruct(self):
-        ntracks = self.findTracks()
+        self.findTracks()
 
     def digitize(self):
 
@@ -280,21 +280,21 @@ class MufluxDigiReco:
             ycoord = MufluxHit.GetY()
             if abs(pid)==13:
                 if (detector[0:8]=="gas_12_1"):
-                    rc=h['hits-T1'].Fill(xcoord,ycoord)
+                    h['hits-T1'].Fill(xcoord,ycoord)
                 if (detector[0:9]=="gas_12_10"):
-                    rc=h['hits-T1x'].Fill(xcoord,ycoord)
+                    h['hits-T1x'].Fill(xcoord,ycoord)
                 if (detector[0:9]=="gas_12_11"):
-                    rc=h['hits-T1u'].Fill(xcoord,ycoord)
+                    h['hits-T1u'].Fill(xcoord,ycoord)
                 if (detector[0:8]=="gas_12_2"):
-                    rc=h['hits-T2'].Fill(xcoord,ycoord)
+                    h['hits-T2'].Fill(xcoord,ycoord)
                 if (detector[0:9]=="gas_12_20"):
-                    rc=h['hits-T2v'].Fill(xcoord,ycoord)
+                    h['hits-T2v'].Fill(xcoord,ycoord)
                 if (detector[0:9]=="gas_12_21"):
-                    rc=h['hits-T2x'].Fill(xcoord,ycoord)
+                    h['hits-T2x'].Fill(xcoord,ycoord)
                 if (detector[0:5]=="gas_3"):
-                    rc=h['hits-T3'].Fill(xcoord,ycoord)
+                    h['hits-T3'].Fill(xcoord,ycoord)
                 if (detector[0:5]=="gas_4"):
-                    rc=h['hits-T4'].Fill(xcoord,ycoord)
+                    h['hits-T4'].Fill(xcoord,ycoord)
 
             if (detector[0:9]=="gas_12_10"):
                 if T1_entries_px.has_key(MufluxTrackId):
@@ -317,7 +317,7 @@ class MufluxDigiReco:
             if (T1_entries_px.get(MufluxTrackId) is None or T4_entries_px.get(MufluxTrackId) is None) :
                 continue
             else:
-                rc=h['pt-kick'].Fill(T1_entries_px.get(MufluxTrackId)[0]-T4_entries_px.get(MufluxTrackId)[0])
+                h['pt-kick'].Fill(T1_entries_px.get(MufluxTrackId)[0]-T4_entries_px.get(MufluxTrackId)[0])
 
     def withT0Estimate(self):
         # loop over all straw tdcs and make average, correct for ToF
@@ -393,7 +393,7 @@ class MufluxDigiReco:
 
     def correctAlignment(self, hit):
         # Taken from charmdet/drifttubeMonitoring.py
-        sqrt2 = ROOT.TMath.Sqrt(2.)
+        ROOT.TMath.Sqrt(2.)
         cos30 = ROOT.TMath.Cos(30./180.*ROOT.TMath.Pi())
         sin30 = ROOT.TMath.Sin(30./180.*ROOT.TMath.Pi())
         #delX=[[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]]
@@ -402,7 +402,7 @@ class MufluxDigiReco:
         delUV = [[0,0,0,0],[0,0,0,0]]
         vtop = ROOT.TVector3()
         vbot = ROOT.TVector3()
-        rc = hit.MufluxSpectrometerEndPoints(vbot,vtop)
+        hit.MufluxSpectrometerEndPoints(vbot,vtop)
         s,v,p,l,view = self.stationInfo(hit)
         if view=='_x':
             cor = delX[s-1][2*l+p]
@@ -688,7 +688,7 @@ class MufluxDigiReco:
             atrack_y12 = atrack['y12']
             atrack_stereo12 = atrack['stereo12']
             atrack_34 = atrack['34']
-            atrack_y_tagger = atrack['y_tagger']
+            atrack['y_tagger']
 
             if len(atrack_y12) > 0:
                 reco_hit_ids_y12 = []
@@ -1219,8 +1219,8 @@ class MufluxDigiReco:
                 atrack_34 = atrack['34']
                 atrack_smeared_hits = list(atrack_y12) + list(atrack_stereo12) + list(atrack_34)
                 atrack_p = np.abs(atrack['p'])
-                atrack_y_in_magnet = atrack['y_in_magnet']
-                atrack_x_in_magnet = atrack['x_in_magnet']
+                atrack['y_in_magnet']
+                atrack['x_in_magnet']
 
                 for sm in atrack_smeared_hits:
 
@@ -1333,7 +1333,7 @@ class MufluxDigiReco:
             #if len(stationCrossed[atrack]) < 4 :
             #    continue  # not enough stations crossed to make a good trackfit
 
-            charge = self.PDG.GetParticle(pdg).Charge()/(3.)
+            self.PDG.GetParticle(pdg).Charge()/(3.)
             posM = ROOT.TVector3(0, 0, 0)
             momM = ROOT.TVector3(0,0,mom_init * u.GeV)
             # approximate covariance
@@ -1386,7 +1386,7 @@ class MufluxDigiReco:
             if len(stationCrossed[atrack]) < 4 :
                 continue  # not enough stations crossed to make a good trackfit
 
-            charge = self.PDG.GetParticle(pdg).Charge()/(3.)
+            self.PDG.GetParticle(pdg).Charge()/(3.)
             posM = ROOT.TVector3(0, 0, 0)
             momM = ROOT.TVector3(0,0,mom_init * u.GeV)
             # approximate covariance
@@ -1437,7 +1437,7 @@ class MufluxDigiReco:
             if len(stationCrossed[atrack]) < 3 :
                 continue  # not enough stations crossed to make a good trackfit
 
-            charge = self.PDG.GetParticle(pdg).Charge()/(3.)
+            self.PDG.GetParticle(pdg).Charge()/(3.)
             posM = ROOT.TVector3(0, 0, 0)
             momM = ROOT.TVector3(0,0,mom_init * u.GeV)
             # approximate covariance

--- a/python/MufluxPatRec.py
+++ b/python/MufluxPatRec.py
@@ -29,7 +29,6 @@ def execute(SmearedHits, TaggerHits, withNTaggerHits, withDist2Wire, debug=0):
     # TaggerHits = []
 
     
-    fittedtrackids = []
     track_hits = {}
     if len(SmearedHits) > 100:
         print "Too large hits in the event!"

--- a/python/PythiaList.py
+++ b/python/PythiaList.py
@@ -1,4 +1,5 @@
-import ROOT,time,sys
+import ROOT
+import sys
 id=int(sys.argv[1])
 ROOT.gSystem.Load("libEG")
 ROOT.gSystem.Load("libpythia8")

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -20,7 +20,7 @@ def getParameter(x,ship_geo,latestCharmGeo):
   return getattr(a,last)
 
 def configure(run,ship_geo,Gfield=''):
- latestCharmGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py")
+ ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py")
 # -----Create media-------------------------------------------------
  run.SetMaterials("media.geo")  # Materials
  

--- a/python/configGenieGenerator.py
+++ b/python/configGenieGenerator.py
@@ -4,8 +4,8 @@ def config(GenieGen):
  fGeo = ROOT.gGeoManager
  top = fGeo.GetTopVolume()
 # positions for nu events inside the nutau detector volume
- muDetector      = top.FindNode("volNuTauMudet_1")
- muDetectorTrans = muSpectrometer.GetMatrix().GetTranslation()
+ top.FindNode("volNuTauMudet_1")
+ muSpectrometer.GetMatrix().GetTranslation()
 # upper and lower yokes:
 # volFeYoke_1, volFeYoke_2, volFeYoke1_1  (in UpYoke) and  volFeYoke_3, volFeYoke_4, volFeYoke1_1 (in LowYoke).
  yokes = ["volUpYoke_1","volLowYoke_1","volArm2Mudet_1"]
@@ -30,8 +30,8 @@ def config(GenieGen):
  zpos   = ( dVec["volArm2Mudet_1/volIron_12"].Z()+dVec["volArm2Mudet_1/volIron_23"].Z() )/2.
  box["volArm2Mudet_1/volIron_12-23"]  = ROOT.TVector3(box["volArm2Mudet_1/volIron_12"].X(),box["volArm2Mudet_1/volIron_12"].Y(),length)
  dVec["volArm2Mudet_1/volIron_12-23"] = ROOT.TVector3(0,0,zpos)
- rc = box.pop("volArm2Mudet_1/volIron_23")
- rc = box.pop("volArm2Mudet_1/volIron_12")
+ box.pop("volArm2Mudet_1/volIron_23")
+ box.pop("volArm2Mudet_1/volIron_12")
  if GenieGen=='debug':
   for aVol in box: 
    print '%50s %6.2F %6.2F %6.2F %5.2F %7.2F %7.2F '%(aVol,box[aVol].X(),box[aVol].Y(),box[aVol].Z(),dVec[aVol].X(),dVec[aVol].Y(),dVec[aVol].Z()) 

--- a/python/decorators.py
+++ b/python/decorators.py
@@ -66,7 +66,7 @@ def TEvePointSetPrintOut(P):
  txt = ''
  if P.GetN()==0: txt = '<ROOT.TEvePointSet object>'
  for n in range(P.GetN()):
-  rc = P.GetPoint(n,x,y,z)
+  P.GetPoint(n,x,y,z)
   txt += '%6i %7.1F,%7.1F,%9.1F x,y,z cm\n'%(n,x,y,z)
  return txt
 

--- a/python/dpProductionRates.py
+++ b/python/dpProductionRates.py
@@ -1,4 +1,5 @@
-import ROOT,os,sys,getopt,math
+import ROOT
+import math
 import shipunit as u
 import proton_bremsstrahlung
 

--- a/python/goliath2root.py
+++ b/python/goliath2root.py
@@ -3,7 +3,7 @@
 # EvH 11/4/2018
 
 
-import ROOT,os,sys
+import ROOT
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf

--- a/python/pi0Reco.py
+++ b/python/pi0Reco.py
@@ -1,4 +1,4 @@
-import ROOT,os
+import ROOT
 import shipunit as u
 import rootUtils as ut
 pdg = ROOT.TDatabasePDG.Instance()

--- a/python/proton_bremsstrahlung.py
+++ b/python/proton_bremsstrahlung.py
@@ -1,7 +1,7 @@
 import numpy as np
 import ROOT as r
 import math
-import os,sys
+import sys
 from scipy.integrate import quad, dblquad
 
 from darkphoton import *

--- a/python/pythia8_conf.py
+++ b/python/pythia8_conf.py
@@ -19,7 +19,7 @@ def configurerpvsusy(P8gen, mass, couplings, sfermionmass, benchmark, inclusive,
     P8gen.UseRandom3() 
     P8gen.SetMom(400)  # beam momentum in GeV 
     if deepCopy: P8gen.UseDeepCopy()
-    pdg = ROOT.TDatabasePDG.Instance()
+    ROOT.TDatabasePDG.Instance()
     # let strange particle decay in Geant4
     make_particles_stable(P8gen, above_lifetime=1)
 
@@ -48,10 +48,9 @@ def configurerpvsusy(P8gen, mass, couplings, sfermionmass, benchmark, inclusive,
         # 12 14 16 neutrinos replace with N2
         charmhistograms = ['d_mu','ds_mu']
         # no tau decay here to consider
-        totaltauBR      = 0.0 
         maxsumBR        = getmaxsumbrrpvsusy(h,charmhistograms,mass,couplings)
         exit_if_zero_br(maxsumBR, inclusive, mass, particle='RPV neutralino')
-        totalBR         = gettotalbrrpvsusy(h,charmhistograms,mass,couplings)
+        gettotalbrrpvsusy(h,charmhistograms,mass,couplings)
 
 
         #overwrite D_s+ decays
@@ -97,7 +96,7 @@ def configurerpvsusy(P8gen, mass, couplings, sfermionmass, benchmark, inclusive,
         beautyhistograms = ['b_mu','b_tau','b0_nu_mu','b0_nu_tau']
         maxsumBR=getmaxsumbrrpvsusy(h,beautyhistograms,mass,couplings)
         exit_if_zero_br(maxsumBR, inclusive, mass, particle='RPV neutralino')
-        totalBR=gettotalbrrpvsusy(h,beautyhistograms,mass,couplings)
+        gettotalbrrpvsusy(h,beautyhistograms,mass,couplings)
 
         #overwrite B+ decays
         P8gen.SetParameters("521:new  B+               B-    1   3   0    5.27925"\
@@ -147,7 +146,7 @@ def configure(P8gen, mass, production_couplings, decay_couplings, process_select
     P8gen.UseRandom3() # TRandom1 or TRandom3 ?
     P8gen.SetMom(400)  # beam momentum in GeV 
     if deepCopy: P8gen.UseDeepCopy()
-    pdg = ROOT.TDatabasePDG.Instance()
+    ROOT.TDatabasePDG.Instance()
     P8gen.SetParameters("Next:numberCount    =  0")
     # let strange particle decay in Geant4
     make_particles_stable(P8gen, above_lifetime=1)

--- a/python/pythia8_conf_utils.py
+++ b/python/pythia8_conf_utils.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import os
 import sys
 import re
 import six
@@ -26,7 +25,7 @@ def getmaxsumbrrpvsusy(h,histograms,mass,couplings):
     sumbrs={}
     for histoname in histograms: 
        item = histoname.split('_') 
-       lepton = item[len(item)-1]
+       item[len(item)-1]
        meson = item[0]
        coupling=couplings[1]
        try:
@@ -40,7 +39,7 @@ def getmaxsumbrrpvsusy(h,histograms,mass,couplings):
 def gettotalbrrpvsusy(h,histograms,mass,couplings):
     totalbr=0.0 
     for histoname in histograms: 
-       item = histoname.split('_') 
+       histoname.split('_') 
        coupling=couplings[1]
        totalbr+=getbr_rpvsusy(h,histoname,mass,coupling)
     return totalbr

--- a/python/pythia8darkphoton_conf.py
+++ b/python/pythia8darkphoton_conf.py
@@ -1,4 +1,5 @@
-import ROOT, os, sys
+import ROOT
+import os
 import shipunit as u
 import readDecayTable
 import darkphoton
@@ -81,7 +82,7 @@ def configure(P8gen, mass, epsilon, inclusive, deepCopy=False):
     P8gen.UseRandom3() # TRandom1 or TRandom3 ?
     P8gen.SetMom(400)  # beam momentum in GeV 
     if deepCopy: P8gen.UseDeepCopy()
-    pdg = ROOT.TDatabasePDG.Instance()
+    ROOT.TDatabasePDG.Instance()
     if inclusive=="meson":
     # let strange particle decay in Geant4
         p8 = P8gen.getPythiaInstance()

--- a/python/rootUtils.py
+++ b/python/rootUtils.py
@@ -1,6 +1,7 @@
 #---Enable Tab completion-----------------------------------------
 try:
-  import rlcompleter, readline
+  import readline
+  import rlcompleter
   readline.parse_and_bind( 'tab: complete' )
   readline.parse_and_bind( 'set show-all-if-ambiguous On' )
 except:
@@ -166,7 +167,7 @@ def stripOffBranches(fout):
      for n in range(nEvents):
       sTree.GetEntry(n)
       if oldTargetClass: sTree.TargetPoint.Clear()
-      rc = newTree.Fill()
+      newTree.Fill()
       sTree.FitTracks.Delete() # stupid ROOT or whoever, otherwise huge memory leak, does not help
     sTree.Clear()
     newTree.AutoSave()

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -4,7 +4,6 @@ else: import shipPatRec
 import shipunit as u
 import rootUtils as ut
 from array import array
-import sys 
 from math import fabs
 stop  = ROOT.TVector3()
 start = ROOT.TVector3()
@@ -39,7 +38,7 @@ class ShipDigiReco:
     newTree = sTree.CloneTree(0)
     for n in range(sTree.GetEntries()):
       sTree.GetEntry(n)
-      rc = newTree.Fill()
+      newTree.Fill()
     sTree.Clear()
     newTree.AutoSave()
     f.Close() 
@@ -179,7 +178,7 @@ class ShipDigiReco:
    self.EcalReconstructed = self.sTree.Branch("EcalReconstructed",ecalReconstructed,32000,-1)
 #
 # init geometry and mag. field
-  gMan  = ROOT.gGeoManager
+  ROOT.gGeoManager
   self.geoMat =  ROOT.genfit.TGeoMaterialInterface()
 #
   self.bfield = ROOT.genfit.FairShipFields()
@@ -201,8 +200,8 @@ class ShipDigiReco:
   shipPatRec.initialize(fgeo)
 
  def reconstruct(self):
-   ntracks = self.findTracks()
-   nGoodTracks = self.findGoodTracks()
+   self.findTracks()
+   self.findGoodTracks()
    self.linkVetoOnTracks()
    for x in self.caloTasks: 
     if hasattr(x,'execute'): x.execute()
@@ -585,7 +584,7 @@ class ShipDigiReco:
    err_y_1 = hit.GetYError()
    err_z_1 = hit.GetZError()
 
-   layer_1 = hit.GetLayerNumber()
+   hit.GetLayerNumber()
 
    # allow one or more 'missing' hit in x/y: not large difference between 1 (no gap) or 2 (one 'missing' hit)
    max_gap = 2.
@@ -767,7 +766,7 @@ class ShipDigiReco:
      if station > 4 : continue
      modules["Strawtubes"].StrawEndPoints(detID,start,stop)
    #distance to wire
-     delt1 = (start[2]-z1)/u.speedOfLight
+     (start[2]-z1)/u.speedOfLight
      p=self.sTree.strawtubesPoint[key]
      # use true t0  construction: 
      #     fdigi = t0 + p->GetTime() + t_drift + ( stop[0]-p->GetX() )/ speedOfLight;
@@ -784,7 +783,6 @@ class ShipDigiReco:
  def findTracks(self):
   hitPosLists    = {}
   stationCrossed = {}
-  fittedtrackids=[]
   listOfIndices  = {}
   self.fGenFitArray.Clear()
   self.fTrackletsArray.Delete()
@@ -858,7 +856,7 @@ class ShipDigiReco:
     if nM < 25 : continue                          # not enough hits to make a good trackfit 
     if len(stationCrossed[atrack]) < 3 : continue  # not enough stations crossed to make a good trackfit 
     if debug: 
-       mctrack = self.sTree.MCTrack[atrack]
+       self.sTree.MCTrack[atrack]
     # charge = self.PDG.GetParticle(pdg).Charge()/(3.)
     posM = ROOT.TVector3(0, 0, 0)
     momM = ROOT.TVector3(0,0,3.*u.GeV)
@@ -914,7 +912,7 @@ class ShipDigiReco:
      continue
     try:
       fittedState = theTrack.getFittedState()
-      fittedMom = fittedState.getMomMag()
+      fittedState.getMomMag()
     except:
       error = "Problem with fittedstate"
       ut.reportError(error)

--- a/python/shipEvent_ex.py
+++ b/python/shipEvent_ex.py
@@ -23,21 +23,21 @@ def exMCTracks():
  sTree.SetBranchAddress("MCTrack", MCTracks)
  detPos = (3.5*u.m+70*u.m+40*u.m-100*u.m)
  for n in range(nEvents):
-  rc = sTree.GetEvent(n) 
+  sTree.GetEvent(n) 
   nMCTracks = MCTracks.GetEntriesFast() 
-  rc = h['N'].Fill( nMCTracks )
+  h['N'].Fill( nMCTracks )
   for i in range(nMCTracks):
    atrack = MCTracks.At(i)
    pdgCode = atrack.GetPdgCode()
    mom = ROOT.TLorentzVector()
    atrack.Get4Momentum(mom)
    if abs(pdgCode)==13 or abs(pdgCode)==211:  
-    rc = h['pz'].Fill( mom.Pz() )
-    rc = h['oz'].Fill( atrack.GetStartZ() )  
+    h['pz'].Fill( mom.Pz() )
+    h['oz'].Fill( atrack.GetStartZ() )  
     lam = ( detPos-atrack.GetStartZ() )/mom.Pz()
     xdet = (atrack.GetStartX()+lam*mom.Px() )/u.m
     ydet = (atrack.GetStartY()+lam*mom.Py() )/u.m
-    rc = h['ex'].Fill(xdet,ydet ) 
+    h['ex'].Fill(xdet,ydet ) 
  h['N'].Draw('box')
 
 def exMCHits(dump=False):
@@ -46,17 +46,17 @@ def exMCHits(dump=False):
  ut.bookHist(h,'txty','tracking hits y vs x',100,-2.5,2.5,100,-2.5,2.5)
  sTree.SetBranchAddress("vetoPoint", TrackingHits)
  for n in range(nEvents):
-  rc = sTree.GetEvent(n) 
+  sTree.GetEvent(n) 
   nHits = TrackingHits.GetEntriesFast() 
   for i in range(nHits):
     ahit = TrackingHits.At(i)
-    rc = h['tz'].Fill( ahit.GetZ()/u.m )
-    rc = h['txty'].Fill( ahit.GetX()/u.m,ahit.GetY()/u.m )
-    rc = h['tztx'].Fill( ahit.GetZ()/u.m,ahit.GetX()/u.m ) 
+    h['tz'].Fill( ahit.GetZ()/u.m )
+    h['txty'].Fill( ahit.GetX()/u.m,ahit.GetY()/u.m )
+    h['tztx'].Fill( ahit.GetZ()/u.m,ahit.GetX()/u.m ) 
  h['tztx'].Draw('box') 
  if dump:
   for n in range( min(10,nEvents) ):
-   rc = sTree.GetEvent(n) 
+   sTree.GetEvent(n) 
    nHits = TrackingHits.GetEntriesFast() 
    for i in range(nHits):
     ahit = TrackingHits.At(i)

--- a/python/shipMuShield_only.py
+++ b/python/shipMuShield_only.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: latin-1 -*-
-import ROOT,os
+import ROOT
 import shipunit as u
 
 def configure(run,ship_geo):

--- a/python/shipPatRec_old.py
+++ b/python/shipPatRec_old.py
@@ -3,7 +3,7 @@
 #configuration, histograms etc done in shipPatRec_config
 #for documentation, see CERN-SHiP-NOTE-2015-002, https://cds.cern.ch/record/2005715/files/main.pdf
 #17-04-2015 comments to EvH
-import ROOT, os
+import ROOT
 import shipunit  as u
 import math
 import copy
@@ -13,7 +13,6 @@ from ROOT import gStyle
 from ROOT import TGraph
 from ROOT import TMultiGraph
 from array import array
-import operator, sys
 
 import rootUtils as ut
 
@@ -233,7 +232,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   #returns a list of reconstructible tracks for this event
   #call this routine once for each event before smearing
   MCTrackIDs=[]
-  rc = sTree.GetEvent(iEvent) 
+  sTree.GetEvent(iEvent) 
   nMCTracks = sTree.MCTrack.GetEntriesFast()   
 
   if debug==1: print "event nbr",iEvent,"has",nMCTracks,"tracks"
@@ -412,18 +411,18 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
         if childtrack.GetMotherId() == ahit.GetTrackID():	   
 	    trackmomentum=atrack.GetP()
 	    trackweight=atrack.GetWeight()
-	    rc=h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
+	    h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
 	    motherId=atrack.GetMotherId() 
 	    if motherId==1 :
 		HNLmomentum=sTree.MCTrack.At(1).GetP()
-		rc=h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum) 
+		h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum) 
 	        if j==nMCTracks :
  		     trackmomentum=atrack.GetP()
 		     trackweight=atrack.GetWeight()
-		     rc=h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
+		     h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
 		     if atrack.GetMotherId()==1 :
 		       HNLmomentum=sTree.MCTrack.At(1).GetP()
-		       rc=h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum)
+		       h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum)
   itemstoremove=[]
   for item in MCTrackIDs:	       
     atrack = sTree.MCTrack.At(item)
@@ -468,8 +467,8 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
             if debug==1: print "No reconstructible pion and muon."  
 	    MCTrackIDs=[]     
   if len(MCTrackIDs)>0:
-     rc=h['nbrhits'].Fill(nHits)
-     rc=h['nbrtracks'].Fill(nMCTracks)
+     h['nbrhits'].Fill(nHits)
+     h['nbrtracks'].Fill(nMCTracks)
   if debug==1: print "Tracks with required HNL decay particles",MCTrackIDs 	     
   return MCTrackIDs
 
@@ -480,10 +479,10 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
   
   top=ROOT.TVector3()
   bot=ROOT.TVector3()
-  random = ROOT.TRandom()
+  ROOT.TRandom()
   ROOT.gRandom.SetSeed(13)
   
-  rc = sTree.GetEvent(iEvent) 
+  sTree.GetEvent(iEvent) 
   nHits = sTree.strawtubesPoint.GetEntriesFast()
   withNoStrawSmearing=None
   hitstraws={}
@@ -548,7 +547,7 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
     if (str(ahit.GetDetectorID())[:1]=="1") :  
        if station1hits.has_key(ahit.GetTrackID()):
           station1hits[ahit.GetTrackID()]+=1
-	  rc=h['hits1xy'].Fill(ahit.GetX(),ahit.GetY())    	  
+	  h['hits1xy'].Fill(ahit.GetX(),ahit.GetY())    	  
        else:
           station1hits[ahit.GetTrackID()]=1
     if (str(ahit.GetDetectorID())[:1]=="2") :  
@@ -627,13 +626,13 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
   if len(station4hits) > 0 : 
      hits4pertrack=total4hits/len(station4hits)  
   
-  rc=h['hits1-4'].Fill(hits1pertrack+hits2pertrack+hits3pertrack+hits4pertrack)  
-  rc=h['hits1'].Fill(hits1pertrack)  
-  rc=h['hits12x'].Fill(hits12xpertrack)  
-  rc=h['hits12y'].Fill(hits12ypertrack)  
-  rc=h['hits2'].Fill(hits2pertrack)    
-  rc=h['hits3'].Fill(hits3pertrack)    
-  rc=h['hits4'].Fill(hits4pertrack)        
+  h['hits1-4'].Fill(hits1pertrack+hits2pertrack+hits3pertrack+hits4pertrack)  
+  h['hits1'].Fill(hits1pertrack)  
+  h['hits12x'].Fill(hits12xpertrack)  
+  h['hits12y'].Fill(hits12ypertrack)  
+  h['hits2'].Fill(hits2pertrack)    
+  h['hits3'].Fill(hits3pertrack)    
+  h['hits4'].Fill(hits4pertrack)        
   return SmearedHits
 
   
@@ -676,14 +675,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 
   hits={}
   rawhits={}
-  stereohits={}
   hitids={}
   ytan={}
   ycst={}
   horpx={}
   horpy={}
   horpz={}
-  stereomom={}
   stereotan={}
   stereocst={}
   fraction={}
@@ -846,7 +843,6 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   if debug==1: print "***************** Start of Stereo PatRec **************************"  
 
   v2hits={}
-  v2hitsMC={}
 
   uvview={}
   j=0
@@ -920,7 +916,6 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     px=0.
     py=0.
     pz=0.
-    m=0
     if firsttwo==True: looplist=reversed(range(len(trcandv1[t]))) 
     else: looplist=range(len(trcandv1[t])) 
     for ipl in looplist:      
@@ -928,7 +923,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if indx>-1: 
  	if debug==1: print '      Plane nr, z-position, y of hit:',ipl,zlayer[ipl],hits[ipl][0][indx]
         hitpoint=[zlayer[ipl],hits[ipl][0][indx]]
-	rc=h['disthittoYviewtrack'].Fill(dist2line(fitt,fitc,hitpoint))
+	h['disthittoYviewtrack'].Fill(dist2line(fitt,fitc,hitpoint))
 	#if px==0. : px=StrawRawLink[hits[ipl][2][indx]][0].GetPx()
 	#if py==0. : py=StrawRawLink[hits[ipl][2][indx]][0].GetPy()
 	#if pz==0. : pz=StrawRawLink[hits[ipl][2][indx]][0].GetPz()
@@ -940,7 +935,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	    print "      p",ptmp,"px",px,"py",py,"pz",pz
 	if tan==0. : tan=py/pz
 	if cst==0. : cst=StrawRawLink[hits[ipl][2][indx]][0].GetY()-tan*zlayer[ipl][0]
-	rc=h['disthittoYviewMCtrack'].Fill(dist2line(tan,cst,hitpoint))
+	h['disthittoYviewMCtrack'].Fill(dist2line(tan,cst,hitpoint))
 
     if debug==1: print '   Track nr',t,'in Y view: MC tangent, MC constant=',tan,cst	
     
@@ -1060,12 +1055,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
         indx= trcandv2[t1][ipl]
         if indx>-1:       
           hitpointx=[zlayerv2[ipl],v2hits[ipl][0][indx]]
-          rc=h['disthittostereotrack'].Fill(dist2line(stereofitt,stereofitc,hitpointx)) 
+          h['disthittostereotrack'].Fill(dist2line(stereofitt,stereofitc,hitpointx)) 
 	  if pxMC==0. :  pxMC=StrawRawLink[v2hits[ipl][2][indx]][0].GetPx()
 	  if pzMC ==0. : pzMC=StrawRawLink[v2hits[ipl][2][indx]][0].GetPz()
 	  if stereotanMCv==0. : stereotanMCv=pxMC/pzMC
 	  if stereocstMCv==0. : stereocstMCv=StrawRawLink[v2hits[ipl][2][indx]][0].GetX()-stereotanMCv*zlayerv2[ipl][0]
-	  rc=h['disthittostereoMCtrack'].Fill(dist2line(stereotanMCv,stereocstMCv,hitpointx))
+	  h['disthittostereoMCtrack'].Fill(dist2line(stereotanMCv,stereocstMCv,hitpointx))
                  
 
       stereotrackids=[]
@@ -1290,11 +1285,11 @@ def TrackFit(hitPosList,theTrack,charge,pinv):
    fittedy=math.degrees(math.acos(fittedtrackDir[1]))
    fittedz=math.degrees(math.acos(fittedtrackDir[2]))      
    fittedmass = fittedState.getMass()
-   rc=h['momentumfittedtracks'].Fill(fittedMom)
-   rc=h['xdirectionfittedtracks'].Fill(fittedx)
-   rc=h['ydirectionfittedtracks'].Fill(fittedy)
-   rc=h['zdirectionfittedtracks'].Fill(fittedz)
-   rc=h['massfittedtracks'].Fill(fittedmass)   
+   h['momentumfittedtracks'].Fill(fittedMom)
+   h['xdirectionfittedtracks'].Fill(fittedx)
+   h['ydirectionfittedtracks'].Fill(fittedy)
+   h['zdirectionfittedtracks'].Fill(fittedz)
+   h['massfittedtracks'].Fill(fittedmass)   
       
    return
 
@@ -1455,8 +1450,8 @@ def fitline(indices,xhits,zhits,resolution):
          sumy+=xhits[ipl][0][indx]
    fitt=(1/Dw)*term
    fitc=ymean-fitt*xmean	 
-   unweightedfitt=(sumxy-sumx*sumy/n)/(sumx2-sumx**2/n)
-   unweightedfitc=(sumy-fitt*sumx)/n
+   (sumxy-sumx*sumy/n)/(sumx2-sumx**2/n)
+   (sumy-fitt*sumx)/n
    return fitt,fitc
 	  
 def IP(s, t, b):
@@ -1518,10 +1513,10 @@ def dist2line(tan,cst,points):
   return dist
 
 def hit2wire(ahit,bot,top,no_amb=None):
-     detID = ahit.GetDetectorID()
-     ex = ahit.GetX()
-     ey = ahit.GetY()
-     ez = ahit.GetZ()
+     ahit.GetDetectorID()
+     ahit.GetX()
+     ahit.GetY()
+     ahit.GetZ()
    #distance to wire, and smear it.
      dw  = ahit.dist2Wire()
      smear = dw
@@ -1605,7 +1600,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
  if debug==1: print "************* PatRect START **************"  
     
  nShits=sTree.strawtubesPoint.GetEntriesFast() 
- nMCTracks = sTree.MCTrack.GetEntriesFast() 
+ sTree.MCTrack.GetEntriesFast() 
  
  #if nMCTracks < 100:
  if nShits < 500: 
@@ -1679,7 +1674,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
             #loop until we get the particle of this track  
 	    particle12   = PDG.GetParticle(StrawRawLink[ids][0].PdgCode())
 	    try:
-	       charge12=particle12.Charge()/3.
+	       particle12.Charge()/3.
 	       break
 	    except:
 	       continue   
@@ -1691,7 +1686,6 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
          for k,v in enumerate(ReconstructibleMCTracks):
 	    if v not in tracksfound: 
 	      tracksfound.append(v)      
-         rawlinkindex=0            
          for ids in hitids34[item1]:
             if ids != 999 :  
 	       particle34   = PDG.GetParticle(StrawRawLink[ids][0].PdgCode())

--- a/python/shipPatRec_prev.py
+++ b/python/shipPatRec_prev.py
@@ -3,7 +3,7 @@
 #configuration, histograms etc done in shipPatRec_config
 #for documentation, see CERN-SHiP-NOTE-2015-002, https://cds.cern.ch/record/2005715/files/main.pdf
 #17-04-2015 comments to EvH
-import ROOT, os
+import ROOT
 import shipunit  as u
 import math
 import copy
@@ -13,7 +13,6 @@ from ROOT import gStyle
 from ROOT import TGraph
 from ROOT import TMultiGraph
 from array import array
-import operator, sys
 
 import rootUtils as ut
 
@@ -233,7 +232,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   #returns a list of reconstructible tracks for this event
   #call this routine once for each event before smearing
   MCTrackIDs=[]
-  rc = sTree.GetEvent(iEvent) 
+  sTree.GetEvent(iEvent) 
   nMCTracks = sTree.MCTrack.GetEntriesFast()   
 
   if debug==1: print "event nbr",iEvent,"has",nMCTracks,"tracks"
@@ -412,18 +411,18 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
         if childtrack.GetMotherId() == ahit.GetTrackID():	   
 	    trackmomentum=atrack.GetP()
 	    trackweight=atrack.GetWeight()
-	    rc=h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
+	    h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
 	    motherId=atrack.GetMotherId() 
 	    if motherId==1 :
 		HNLmomentum=sTree.MCTrack.At(1).GetP()
-		rc=h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum) 
+		h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum) 
 	        if j==nMCTracks :
  		     trackmomentum=atrack.GetP()
 		     trackweight=atrack.GetWeight()
-		     rc=h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
+		     h['reconstructiblemomentum'].Fill(trackmomentum,trackweight)
 		     if atrack.GetMotherId()==1 :
 		       HNLmomentum=sTree.MCTrack.At(1).GetP()
-		       rc=h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum)
+		       h['HNLmomentumvsweight'].Fill(trackweight,HNLmomentum)
   itemstoremove=[]
   for item in MCTrackIDs:	       
     atrack = sTree.MCTrack.At(item)
@@ -468,8 +467,8 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
             if debug==1: print "No reconstructible pion and muon."  
 	    MCTrackIDs=[]     
   if len(MCTrackIDs)>0:
-     rc=h['nbrhits'].Fill(nHits)
-     rc=h['nbrtracks'].Fill(nMCTracks)
+     h['nbrhits'].Fill(nHits)
+     h['nbrtracks'].Fill(nMCTracks)
   if debug==1: print "Tracks with required HNL decay particles",MCTrackIDs 	     
   return MCTrackIDs
 
@@ -480,10 +479,10 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
   
   top=ROOT.TVector3()
   bot=ROOT.TVector3()
-  random = ROOT.TRandom()
+  ROOT.TRandom()
   ROOT.gRandom.SetSeed(13)
   
-  rc = sTree.GetEvent(iEvent) 
+  sTree.GetEvent(iEvent) 
   nHits = sTree.strawtubesPoint.GetEntriesFast()
   withNoStrawSmearing=None
   hitstraws={}
@@ -548,7 +547,7 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
     if (str(ahit.GetDetectorID())[:1]=="1") :  
        if station1hits.has_key(ahit.GetTrackID()):
           station1hits[ahit.GetTrackID()]+=1
-	  rc=h['hits1xy'].Fill(ahit.GetX(),ahit.GetY())    	  
+	  h['hits1xy'].Fill(ahit.GetX(),ahit.GetY())    	  
        else:
           station1hits[ahit.GetTrackID()]=1
     if (str(ahit.GetDetectorID())[:1]=="2") :  
@@ -627,13 +626,13 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
   if len(station4hits) > 0 : 
      hits4pertrack=total4hits/len(station4hits)  
   
-  rc=h['hits1-4'].Fill(hits1pertrack+hits2pertrack+hits3pertrack+hits4pertrack)  
-  rc=h['hits1'].Fill(hits1pertrack)  
-  rc=h['hits12x'].Fill(hits12xpertrack)  
-  rc=h['hits12y'].Fill(hits12ypertrack)  
-  rc=h['hits2'].Fill(hits2pertrack)    
-  rc=h['hits3'].Fill(hits3pertrack)    
-  rc=h['hits4'].Fill(hits4pertrack)        
+  h['hits1-4'].Fill(hits1pertrack+hits2pertrack+hits3pertrack+hits4pertrack)  
+  h['hits1'].Fill(hits1pertrack)  
+  h['hits12x'].Fill(hits12xpertrack)  
+  h['hits12y'].Fill(hits12ypertrack)  
+  h['hits2'].Fill(hits2pertrack)    
+  h['hits3'].Fill(hits3pertrack)    
+  h['hits4'].Fill(hits4pertrack)        
   return SmearedHits
 
   
@@ -676,14 +675,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 
   hits={}
   rawhits={}
-  stereohits={}
   hitids={}
   ytan={}
   ycst={}
   horpx={}
   horpy={}
   horpz={}
-  stereomom={}
   stereotan={}
   stereocst={}
   fraction={}
@@ -846,7 +843,6 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   if debug==1: print "***************** Start of Stereo PatRec **************************"  
 
   v2hits={}
-  v2hitsMC={}
 
   uvview={}
   j=0
@@ -920,7 +916,6 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     px=0.
     py=0.
     pz=0.
-    m=0
     if firsttwo==True: looplist=reversed(range(len(trcandv1[t]))) 
     else: looplist=range(len(trcandv1[t])) 
     for ipl in looplist:      
@@ -928,7 +923,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if indx>-1: 
  	if debug==1: print '      Plane nr, z-position, y of hit:',ipl,zlayer[ipl],hits[ipl][0][indx]
         hitpoint=[zlayer[ipl],hits[ipl][0][indx]]
-	rc=h['disthittoYviewtrack'].Fill(dist2line(fitt,fitc,hitpoint))
+	h['disthittoYviewtrack'].Fill(dist2line(fitt,fitc,hitpoint))
 	#if px==0. : px=StrawRawLink[hits[ipl][2][indx]][0].GetPx()
 	#if py==0. : py=StrawRawLink[hits[ipl][2][indx]][0].GetPy()
 	#if pz==0. : pz=StrawRawLink[hits[ipl][2][indx]][0].GetPz()
@@ -940,7 +935,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	    print "      p",ptmp,"px",px,"py",py,"pz",pz
 	if tan==0. : tan=py/pz
 	if cst==0. : cst=StrawRawLink[hits[ipl][2][indx]][0].GetY()-tan*zlayer[ipl][0]
-	rc=h['disthittoYviewMCtrack'].Fill(dist2line(tan,cst,hitpoint))
+	h['disthittoYviewMCtrack'].Fill(dist2line(tan,cst,hitpoint))
 
     if debug==1: print '   Track nr',t,'in Y view: MC tangent, MC constant=',tan,cst	
     
@@ -1060,12 +1055,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
         indx= trcandv2[t1][ipl]
         if indx>-1:       
           hitpointx=[zlayerv2[ipl],v2hits[ipl][0][indx]]
-          rc=h['disthittostereotrack'].Fill(dist2line(stereofitt,stereofitc,hitpointx)) 
+          h['disthittostereotrack'].Fill(dist2line(stereofitt,stereofitc,hitpointx)) 
 	  if pxMC==0. :  pxMC=StrawRawLink[v2hits[ipl][2][indx]][0].GetPx()
 	  if pzMC ==0. : pzMC=StrawRawLink[v2hits[ipl][2][indx]][0].GetPz()
 	  if stereotanMCv==0. : stereotanMCv=pxMC/pzMC
 	  if stereocstMCv==0. : stereocstMCv=StrawRawLink[v2hits[ipl][2][indx]][0].GetX()-stereotanMCv*zlayerv2[ipl][0]
-	  rc=h['disthittostereoMCtrack'].Fill(dist2line(stereotanMCv,stereocstMCv,hitpointx))
+	  h['disthittostereoMCtrack'].Fill(dist2line(stereotanMCv,stereocstMCv,hitpointx))
                  
 
       stereotrackids=[]
@@ -1290,11 +1285,11 @@ def TrackFit(hitPosList,theTrack,charge,pinv):
    fittedy=math.degrees(math.acos(fittedtrackDir[1]))
    fittedz=math.degrees(math.acos(fittedtrackDir[2]))      
    fittedmass = fittedState.getMass()
-   rc=h['momentumfittedtracks'].Fill(fittedMom)
-   rc=h['xdirectionfittedtracks'].Fill(fittedx)
-   rc=h['ydirectionfittedtracks'].Fill(fittedy)
-   rc=h['zdirectionfittedtracks'].Fill(fittedz)
-   rc=h['massfittedtracks'].Fill(fittedmass)   
+   h['momentumfittedtracks'].Fill(fittedMom)
+   h['xdirectionfittedtracks'].Fill(fittedx)
+   h['ydirectionfittedtracks'].Fill(fittedy)
+   h['zdirectionfittedtracks'].Fill(fittedz)
+   h['massfittedtracks'].Fill(fittedmass)   
       
    return
 
@@ -1455,8 +1450,8 @@ def fitline(indices,xhits,zhits,resolution):
          sumy+=xhits[ipl][0][indx]
    fitt=(1/Dw)*term
    fitc=ymean-fitt*xmean	 
-   unweightedfitt=(sumxy-sumx*sumy/n)/(sumx2-sumx**2/n)
-   unweightedfitc=(sumy-fitt*sumx)/n
+   (sumxy-sumx*sumy/n)/(sumx2-sumx**2/n)
+   (sumy-fitt*sumx)/n
    return fitt,fitc
 	  
 def IP(s, t, b):
@@ -1518,10 +1513,10 @@ def dist2line(tan,cst,points):
   return dist
 
 def hit2wire(ahit,bot,top,no_amb=None):
-     detID = ahit.GetDetectorID()
-     ex = ahit.GetX()
-     ey = ahit.GetY()
-     ez = ahit.GetZ()
+     ahit.GetDetectorID()
+     ahit.GetX()
+     ahit.GetY()
+     ahit.GetZ()
    #distance to wire, and smear it.
      dw  = ahit.dist2Wire()
      smear = dw
@@ -1605,7 +1600,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
  if debug==1: print "************* PatRect START **************"  
     
  nShits=sTree.strawtubesPoint.GetEntriesFast() 
- nMCTracks = sTree.MCTrack.GetEntriesFast() 
+ sTree.MCTrack.GetEntriesFast() 
  
  #if nMCTracks < 100:
  if nShits < 500: 
@@ -1679,7 +1674,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
             #loop until we get the particle of this track  
 	    particle12   = PDG.GetParticle(StrawRawLink[ids][0].PdgCode())
 	    try:
-	       charge12=particle12.Charge()/3.
+	       particle12.Charge()/3.
 	       break
 	    except:
 	       continue   
@@ -1691,7 +1686,6 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
          for k,v in enumerate(ReconstructibleMCTracks):
 	    if v not in tracksfound: 
 	      tracksfound.append(v)      
-         rawlinkindex=0            
          for ids in hitids34[item1]:
             if ids != 999 :  
 	       particle34   = PDG.GetParticle(StrawRawLink[ids][0].PdgCode())

--- a/python/shipPid.py
+++ b/python/shipPid.py
@@ -31,10 +31,10 @@ class Task:
   self.zpositions = {}
   self.parallelToZ = ROOT.TVector3(0., 0., 1.)
   hadron = top.GetNode("Hcal_1")
-  hvol = hadron.GetVolume()
+  hadron.GetVolume()
   self.zpositions['hcal'] = hadron.GetMatrix().GetTranslation()[2]
   ecal = top.GetNode("Ecal_1")
-  evol = ecal.GetVolume()   
+  ecal.GetVolume()   
   self.zpositions['ecal'] = ecal.GetMatrix().GetTranslation()[2]
   x = sys.modules['__main__']
   ShipGeo = x.ShipGeo
@@ -107,7 +107,7 @@ class Task:
 #  print 'numer of hites = ', self.sTree.muonPoint.GetEntries()
   for ahit in self.sTree.muonPoint:
    if not ahit.GetEnergyLoss()>0: continue
-   detID = ahit.GetDetectorID()
+   ahit.GetDetectorID()
    if m.fabs(ahit.GetZ()-self.zpositions['muon0'])<self.muly_acceptance:
       mul=0
       ##print 'mu0 = ',ahit.GetX(),ahit.GetY(),ahit.GetEnergyLoss()/u.MeV,ahit.GetZ()
@@ -235,7 +235,7 @@ class Task:
     if self.det == 'muon0':
       extrap_X_mu0 = self.extrapStates[self.det][0]
       extrap_Y_mu0 = self.extrapStates[self.det][1]
-      extrap_Z_mu0 = self.extrapStates[self.det][2]
+      self.extrapStates[self.det][2]
       X_pos0=extrap_X_mu0+self.dimensions_x
       Y_pos0=extrap_Y_mu0+self.dimensions_y
       self.pos_pad_x0=m.floor(X_pos0/self.pad_size_x)+1
@@ -243,7 +243,7 @@ class Task:
     if self.det == 'muon1':
       self.extrap_X_mu1 = self.extrapStates[self.det][0]
       self.extrap_Y_mu1 = self.extrapStates[self.det][1]
-      extrap_Z_mu1 = self.extrapStates[self.det][2]
+      self.extrapStates[self.det][2]
       X_pos1=self.extrap_X_mu1+self.dimensions_x
       Y_pos1=self.extrap_Y_mu1+self.dimensions_y
       self.pos_pad_x1=m.floor(X_pos1/self.pad_size_x)+1
@@ -251,7 +251,7 @@ class Task:
     if self.det == 'muon2':
       extrap_X_mu2 = self.extrapStates[self.det][0]
       extrap_Y_mu2 = self.extrapStates[self.det][1]
-      extrap_Z_mu2 = self.extrapStates[self.det][2]
+      self.extrapStates[self.det][2]
       X_pos2=extrap_X_mu2+self.dimensions_x
       Y_pos2=extrap_Y_mu2+self.dimensions_y
       self.pos_pad_x2=m.floor(X_pos2/self.pad_size_x)+1
@@ -259,7 +259,7 @@ class Task:
     if self.det == 'muon3':
       extrap_X_mu3 = self.extrapStates[self.det][0]
       extrap_Y_mu3 = self.extrapStates[self.det][1]
-      extrap_Z_mu3 = self.extrapStates[self.det][2]
+      self.extrapStates[self.det][2]
       X_pos3=extrap_X_mu3+self.dimensions_x
       Y_pos3=extrap_Y_mu3+self.dimensions_y
       self.pos_pad_x3=m.floor(X_pos3/self.pad_size_x)+1
@@ -323,7 +323,7 @@ class Task:
     if self.det == 'ecal':
      self.extrap_X_ecal = self.extrapStates[self.det][0]
      self.extrap_Y_ecal = self.extrapStates[self.det][1]
-     extrap_Z_ecal = self.extrapStates[self.det][2]
+     self.extrapStates[self.det][2]
 
  def run_elec_ID(self):
      for aClus in self.sTree.EcalReconstructed:
@@ -342,7 +342,7 @@ class Task:
     if self.det == 'hcal':
       self.extrap_X_hcal = self.extrapStates[self.det][0]
       self.extrap_Y_hcal = self.extrapStates[self.det][1]
-      extrap_Z_hcal = self.extrapStates[self.det][2]
+      self.extrapStates[self.det][2]
 
  def run_hcal_ID(self):
       N1,N2,M,E_est,E_totale=0,0,0,0.,0.

--- a/python/shipRoot_conf.py
+++ b/python/shipRoot_conf.py
@@ -50,7 +50,6 @@ def pyExit():
         os.system('kill '+str(os.getpid()))
    if hasattr(x,'fMan'): del x.fMan
    if hasattr(x,'fRun'): del x.fRun
-   pass
 
 def configure(darkphoton=None):
    ROOT.gROOT.ProcessLine('#include "'+os.environ["FAIRSHIP"]+'/shipdata/ShipGlobals.h"')

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -78,9 +78,9 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
     run.SetName("TGeant4")  # Transport engine
     run.SetOutputFile("dummy")  # Output file
     run.SetUserConfig("g4Config_basic.C") # geant4 transport not used, only needed for the mag field
-    rtdb = run.GetRuntimeDb()
+    run.GetRuntimeDb()
 
-    modules = shipDet_conf.configure(run,ShipGeo)
+    shipDet_conf.configure(run,ShipGeo)
     run.Init()
 
     #run = ROOT.FairRunSim()
@@ -259,7 +259,6 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
                 n_ghosts += 1
             
             is_reconstructed = 0
-            is_reconstructed_no_clones = 0
             
             
             if tmax_y12 in reconstructible_tracks:
@@ -319,7 +318,6 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
                                             h['TracksPassedU'].Fill("Combined stations 1&2/3&4", 1)
                                             metrics['reco_passed_no_clones'] += 1
                                             in_combo.append(tmax_34)
-                                            is_reconstructed_no_clones = 1
                                         
             # For reconstructed tracks
             if is_reconstructed == 0:
@@ -328,9 +326,9 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
             metrics['reco_frac_tot'] += [frac_tot]
             
             # Momentum
-            Pz = hits['Pz']
-            Px = hits['Px']
-            Py = hits['Py']
+            hits['Pz']
+            hits['Px']
+            hits['Py']
 
             p, px, py, pz = getPtruthFirst(sTree, tmax_tot)
             pt = math.sqrt(px**2 + py**2)
@@ -530,7 +528,6 @@ def extrapolateToPlane(fT,z):
                 rc = True
             except:
                 print 'error with extrapolation'
-                pass
             if not rc:
                 # use linear extrapolation
                 px,py,pz  = mom.X(),mom.Y(),mom.Z()
@@ -641,12 +638,12 @@ def getReconstructibleTracks(iEvent, sTree, sGeo, ShipGeo):
     TStation4EndZ = Zpos + ShipGeo.strawtubes.OuterStrawDiameter / 2
 
 
-    PDG=ROOT.TDatabasePDG.Instance()
+    ROOT.TDatabasePDG.Instance()
 
     #returns a list of reconstructible tracks for this event
     #call this routine once for each event before smearing
     MCTrackIDs=[]
-    rc = sTree.GetEvent(iEvent)
+    sTree.GetEvent(iEvent)
     nMCTracks = sTree.MCTrack.GetEntriesFast()
 
     

--- a/python/shipStrawTracking_old.py
+++ b/python/shipStrawTracking_old.py
@@ -4,7 +4,9 @@
 #17-04-2015 comments to EvH
 
 import shipPatRec 
-import ROOT,os,sys,getopt
+import ROOT
+import os
+import sys
 import shipDet_conf
 import shipunit  as u
 
@@ -149,7 +151,7 @@ def EventLoop(SmearedHits):
   fitTrack2MC_PR.clear()
   fPartArray_PR.Delete()
   
-  rc = sTree.GetEvent(n)    
+  sTree.GetEvent(n)    
   
   if shipPatRec.monitor==True: 
      shipPatRec.ReconstructibleMCTracks=shipPatRec.getReconstructibleTracks(n,sTree,sGeo)

--- a/python/shipStrawTracking_prev.py
+++ b/python/shipStrawTracking_prev.py
@@ -4,7 +4,9 @@
 #17-04-2015 comments to EvH
 
 import shipPatRec_prev 
-import ROOT,os,sys,getopt
+import ROOT
+import os
+import sys
 import shipDet_conf
 import shipunit  as u
 
@@ -149,7 +151,7 @@ def EventLoop(SmearedHits):
   fitTrack2MC_PR.clear()
   fPartArray_PR.Delete()
   
-  rc = sTree.GetEvent(n)    
+  sTree.GetEvent(n)    
   
   if shipPatRec_prev.monitor==True: 
      shipPatRec_prev.ReconstructibleMCTracks=shipPatRec_prev.getReconstructibleTracks(n,sTree,sGeo)

--- a/python/shipTarget_only.py
+++ b/python/shipTarget_only.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: latin-1 -*-
-import ROOT,os
+import ROOT
 import shipunit as u
 
 def configure(run,ship_geo):

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -1,5 +1,5 @@
 # simple vertex reconstruction with errors
-import ROOT,sys,os
+import ROOT
 import shipunit as u
 import rootUtils as ut
 import numpy as np
@@ -83,7 +83,7 @@ class Task:
   particles    = self.fPartArray
   PosDirCharge,CovMat,scalFac = {},{},{}
   for tr in goodTracks:
-   fitStatus = fittedTracks[tr].getFitStatus()
+   fittedTracks[tr].getFitStatus()
    xx  = fittedTracks[tr].getFittedState()
    pid   = xx.getPDG()
    if not pidProton and abs(pid) == 2212:
@@ -143,8 +143,8 @@ class Task:
 #   HNL true
      if  self.sTree.GetBranch("fitTrack2MC"):
       mctrack = self.sTree.MCTrack[self.sTree.fitTrack2MC[t1]]
-      mctrack2 = self.sTree.MCTrack[self.sTree.fitTrack2MC[t2]]
-      mcHNL = self.sTree.MCTrack[mctrack.GetMotherId()]
+      self.sTree.MCTrack[self.sTree.fitTrack2MC[t2]]
+      self.sTree.MCTrack[mctrack.GetMotherId()]
       #print "true vtx: ",mctrack.GetStartX(),mctrack.GetStartY(),mctrack.GetStartZ()
       #print "reco vtx: ",HNLPos[0],HNLPos[1],HNLPos[2]
       #self.h['Vzpull'].Fill( (mctrack.GetStartZ()-HNLPos[2])/ROOT.TMath.Sqrt(covX[2][2]) )
@@ -157,7 +157,7 @@ class Task:
      
      #print "*********************************** vertex fit precise   ******************************************** "
      
-     detPlane = ROOT.genfit.DetPlane(ROOT.TVector3(0,0,HNLPos[2]),ROOT.TVector3(1,0,0),ROOT.TVector3(0,1,0))
+     ROOT.genfit.DetPlane(ROOT.TVector3(0,0,HNLPos[2]),ROOT.TVector3(1,0,0),ROOT.TVector3(0,1,0))
      plane = ROOT.genfit.RKTrackRep().makePlane(ROOT.TVector3(0,0,HNLPos[2]),ROOT.TVector3(1,0,0),ROOT.TVector3(0,1,0))
      st1  = fittedTracks[t1].getFittedState()
      st2  = fittedTracks[t2].getFittedState()
@@ -194,7 +194,7 @@ class Task:
      for i in range(100):	
        self.Vy[i] = covInv[i/10][i%10]
      
-     f=np.array([0.])
+     np.array([0.])
      gMinuit = ROOT.TMinuit(9)
      gMinuit.SetFCN(self.fcn)
      gMinuit.SetPrintLevel(-1)#minute quiet mode
@@ -256,9 +256,9 @@ class Task:
      yFit = values[1]
      zFit = values[2]
      HNLPosFit =  ROOT.TVector3(xFit,yFit,zFit)
-     xFitErr = errors[0]
-     yFitErr = errors[1]
-     zFitErr = errors[2]
+     errors[0]
+     errors[1]
+     errors[2]
      
      #fixme: mass from track reconstraction needed 
      m1 = self.PDG.GetParticle(PosDirCharge[t1]['pdgCode']).Mass()

--- a/python/shipVeto.py
+++ b/python/shipVeto.py
@@ -45,8 +45,8 @@ class Task:
          if mcParticle>0 and mcParticle != mcP : found=True
          if mcParticle<0 and abs(mcParticle) == mcP : found=True
         if found: continue
-     position = aDigi.GetXYZ()
-     ELoss    = aDigi.GetEloss()
+     aDigi.GetXYZ()
+     aDigi.GetEloss()
      if aDigi.isValid(): hitSegments += 1 #threshold of 45 MeV per segment
   w = (1-self.SBTefficiency)**hitSegments  
   veto = self.random.Rndm() > w
@@ -135,7 +135,7 @@ class Task:
     nav.SetCurrentPoint(aPoint.x(),aPoint.y(),aPoint.z())
     cNode = nav.FindNode().GetName()
     nav.SetCurrentDirection(xDir,yDir,0.)
-    rc = nav.FindNextBoundaryAndStep()
+    nav.FindNextBoundaryAndStep()
     x,y  = nav.GetCurrentPoint()[0],nav.GetCurrentPoint()[1]
     if cNode != nav.GetCurrentNode().GetName():
      dist = ROOT.TMath.Sqrt( (aPoint.x()-x)**2 + (aPoint.y()-y)**2)

--- a/python/tweakConfig
+++ b/python/tweakConfig
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import os,sys
+import os
 f=open('config.sh')
 l=f.readlines()
 f.close()


### PR DESCRIPTION
Hi all,

a standard technique when reviewing code is to look for unused variables and declaration.

### Why? They do no harm, right?

Yes, it is correct that they do no harm, however, are usually symptomatic of other issues.

First of all, if the variable is not used, why do we compute them in first place? It is a waste of resources.

Then they may hide some issue in the code? Maybe we need to actually use them, but for some reason, we forgot to. Maybe we used a variable with a similar name but that contains a wrong value.

Hence it is important to have an eye on unused variables, [very expert programmers wasted hours because they forget to run an unused variable analysis on their code](https://twitter.com/antirez/status/969169622430879744).

### How to find unused variables

Fortunately is possible to automatically find unused variables, indeed this same PR was generated using an automated tool. Underneat it uses a simple graph algorithm.

The PR itself is safe to merge, the behaviour of the software does not change after merging, however is much more important to understand **why** the unused variable is there rather than just remove it.

Again, unused variables cause no harm, but they are sympomatic of other, underlining issues.

### Can you remove all the unused variables?

I could in theory, but I am afraid to don't know the code base and the domain well enough to understand each and every case, somebody more expert should take a look.

### It is a lot of work!

I know, but usually is worthed. If we are interested in this kind of work we could procede step by step, one folder at the time, so that in less than a week everything get's done.

### Even if we do this work, other people will re-introduce unused variables.

The solution is to run the same LINT before to merge each pull request, in this way we are sure that no unused variable is added to the codebase.

We can done this in gitlab for free.

### But some unused variables are generally useful, we may not need them now, but for sure they will be necessary next month.

I agree, the best thing we can do is to place all of them in few files and we will instruct the linter to don't run on those file.

In this way we respect the [single responsability principle](https://redbeardlab.com/2019/01/24/cb2-single-responsibility-principle/) and we will still keep the advantages of removing unused variables from the code.

---


