### PR TITLE
Change the way unpackers are selected

### DIFF
--- a/online/PixelUnpack.cxx
+++ b/online/PixelUnpack.cxx
@@ -72,7 +72,7 @@ Bool_t PixelUnpack::DoUnpack(Int_t *data, Int_t size)
    for (auto &&hit : hits) {
       auto hitData = reinterpret_cast<HitData *>(&(hit.hitTime));
       auto channelId = reinterpret_cast<ChannelId *>(&(hit.channelId));
-      auto detectorID = (fPartitionId%0x0800) * 10000000 + 1000000 * hitData->moduleID + 1000 * channelId->row + channelId->column;
+      auto detectorID = (df->header.partitionId%0x0800) * 10000000 + 1000000 * hitData->moduleID + 1000 * channelId->row + channelId->column;
       auto tot = hitData->tot;
       new ((*fRawData)[fNHits]) ShipPixelHit(detectorID, tot); //tot is measured in steps of 25 ns
       fNHits++;

--- a/online/ShipTdcSource.cxx
+++ b/online/ShipTdcSource.cxx
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include "ShipTdcSource.h"
 #include "FairLogger.h"
 #include "FairEventHeader.h"
@@ -104,16 +105,12 @@ Int_t ShipTdcSource::ReadEvent(UInt_t)
 
 Bool_t ShipTdcSource::Unpack(Int_t *data, Int_t size, uint16_t partitionId)
 {
-
-   for (TObject *item : *fUnpackers) {
-      auto unpacker = dynamic_cast<ShipUnpack *>(item);
-      if (unpacker->GetPartition() == partitionId) {
-         return unpacker->DoUnpack(data, size);
-      }
+   try {
+      return fUnpackerMap.at(partitionId)->DoUnpack(data, size);
+   } catch (const std::out_of_range &oor) {
+      LOG(WARNING) << "ShipTdcSource: Failed to find suitable unpacker." << FairLogger::endl;
+      return kFALSE;
    }
-
-   LOG(WARNING) << "ShipTdcSource: Failed to find suitable unpacker." << FairLogger::endl;
-   return kFALSE;
 }
 
 void ShipTdcSource::FillEventHeader(FairEventHeader *feh)

--- a/online/ShipTdcSource.h
+++ b/online/ShipTdcSource.h
@@ -1,6 +1,7 @@
 #ifndef ONLINE_SHIPTDCSOURCE_H
 #define ONLINE_SHIPTDCSOURCE_H
 
+#include <map>
 #include "FairOnlineSource.h"
 #include "TObjArray.h"
 #include "TFile.h"
@@ -20,6 +21,11 @@ public:
    virtual Int_t ReadEvent(UInt_t = 0); // Read frame by frame
    virtual void Close();
    void FillEventHeader(FairEventHeader *feh);
+   inline void AddUnpacker(uint16_t partitionId, FairUnpack *unpacker)
+   {
+      fUnpackerMap[partitionId] = unpacker;
+      fUnpackers->Add(unpacker);
+   }
 
 protected:
    Bool_t Unpack(Int_t *data, Int_t size, uint16_t partitionId);
@@ -27,6 +33,7 @@ protected:
    TFile *fIn;
    unsigned char buffer[UINT16_MAX];
    Double_t fEventTime = 0;
+   std::map<uint16_t, FairUnpack *> fUnpackerMap{};
 
    TString fFilename;
 


### PR DESCRIPTION
**Please do not merge before this has been tested!**
This is a first step to simplify the way unpackers are handled, allowing one to re-use unpackers for several partitions (as necessary for the pixel)

This also changes the way the unpackers need to be defined in the unpacking macro. The relevant changes are here: https://github.com/olantwin/muon_flux_online/tree/unpackers (I wonder whether the unpack.py script should be added to FairShip/macro dir, as it now doesn't need to compile and only depends on standard FairShip).

@owtscharenko @matclim @antonioiuliano2 : Would very much appreciate your feedback and testing: This should only affect the pixels and should not change anything for the other partitions.
 Once tested, I might clean it up a bit more, as I left the old way of adding unpackers in place to not break compatibility with the FairRoot FairOnlineSource.
