### PR TITLE
Updating CharmDetHitPositions to handle DriftTubes and SciFi data

### DIFF
--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -130,8 +130,6 @@ def GetPixelPositions(n=1,draw=True,writentuple=False):
   npixelpoints = 0
   pixelhitslist = []
   pixelhitslist.append(sTree.Digi_PixelHits_1)
- # pixelhitslist.append(sTree.Digi_PixelHits_2)
- # pixelhitslist.append(sTree.Digi_PixelHits_3)
   hitx = []
   hity = []
   hitz = []
@@ -154,8 +152,7 @@ def GetPixelPositions(n=1,draw=True,writentuple=False):
      leaftrackID[hitnumber] = 0
      leafsubdetector[hitnumber] = 1
      leafnhits[0] += 1
-     # print "Test tree saving: ", hitnumber, leafdetID[hitnumber], leafposx[hitnumber], leafposy[hitnumber], leafposz[hitnumber] 
-     #outputtree.Fill()
+     # print "Test tree saving: ", hitnumber, leafdetID[hitnumber], leafposx[hitnumber], leafposy[hitnumber], leafposz[hitnumber]  
   if draw:
    DrawPoints(npixelpoints,hitx,hity,hitz,"PixelHits")
 
@@ -191,7 +188,6 @@ def GetSciFiPositions(n=1,draw=True,writentuple=False):
 	 leaftrackID[hitnumber] = 0
 	 leafsubdetector[hitnumber] = 2
          leafnhits[0] += 1
- #        outputtree[0].Fill()
   if draw:
    DrawPoints(nscifipoints,hitx,hity,hitz)
 
@@ -231,11 +227,6 @@ def GetDTPositions(n=1, draw=True,writentuple=False):
     hity.append(y)
     hitz.append(z)
     npoints = npoints + 1
-  #npoints = len(hitlist)
- # print hitx
-  #print hity
- # print hitz
- # print len(hitx), len(hitlist), npoints
     if writentuple: #add pixel hit position to ntuple
      hitnumber = leafnhits[0]
      leafdetID[hitnumber] = detID
@@ -245,7 +236,6 @@ def GetDTPositions(n=1, draw=True,writentuple=False):
      leaftrackID[hitnumber] = 0
      leafsubdetector[hitnumber] = 3
      leafnhits[0] += 1
-     #outputtree.Fill()
   if draw:
    DrawPoints(npoints,hitx,hity,hitz,"DTHits")
 def RPCPosition():
@@ -310,15 +300,11 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
      if (trackID > maxtrackID): maxtrackID = trackID
      #adding the point to two different lists according to the view  
      # for each track we have a xyz position at each station (with at most two views)
-     if view == 0: #I have yz info
-       #hity[station-1] = y 
-       #hitz[station-1] = z
+     if view == 0: #I have yz info     
        hityarray[trackID-1][station-1] = y
        hitzarray[trackID-1][station-1] = z
        clustersH.append([x,y,z])
      elif view == 1: #I have xz info
-       #hitx[station-1] = x
-       #hitz[station-1] = z
        hitxarray[trackID-1][station-1] = x
        hitzarray[trackID-1][station-1] = z
        clustersV.append([x,y,z])
@@ -336,7 +322,6 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
        leaftrackID[hitnumber] = 0
        leafsubdetector[hitnumber] = 4
        leafnhits[0] += 1
-       #outputtree.Fill()
     #print "Position of loaded cluster: ({},{},{}), station {} and view {}".format(x,y,z,station,view)    
   #fitting to two 2D tracks
   if fittedtracks:
@@ -365,7 +350,6 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
          leaftrackID[hitnumber] = itrk + 1 
          leafsubdetector[hitnumber] = 4
          leafnhits[0] += 1
-         #outputtree.Fill()
   #print "Line equation along horizontal: {}*z + {}".format(mH,bH)
   #print "Line equation along vertical: {}*z + {}".format(mV,bV)
    theta = ROOT.TMath.ATan(pow((mH**2+mV**2),0.5))
@@ -400,7 +384,7 @@ def DrawTrack(theta,phi,lastpoint):
   track.SetName("Test proton")
   track.SetLineColor(ROOT.kRed)
   tracklist.AddElement(track)
-  #gEve.AddElement(tracklist) #track seems bugged, to be addressed
+  gEve.AddElement(tracklist)
 
   track.MakeTrack()
   gEve.Redraw3D()
@@ -427,8 +411,11 @@ def getSlopes(clusters,view=0):
 
 # what methods are launched?
 GetPixelPositions(nevent)    
+GetSciFiPositions(nevent)
 GetDTPositions(nevent)
+loadRPCtracks(nevent,True,False,fittedtracks = False)
 RPCPosition()
+
 def writeNtuples():
   """write positions of subdetectors into an easy to read ntuple. DetectorID go downstream to upstream, 1: Pixel, 2:SciFi, 3:DT,4:RPC"""
   nevents = sTree.GetEntries()
@@ -449,8 +436,6 @@ if writentuple:
  outputtree = ROOT.TTree("shippositions","Ntuple with hit positions")
  # tree initialization, branches must be arrays in order to pass the addresss
  maxdim = 10000
- #n = array( 'i', [ 0 ] ) from ROOT tutorial
- #d = array( 'f', maxn*[ 0. ] )
  leafnhits = array('i',[0])
  leafsubdetector = array( 'i',maxdim*[0])
  leafdetID = array( 'i',maxdim*[0])
@@ -467,5 +452,3 @@ if writentuple:
  outputtree.Branch("trackID",leaftrackID,"trackID[nhits]/I")
  outputtree.Branch("subdetector",leafsubdetector,"subdetector[nhits]/I")
  writeNtuples()
-
-#loadRPCtracks(nevent,True,False,fittedtracks = True)

--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -22,6 +22,7 @@ def pyExit():
 #-----list of arguments--------------------------------------------------
 parser = ArgumentParser()
 parser.add_argument("-f", "--files", dest="listOfFiles", help="list of files comma separated", required=True)
+parser.add_argument("-s", "--scififile", dest="scififilename", help="root file with scifi data", required=True)
 parser.add_argument("-nev", "--nevent", dest="nevent", help="number of event to plot", default=0)
 parser.add_argument("-w", "--write", dest="writentuple", help="option to write an ntuple",default=False, action='store_true')
 parser.add_argument("-o", "--outputfile", dest="outputfilename", help= "outputfile with the ntuples", default="positions.root")
@@ -31,6 +32,9 @@ parser.add_argument("-e", "--eos", dest="onEOS", help="files on EOS", default=Fa
 parser.add_argument("-u", "--update", dest="updateFile", help="update file", default=False, action='store_true')
 #-----accessing file------------------------------------------------------
 options = parser.parse_args()
+
+scififile = ROOT.TFile.Open(options.scififilename)
+scifitree = scififile.Get('cbmsim')
 
 writentuple = options.writentuple
 nevent = int(options.nevent)
@@ -68,7 +72,7 @@ else:
 
 #-------------------------------geometry initialization
 from ShipGeoConfig import ConfigRegistry
-ShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = 1, cTarget = 3)
+ShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = 1, cTarget = 1)
 builtin.ShipGeo = ShipGeo
 import charmDet_conf
 run = ROOT.FairRunSim()
@@ -126,14 +130,14 @@ def GetPixelPositions(n=1,draw=True,writentuple=False):
   npixelpoints = 0
   pixelhitslist = []
   pixelhitslist.append(sTree.Digi_PixelHits_1)
-  pixelhitslist.append(sTree.Digi_PixelHits_2)
-  pixelhitslist.append(sTree.Digi_PixelHits_3)
-  pos = ROOT.TVector3(0,0,0)
+ # pixelhitslist.append(sTree.Digi_PixelHits_2)
+ # pixelhitslist.append(sTree.Digi_PixelHits_3)
   hitx = []
   hity = []
   hitz = []
   for pixelhits in pixelhitslist:
    for hit in pixelhits:
+    pos = ROOT.TVector3(0,0,0)
     npixelpoints = npixelpoints + 1
     detID = hit.GetDetectorID()
     hit.GetPixelXYZ(pos,detID)
@@ -142,9 +146,18 @@ def GetPixelPositions(n=1,draw=True,writentuple=False):
     hity.append(pos[1])
     hitz.append(pos[2])
     if writentuple: #add pixel hit position to ntuple
-     ntuple.Fill(n,detID,pos[0], pos[1],pos[2],1)
+     hitnumber = leafnhits[0]
+     leafdetID[hitnumber] = detID
+     leafposx[hitnumber] = pos[0]
+     leafposy[hitnumber] = pos[1]
+     leafposz[hitnumber] = pos[2]
+     leaftrackID[hitnumber] = 0
+     leafsubdetector[hitnumber] = 1
+     leafnhits[0] += 1
+     # print "Test tree saving: ", hitnumber, leafdetID[hitnumber], leafposx[hitnumber], leafposy[hitnumber], leafposz[hitnumber] 
+     #outputtree.Fill()
   if draw:
-   DrawPoints(npixelpoints,hitx,hity,hitz)
+   DrawPoints(npixelpoints,hitx,hity,hitz,"PixelHits")
 
 def GetSciFiPositions(n=1,draw=True,writentuple=False):
   """ retrieves the position of the pixel hit using the pixel map """
@@ -152,15 +165,15 @@ def GetSciFiPositions(n=1,draw=True,writentuple=False):
    #print 'display disabled, hits will not be drawn'
    draw = False
 
-  sTree.GetEntry(n)
+  scifitree.GetEntry(n+1)
   nscifipoints = 0
   scifihitslist = []
-  scifihitslist.append(sTree.Digi_SciFiHits)
+  scifihitslist.append(scifitree.Digi_SciFiHits)
   pos = ROOT.TVector3(0,0,0)
   hitx = []
   hity = []
   hitz = []
-  for scifihits in scifihitslist:
+  for scifihits in scifihitslist:     
    for hit in scifihits:
     nscifipoints = nscifipoints + 1
     detID = hit.GetDetectorID()
@@ -170,7 +183,15 @@ def GetSciFiPositions(n=1,draw=True,writentuple=False):
     hity.append(pos[1])
     hitz.append(pos[2])
     if writentuple: #add scifi hit position to ntuple
-     ntuple.Fill(n,detID,pos[0], pos[1],pos[2],1)
+	 hitnumber = leafnhits[0]
+	 leafdetID[hitnumber] = detID
+	 leafposx[hitnumber] = pos[0]
+	 leafposy[hitnumber] = pos[1]
+	 leafposz[hitnumber] = pos[2]
+	 leaftrackID[hitnumber] = 0
+	 leafsubdetector[hitnumber] = 2
+         leafnhits[0] += 1
+ #        outputtree[0].Fill()
   if draw:
    DrawPoints(nscifipoints,hitx,hity,hitz)
 
@@ -186,6 +207,47 @@ def correctAlignmentRPC(hit,v):
     vtop[1] = vtop[1] -1.21
   return vbot,vtop
 
+def GetDTPositions(n=1, draw=True,writentuple=False):
+  if not options.withDisplay:
+   #print 'display disabled, hits will not be drawn'
+   draw = False
+  sTree.GetEntry(n)
+  hitlist = sTree.Digi_MufluxSpectrometerHits
+  hitx = []
+  hity = []
+  hitz = []
+  npoints = 0
+  for hit in hitlist:
+    detID = hit.GetDetectorID()
+
+    vtop = ROOT.TVector3(0,0,0)
+    vbot = ROOT.TVector3(0,0,0)
+    hit.MufluxSpectrometerEndPoints(vtop,vbot, True)
+
+    x = (vbot[0]+vtop[0])/2.
+    y = (vbot[1]+vtop[1])/2.
+    z = (vbot[2]+vtop[2])/2.
+    hitx.append(x)
+    hity.append(y)
+    hitz.append(z)
+    npoints = npoints + 1
+  #npoints = len(hitlist)
+ # print hitx
+  #print hity
+ # print hitz
+ # print len(hitx), len(hitlist), npoints
+    if writentuple: #add pixel hit position to ntuple
+     hitnumber = leafnhits[0]
+     leafdetID[hitnumber] = detID
+     leafposx[hitnumber] = x
+     leafposy[hitnumber] = y
+     leafposz[hitnumber] = z
+     leaftrackID[hitnumber] = 0
+     leafsubdetector[hitnumber] = 3
+     leafnhits[0] += 1
+     #outputtree.Fill()
+  if draw:
+   DrawPoints(npoints,hitx,hity,hitz,"DTHits")
 def RPCPosition():
   """ builds the list of positions for each detectorID. Same as driftubeMonitoring.py """
   for s in range(1,6): #RPC stations
@@ -223,10 +285,16 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
      hitz.append(0)
 
   sTree.GetEntry(n)
-  #trackhits = sTree.MuonTaggerHit
+  #trackhits = sTree.LocallyTracked_MuonTaggerHits
   trackhits = sTree.Digi_MuonTaggerHits
   clustersH = []
   clustersV = []
+
+  maxntracks = 20 
+  maxtrackID = 0
+  hitxarray = numpy.zeros((maxntracks,5))
+  hityarray = numpy.zeros((maxntracks,5))
+  hitzarray = numpy.zeros((maxntracks,5))
 
   for hit in trackhits:
     detID = hit.GetDetectorID()
@@ -237,24 +305,38 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
     x = (a[0]+b[0])/2.
     y = (a[1]+b[1])/2.
     z = (a[2]+b[2])/2.
-
     if fittedtracks: #clusters with already fitted tracks
+     trackID = int(hit.GetDigi())
+     if (trackID > maxtrackID): maxtrackID = trackID
      #adding the point to two different lists according to the view  
-     if view == 0:
-       hity[station-1] = y
-       hitz[station-1] = z
+     # for each track we have a xyz position at each station (with at most two views)
+     if view == 0: #I have yz info
+       #hity[station-1] = y 
+       #hitz[station-1] = z
+       hityarray[trackID-1][station-1] = y
+       hitzarray[trackID-1][station-1] = z
        clustersH.append([x,y,z])
-     elif view == 1:
-       hitx[station-1] = x
-       hitz[station-1] = z
+     elif view == 1: #I have xz info
+       #hitx[station-1] = x
+       #hitz[station-1] = z
+       hitxarray[trackID-1][station-1] = x
+       hitzarray[trackID-1][station-1] = z
        clustersV.append([x,y,z])
     else: 
       hitx.append(x) 
       hity.append(y)
       hitz.append(z)
       npoint = npoint+1 
-    if writentuple:
-       ntuple.Fill(n,detID,x, y,z,2)
+      if writentuple:
+       hitnumber = leafnhits[0]
+       leafdetID[hitnumber] = detID
+       leafposx[hitnumber] = x
+       leafposy[hitnumber] = y
+       leafposz[hitnumber] = z
+       leaftrackID[hitnumber] = 0
+       leafsubdetector[hitnumber] = 4
+       leafnhits[0] += 1
+       #outputtree.Fill()
     #print "Position of loaded cluster: ({},{},{}), station {} and view {}".format(x,y,z,station,view)    
   #fitting to two 2D tracks
   if fittedtracks:
@@ -262,6 +344,28 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
    mV,bV = getSlopes(clustersV,1)   
    trackH = ROOT.RPCTrack(mH,bH)
    trackV = ROOT.RPCTrack(mV,bV)
+   for itrk in range(maxtrackID):
+      for istation in range(5):
+        x = hitxarray[itrk,istation]
+        y = hityarray[itrk,istation]
+        z = hitzarray[itrk,istation]
+        #point added to containers for drawing
+        hitx[istation] = x
+        hity[istation] = y
+        hitz[istation] = z
+        npoint = 5      
+        if x == 0: subdetector = 40 #not paired cluster
+        if y == 0: subdetector = 40
+        if writentuple:
+         hitnumber = leafnhits[0]
+         leafdetID[hitnumber] = istation + 1
+         leafposx[hitnumber] = x
+         leafposy[hitnumber] = y
+         leafposz[hitnumber] = z
+         leaftrackID[hitnumber] = itrk + 1 
+         leafsubdetector[hitnumber] = 4
+         leafnhits[0] += 1
+         #outputtree.Fill()
   #print "Line equation along horizontal: {}*z + {}".format(mH,bH)
   #print "Line equation along vertical: {}*z + {}".format(mV,bV)
    theta = ROOT.TMath.ATan(pow((mH**2+mV**2),0.5))
@@ -272,7 +376,7 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
    if draw:
       DrawTrack(theta,phi,lastpoint)
   if draw:
-   DrawPoints(npoint,hitx,hity,hitz)
+   DrawPoints(npoint,hitx,hity,hitz,"MuonTaggerHits")
  
 
 def DrawPoints(nclusters,hitx,hity,hitz, name = "FairShipHits"):
@@ -323,20 +427,45 @@ def getSlopes(clusters,view=0):
 
 # what methods are launched?
 GetPixelPositions(nevent)    
+GetDTPositions(nevent)
 RPCPosition()
 def writeNtuples():
   """write positions of subdetectors into an easy to read ntuple. DetectorID go downstream to upstream, 1: Pixel, 2:SciFi, 3:DT,4:RPC"""
   nevents = sTree.GetEntries()
   print "Start processing", nevents, "nevents"
-  for ievent in range(sTree.GetEntries()):
-   loadRPCtracks(ievent, False, True)
+  for ievent in range(nevents):
+   leafnhits[0] = 0 #resetting counter of hits
    GetPixelPositions(ievent, False, True)
+   GetDTPositions(ievent, False, True)
    GetSciFiPositions(ievent, False, True)
+   loadRPCtracks(ievent, False, True, False)
+   outputtree.Fill()
   outputfile.Write()
 
 if writentuple:
+ from array import array
+
  outputfile = ROOT.TFile(options.outputfilename,"RECREATE")
- ntuple = ROOT.TNtuple("shippositions","Ntuple with hit positions","ievent:detID:x:y:z:subdetector")
+ outputtree = ROOT.TTree("shippositions","Ntuple with hit positions")
+ # tree initialization, branches must be arrays in order to pass the addresss
+ maxdim = 10000
+ #n = array( 'i', [ 0 ] ) from ROOT tutorial
+ #d = array( 'f', maxn*[ 0. ] )
+ leafnhits = array('i',[0])
+ leafsubdetector = array( 'i',maxdim*[0])
+ leafdetID = array( 'i',maxdim*[0])
+ leaftrackID = array( 'i',maxdim*[0])
+ leafposx = array('f',maxdim*[0.])
+ leafposy = array('f',maxdim*[0.])
+ leafposz = array('f',maxdim*[0.])
+ #creating the branches
+ outputtree.Branch("nhits",leafnhits,"nhits/I")
+ outputtree.Branch("detID",leafdetID,"detID[nhits]/I")
+ outputtree.Branch("posx",leafposx,"posx[nhits]/F")
+ outputtree.Branch("posy",leafposy,"posy[nhits]/F")
+ outputtree.Branch("posz",leafposz,"posz[nhits]/F")
+ outputtree.Branch("trackID",leaftrackID,"trackID[nhits]/I")
+ outputtree.Branch("subdetector",leafsubdetector,"subdetector[nhits]/I")
  writeNtuples()
 
 #loadRPCtracks(nevent,True,False,fittedtracks = True)

--- a/charmdet/MufluxSpectrometerHit.cxx
+++ b/charmdet/MufluxSpectrometerHit.cxx
@@ -39,7 +39,7 @@ MufluxSpectrometerHit::MufluxSpectrometerHit(MufluxSpectrometerPoint* p, Double_
      time_over_threshold = 167.2;
 } 
 
-void MufluxSpectrometerHit::MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop)
+void MufluxSpectrometerHit::MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop, bool charm = false)
 { 
      Int_t statnb = fDetectorID/10000000; 
      Int_t vnb =  (fDetectorID - statnb*10000000)/1000000; 
@@ -70,6 +70,54 @@ void MufluxSpectrometerHit::MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3
      if (statnb<3){wire = "gas_12_";wire+=(fDetectorID);} 
      //TString path = "/volProva_1";path+="/";path+=stat;path+="/";path+=plane;path+="/";path+=layer;path+="/";path+=wire; 
      TString path = "";path+="/";path+=stat;path+="/";path+=plane;path+="/";path+=layer;path+="/";path+=wire; 
+
+     if (charm){
+      Int_t snb =   fDetectorID - statnb*10000000 - vnb*1000000 - pnb*100000 - lnb*10000 - 2000;  
+      Int_t modulenumber = (snb-1)/12; //as told me by Daniel
+      TString module; 
+      //level 1: mother volume, same for everyone
+      TString mother ="volDriftTubeCharm_1/";
+      //level 2: station, plane and module information:
+      //example: x_station_3_plane_0_module_1_130000000
+      prefix = "x_station_"; 
+      stat = prefix + statnb;
+
+      plane = "_plane_";
+      plane += pnb;
+      module = "_module_";
+      module += modulenumber;
+
+      wire = "_";
+      if (modulenumber > 0) wire += modulenumber;
+      wire += statnb;
+      wire += "0";
+      wire += pnb;
+      wire += "00000";
+
+      path = "/"+mother+stat+plane+module+wire;
+      //level 3: now added layer information
+      //example name x_station_3_plane_0_module_4_layer_1_430010000
+      layer = "_layer_";
+      layer += lnb;
+
+      wire = "_";
+      if (modulenumber > 0) wire += modulenumber;
+      wire += statnb;
+      wire += "0";
+      wire += pnb;
+      wire += lnb;
+      wire += "0000";
+
+      path += "/"+stat+plane+module+layer+wire;
+
+      //level 4: gas tube
+      //examples: gas_30002016 
+      if (modulenumber==4) wire ="short_gas_";
+      else wire = "gas_";
+      wire += fDetectorID;
+      path += "/"+wire;
+     }
+
      Bool_t rc = nav->cd(path); 
      if (not rc){ 
         std::cout << "MufluxSpectrometer::TubeDecode, TGeoNavigator failed "<<path<< std::endl;

--- a/charmdet/MufluxSpectrometerHit.h
+++ b/charmdet/MufluxSpectrometerHit.h
@@ -51,7 +51,7 @@ private:
    uint16_t flags;
    uint16_t channel;
 
-   ClassDef(MufluxSpectrometerHit, 7);
+   ClassDef(MufluxSpectrometerHit, 8);
 };
 
 #endif

--- a/charmdet/MufluxSpectrometerHit.h
+++ b/charmdet/MufluxSpectrometerHit.h
@@ -19,7 +19,7 @@ public:
    MufluxSpectrometerHit(Int_t detID, Float_t ftdc);
    MufluxSpectrometerHit(Int_t detID, Float_t ftdc, Float_t signal_width, uint16_t flag, uint16_t ch);
    MufluxSpectrometerHit(MufluxSpectrometerPoint *p, Double_t t0);
-   void MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop);
+   void MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop, bool charm); // false for muonflux configuration, true for charm one
    /** Destructor **/
    virtual ~MufluxSpectrometerHit();
 


### PR DESCRIPTION
Dear all,

this commit updates the script to produce  simple ROOT ntuples from the data of the charm test beam. 
DriftTubes volumes in the configuration used for the charm geometry are read with a dedicated charm flag (by default set to false).
SciFi data are read from another file, since they are currently stored in separate files with respect to data from other subdetectors.

If you any question, please ask me.
Best regards,
Antonio Iuliano