### PR TITLE
(WIP) First steps towards python3 compatibility

### DIFF
--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -1,9 +1,12 @@
 from __future__ import print_function, division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
 import ROOT,os
 #ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 import numpy
 from decorators import *
-import __builtin__ as builtin
+import builtins as builtin
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------

--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -410,8 +410,8 @@ def getSlopes(clusters,view=0):
 GetPixelPositions(nevent)    
 GetSciFiPositions(nevent)
 GetDTPositions(nevent)
-loadRPCtracks(nevent,True,False,fittedtracks = False)
 RPCPosition()
+loadRPCtracks(nevent,True,False,fittedtracks = False)
 
 def writeNtuples():
   """write positions of subdetectors into an easy to read ntuple. DetectorID go downstream to upstream, 1: Pixel, 2:SciFi, 3:DT,4:RPC"""

--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division
 import ROOT,os
 #ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 import numpy
@@ -48,7 +49,7 @@ if options.catalog:
   f=ROOT.TFile.Open(fname)
   sTree = f.cbmsim
   if not sTree.GetBranch("FitTracks"): 
- #  print "does not contain FitTracks",fname
+   print("does not contain FitTracks: ",fname)
    f.Close()
    continue
   fnames.append(fname)
@@ -61,12 +62,12 @@ if options.updateFile:
  f=ROOT.TFile(fname,'update')
  sTree=f.Get('cbmsim')
  if not sTree: 
-   print "Problem with updateFile",f
+   print("Problem with updateFile: ",f)
    exit(-1)
 else:
  sTree = ROOT.TChain('cbmsim')
  for f in fnames: 
-  print "add ",f
+  print("add ",f)
   if options.onEOS: sTree.Add(os.environ['EOSSHIP']+f)
   else:             sTree.Add(f)
 
@@ -122,8 +123,7 @@ vtop = ROOT.TVector3()
 
 def GetPixelPositions(n=1,draw=True,writentuple=False):
   """ retrieves the position of the pixel hit using the pixel map """
-  if not options.withDisplay:
-   #print 'display disabled, hits will not be drawn'
+  if not options.withDisplay:  
    draw = False
 
   sTree.GetEntry(n)
@@ -139,7 +139,7 @@ def GetPixelPositions(n=1,draw=True,writentuple=False):
     npixelpoints = npixelpoints + 1
     detID = hit.GetDetectorID()
     hit.GetPixelXYZ(pos,detID)
-    #print "This is the position of our pixel hit: ", detID, pos[0], pos[1], pos[2] 
+    #print ("This is the position of our pixel hit: ", detID, pos[0], pos[1], pos[2])
     hitx.append(pos[0])
     hity.append(pos[1])
     hitz.append(pos[2])
@@ -152,14 +152,13 @@ def GetPixelPositions(n=1,draw=True,writentuple=False):
      leaftrackID[hitnumber] = 0
      leafsubdetector[hitnumber] = 1
      leafnhits[0] += 1
-     # print "Test tree saving: ", hitnumber, leafdetID[hitnumber], leafposx[hitnumber], leafposy[hitnumber], leafposz[hitnumber]  
+     # print ("Test tree saving: ", hitnumber, leafdetID[hitnumber], leafposx[hitnumber], leafposy[hitnumber], leafposz[hitnumber])
   if draw:
    DrawPoints(npixelpoints,hitx,hity,hitz,"PixelHits")
 
 def GetSciFiPositions(n=1,draw=True,writentuple=False):
   """ retrieves the position of the pixel hit using the pixel map """
-  if not options.withDisplay:
-   #print 'display disabled, hits will not be drawn'
+  if not options.withDisplay:   
    draw = False
 
   scifitree.GetEntry(n+1)
@@ -175,7 +174,7 @@ def GetSciFiPositions(n=1,draw=True,writentuple=False):
     nscifipoints = nscifipoints + 1
     detID = hit.GetDetectorID()
     hit.GetSciFiXYZ(pos,detID)
-    #print "This is the position of our scifi hit: ", detID, pos[0], pos[1], pos[2] 
+    #print("This is the position of our scifi hit: ", detID, pos[0], pos[1], pos[2]) 
     hitx.append(pos[0])
     hity.append(pos[1])
     hitz.append(pos[2])
@@ -205,7 +204,6 @@ def correctAlignmentRPC(hit,v):
 
 def GetDTPositions(n=1, draw=True,writentuple=False):
   if not options.withDisplay:
-   #print 'display disabled, hits will not be drawn'
    draw = False
   sTree.GetEntry(n)
   hitlist = sTree.Digi_MufluxSpectrometerHits
@@ -251,7 +249,7 @@ def RPCPosition():
         x = (a[0]+b[0])/2.
         y = (a[1]+b[1])/2.
         z = (a[2]+b[2])/2.
-       # print "Postion for view {} and channel {}: ({}, {},{})".format(v,c,x,y,z)
+       # print("Postion for view {} and channel {}: ({}, {},{})".format(v,c,x,y,z))
 
 def GetRPCPosition(s,v,c):
   """ Gets RPC Positions from the information of station, view and channel """
@@ -261,7 +259,6 @@ def GetRPCPosition(s,v,c):
 def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
   """ Loads MuonTaggerHits from file and get position of clusters. Fittedtracks is used when reading hits from locally reconstructed tracks by Alessandra"""
   if not options.withDisplay:
-   #print 'display disabled, hits will not be drawn'
    draw = False
   hitx = []
   hity = []
@@ -288,7 +285,7 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
 
   for hit in trackhits:
     detID = hit.GetDetectorID()
-    station = int (detID/10000) #automatically an int in python2, but calling the conversion avoids confusion
+    station = int (detID/10000)
     view = int((detID-station*10000)/1000)
 
     a,b = RPCPositionsBotTop[detID]
@@ -322,7 +319,7 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
        leaftrackID[hitnumber] = 0
        leafsubdetector[hitnumber] = 4
        leafnhits[0] += 1
-    #print "Position of loaded cluster: ({},{},{}), station {} and view {}".format(x,y,z,station,view)    
+    #print("Position of loaded cluster: ({},{},{}), station {} and view {}".format(x,y,z,station,view))    
   #fitting to two 2D tracks
   if fittedtracks:
    mH,bH = getSlopes(clustersH,0) 
@@ -350,11 +347,11 @@ def loadRPCtracks(n=1,draw=True,writentuple=False,fittedtracks=False):
          leaftrackID[hitnumber] = itrk + 1 
          leafsubdetector[hitnumber] = 4
          leafnhits[0] += 1
-  #print "Line equation along horizontal: {}*z + {}".format(mH,bH)
-  #print "Line equation along vertical: {}*z + {}".format(mV,bV)
+  #print("Line equation along horizontal: {}*z + {}".format(mH,bH))
+  #print("Line equation along vertical: {}*z + {}".format(mV,bV))
    theta = ROOT.TMath.ATan(pow((mH**2+mV**2),0.5))
    phi = ROOT.TMath.ATan(mH/mV)
-  #print "Angles of 3D track: theta is {} and phi is {}".format(theta,phi)  
+  #print("Angles of 3D track: theta is {} and phi is {}".format(theta,phi))  
     
    lastpoint = ROOT.TVector3(hitx[4],hity[4],hitz[4])
    if draw:
@@ -419,7 +416,7 @@ RPCPosition()
 def writeNtuples():
   """write positions of subdetectors into an easy to read ntuple. DetectorID go downstream to upstream, 1: Pixel, 2:SciFi, 3:DT,4:RPC"""
   nevents = sTree.GetEntries()
-  print "Start processing", nevents, "nevents"
+  print("Start processing", nevents, "nevents")
   for ievent in range(nevents):
    leafnhits[0] = 0 #resetting counter of hits
    GetPixelPositions(ievent, False, True)

--- a/macro/getGeoInformation.py
+++ b/macro/getGeoInformation.py
@@ -4,6 +4,7 @@
 #24-02-2015 comments to EvH
 
 from __future__ import print_function, division
+from builtins import range
 import operator, sys
 from argparse import ArgumentParser
 from array import array
@@ -59,7 +60,7 @@ def print_info(path, node, level, currentlevel, print_sub_det_info=False):
     fullInfo[name] = local2Global(path + '/' + name)
     sub_nodes[name] = fullInfo[name]['origin'][2]
 
-  for name, _ in sorted(sub_nodes.items(), key=operator.itemgetter(1)):
+  for name, _ in sorted(list(sub_nodes.items()), key=operator.itemgetter(1)):
     boundingbox = fullInfo[name]['boundingbox']
 
     format_string = "{:<28s}: z={:10.4F}cm  dZ={:10.4F}cm  [{:10.4F}   {:10.4F}]"+\

--- a/macro/getGeoInformation.py
+++ b/macro/getGeoInformation.py
@@ -3,6 +3,7 @@
 #WARNING: printing the entire geometry takes a lot of time
 #24-02-2015 comments to EvH
 
+from __future__ import print_function, division
 import operator, sys
 from argparse import ArgumentParser
 from array import array
@@ -76,7 +77,7 @@ def print_info(path, node, level, currentlevel, print_sub_det_info=False):
       format_string += " {:10.1F}kg {:10.1F}m3"
       format_variable.extend([weight, cubicmeter])
 
-    print format_string.format(*format_variable)
+    print (format_string.format(*format_variable))
 
     if options.volume in ["", name]:
       print_sub_det_info = True
@@ -106,11 +107,11 @@ top = fGeo.GetTopVolume()
 
 
 if options.moreInfo:
- print "   Detector element             z(midpoint)     halflength       volume-start volume-end   dx"\
-       "                x-start       x-end       dy                y-start       y-end         material          weight  capacity"
+ print ("   Detector element             z(midpoint)     halflength       volume-start volume-end   dx"\
+        "                x-start       x-end       dy                y-start       y-end         material          weight  capacity")
 else:
- print "   Detector element             z(midpoint)     halflength       volume-start volume-end   dx"\
-       "                x-start       x-end       dy                y-start       y-end         material"
+ print ("   Detector element             z(midpoint)     halflength       volume-start volume-end   dx"\
+        "                x-start       x-end       dy                y-start       y-end         material")
 
 currentlevel = 0
 print_info("", top, int(options.level), currentlevel)


### PR DESCRIPTION
Dear FairShip expert,

during the last ShipSoft meeting, Oliver (@olantwin) proposed to start checking our code to ensure python3 compatibility: https://indico.cern.ch/event/833735/contributions/3493690/attachments/1878722/3094666/talk.slides.pdf

I then tried to start to do it  on two simple scripts I often use, getGeoInformation.py and CharmDetHitPosition.py, by updating the print functions and checking divisions between integers. Since, as suggested by Oliver, I imported the __future__ modules, so the code works on python2.7 without visible changes

I do not know if it is planned to put these updates and relative tests on a separate branch, so I wait for your suggestions on the matter.

Best regards,
Antonio Iuliano