### PR TITLE
Replacing virtual volumes with assemblies

### DIFF
--- a/charmdet/Box.cxx
+++ b/charmdet/Box.cxx
@@ -204,10 +204,7 @@ void Box::AddEmulsionFilm(Double_t zposition, Int_t nreplica, TGeoVolume * volTa
 void Box::ConstructGeometry()
 {
     InitMedium("tantalum");
-    TGeoMedium *tantalum = gGeoManager->GetMedium("tantalum");
-       
-    InitMedium("vacuum");
-    TGeoMedium *vacuum = gGeoManager->GetMedium("vacuum");
+    TGeoMedium *tantalum = gGeoManager->GetMedium("tantalum");      
    
     InitMedium("air");
     TGeoMedium *air = gGeoManager->GetMedium("air");
@@ -278,8 +275,7 @@ void Box::ConstructGeometry()
       else if (nrun > 6) TargetZ = zPasLead * NBricks; //all passive 
       else TargetZ = (NPlates[5] * AllPlateWidth + EmPlateWidth)*NBricks;          
 
-      TGeoBBox *Brick = new TGeoBBox("brick", TargetX/2, TargetY/2, TargetZ/2);
-      TGeoVolume *volTarget = new TGeoVolume("volTarget",Brick,vacuum);
+      TGeoVolumeAssembly *volTarget = new TGeoVolumeAssembly("volTarget");
       volTarget->SetLineColor(kCyan);
       volTarget->SetTransparency(1);
       

--- a/charmdet/Box.cxx
+++ b/charmdet/Box.cxx
@@ -204,10 +204,7 @@ void Box::AddEmulsionFilm(Double_t zposition, Int_t nreplica, TGeoVolume * volTa
 void Box::ConstructGeometry()
 {
     InitMedium("tantalum");
-    TGeoMedium *tantalum = gGeoManager->GetMedium("tantalum");      
-   
-    InitMedium("air");
-    TGeoMedium *air = gGeoManager->GetMedium("air");
+    TGeoMedium *tantalum = gGeoManager->GetMedium("tantalum");       
 
     InitMedium("molybdenum");
     TGeoMedium *molybdenum = gGeoManager->GetMedium("molybdenum");
@@ -390,9 +387,8 @@ void Box::ConstructGeometry()
       }
       
       int index = 0;   
-
-      TGeoBBox *Target = new TGeoBBox("Target", TargetX/2, TargetY/2, TargetZ/2); //for the moment I will use numbers instead of variables.
-      TGeoVolume *volTarget = new TGeoVolume("volTarget", Target, air);
+     
+      TGeoVolumeAssembly *volTarget = new TGeoVolumeAssembly("volTarget");
       volTarget->SetTransparency(1);
 
       top->AddNode(volTarget,1,new TGeoTranslation(0,0,zBoxPosition-TargetZ/2));

--- a/charmdet/MufluxSpectrometer.cxx
+++ b/charmdet/MufluxSpectrometer.cxx
@@ -352,10 +352,7 @@ void MufluxSpectrometer::SetT4(Double_t SurveyCharm_T4x, Double_t SurveyCharm_T4
 
 void MufluxSpectrometer::ConstructGeometry()
 { 
-  gGeoManager->SetVisLevel(4);
-    
-  InitMedium("vacuum");
-  TGeoMedium *vacuum = gGeoManager->GetMedium("vacuum");
+  gGeoManager->SetVisLevel(4);    
 
   InitMedium("iron");
   TGeoMedium *Fe =gGeoManager->GetMedium("iron");
@@ -398,10 +395,8 @@ void MufluxSpectrometer::ConstructGeometry()
   
   const Double_t MagneticField = 0.05 * tesla; //magnetic field; return field positive but Bdl appr 1/20
   TGeoUniformMagField *magField = new TGeoUniformMagField(0., MagneticField, 0.); //The magnetic field must be only in the vacuum space between the stations
-  
-
-  TGeoBBox *ProvaBox = new TGeoBBox("ProvaBox", 0. , 0., 0.);  
-  TGeoVolume *volProva = new TGeoVolume("volProva", ProvaBox, vacuum);   
+    
+  TGeoVolumeAssembly *volProva = new TGeoVolumeAssembly("volProva");   
   
  
   if (fMuonFlux){

--- a/charmdet/MuonTagger.cxx
+++ b/charmdet/MuonTagger.cxx
@@ -221,8 +221,7 @@ void MuonTagger::ConstructGeometry()
   
   TGeoVolume *top= gGeoManager->GetTopVolume(); 
 
-  TGeoBBox *MuonBox = new TGeoBBox(BoxX/2,BoxY/2,BoxZ/2);
-  TGeoVolume *VMuonBox = new TGeoVolume("VMuonBox", MuonBox,air);
+  TGeoVolumeAssembly *VMuonBox = new TGeoVolumeAssembly("VMuonBox");
   VMuonBox->SetTransparency(1);
   Double_t goliathcentre_to_beam = 178.6; //mm   
   Double_t walldisalignment = 15; //mm, all walls but one were disaligned with respect to the nominal beam position

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -150,8 +150,6 @@ void PixelModules::SetSiliconDetNumber(Int_t nSilicon)
 
 void PixelModules::ConstructGeometry()
 {
-    InitMedium("air");
-  TGeoMedium *air = gGeoManager->GetMedium("air");
 
     InitMedium("iron");
     TGeoMedium *Fe =gGeoManager->GetMedium("iron");
@@ -179,9 +177,8 @@ void PixelModules::ConstructGeometry()
      if (TMath::Abs(xs[istation]) > offsetxmax) offsetxmax = TMath::Abs(xs[istation]);
      if (TMath::Abs(ys[istation]) > offsetymax) offsetymax = TMath::Abs(ys[istation]);
     }
-    //Double_t DimZPixelBox = zs5 -zs0 +pairwisedistance + DimZSi;
-    TGeoBBox *PixelBox = new TGeoBBox("PixelBox", Dim1Long/2 + offsetxmax, Dim1Long/2 + offsetymax, DimZPixelBox/2.); //The box is symmetric, offsets are not. So we enlarge the offset by a factor two for coverage
-    TGeoVolume *volPixelBox = new TGeoVolume("volPixelBox",PixelBox,air);
+    //Double_t DimZPixelBox = zs5 -zs0 +pairwisedistance + DimZSi;    
+    TGeoVolumeAssembly *volPixelBox = new TGeoVolumeAssembly("volPixelBox");
     Double_t inimodZoffset(zs[0]) ;//initial Z offset of Pixel Module 0 so as to avoid volume extrusion
     top->AddNode(volPixelBox, 1, new TGeoTranslation(0,0,zBoxPosition+ inimodZoffset)); //volume moved in
 

--- a/charmdet/SciFi.cxx
+++ b/charmdet/SciFi.cxx
@@ -148,8 +148,6 @@ void SciFi::SetStationNumber(Int_t nSciFistations)
 //
 void SciFi::ConstructGeometry()
 {
-  InitMedium("air");
-  TGeoMedium *air = gGeoManager->GetMedium("air");
 
   InitMedium("silicon");
   TGeoMedium *Silicon = gGeoManager->GetMedium("silicon");
@@ -162,8 +160,7 @@ void SciFi::ConstructGeometry()
     if (TMath::Abs(xs[istation]) > offsetxmax) offsetxmax = TMath::Abs(xs[istation]);
     if (TMath::Abs(ys[istation]) > offsetymax) offsetymax = TMath::Abs(ys[istation]);
   }
-  TGeoBBox *SciFiBox = new TGeoBBox("SciFiBox", SBoxX/2 + offsetxmax, SBoxY/2 + offsetymax, SBoxZ/2.);
-  TGeoVolume *volSciFiBox = new TGeoVolume("volSciFiBox",SciFiBox,air);
+  TGeoVolumeAssembly *volSciFiBox = new TGeoVolumeAssembly("volSciFiBox");
   //positioning the mother volume
   top->AddNode(volSciFiBox, 1, new TGeoTranslation(0,0,zBoxPosition)); 
 

--- a/nutaudet/EmulsionMagnet.cxx
+++ b/nutaudet/EmulsionMagnet.cxx
@@ -159,9 +159,6 @@ void EmulsionMagnet::ConstructGeometry()
 {
   TGeoVolume *top=gGeoManager->GetTopVolume();
     
-  InitMedium("vacuum");
-  TGeoMedium *vacuum =gGeoManager->GetMedium("vacuum");
-    
   InitMedium("iron");
   TGeoMedium *Fe =gGeoManager->GetMedium("iron");
     
@@ -185,8 +182,7 @@ void EmulsionMagnet::ConstructGeometry()
       TGeoUniformMagField *magField1 = new TGeoUniformMagField(0.,-fField,0.); //magnetic field in Magnet pillars
       TGeoUniformMagField *magField2 = new TGeoUniformMagField(0.,fField,0.); //magnetic field in target
 
-      TGeoBBox *MagnetBox = new TGeoBBox(fMagnetX/2, fMagnetY/2, fMagnetZ/2);
-      TGeoVolume *MagnetVol = new TGeoVolume("Goliath",MagnetBox,vacuum);
+      TGeoVolumeAssembly *MagnetVol = new TGeoVolumeAssembly("Goliath");
       tTauNuDet->AddNode(MagnetVol,1,new TGeoTranslation(0,0,fCenterZ));
       
       //Iron basis on which the coils are placed
@@ -396,8 +392,7 @@ void EmulsionMagnet::ConstructGeometry()
       TGeoUniformMagField *magField1 = new TGeoUniformMagField(-fField,0.,0.); //magnetic field in Magnet pillars
       TGeoUniformMagField *magField2 = new TGeoUniformMagField(fField,0.,0.); //magnetic field in target
       
-      TGeoBBox *MagnetBox = new TGeoBBox(fMagnetX/2, fMagnetY/2, fMagnetZ/2);
-      TGeoVolume *MagnetVol = new TGeoVolume("Davide",MagnetBox,vacuum);
+      TGeoVolumeAssembly *MagnetVol = new TGeoVolumeAssembly("Davide");
       tTauNuDet->AddNode(MagnetVol,1,new TGeoTranslation(0,0,fCenterZ));
     
       //The -0.01*mm is only for drawing reasons
@@ -457,8 +452,7 @@ void EmulsionMagnet::ConstructGeometry()
    if(fDesign==3) //NEW with magnet
     {
       //Box for Magnet
-      TGeoBBox *MagnetBox = new TGeoBBox(fMagnetX/2, fMagnetY/2, fMagnetZ/2);
-      TGeoVolume *MagnetVol = new TGeoVolume("NudetMagnet",MagnetBox,vacuum);
+      TGeoVolumeAssembly *MagnetVol = new TGeoVolumeAssembly("NudetMagnet");
       tTauNuDet->AddNode(MagnetVol,1,new TGeoTranslation(0,0,fCenterZ));
 
       TGeoBBox *BaseBox = new TGeoBBox(fBaseX/2,fBaseY/2,fBaseZ/2);
@@ -572,7 +566,7 @@ void EmulsionMagnet::ConstructGeometry()
       MagnetVol->AddNode(CoilVol,2,new TGeoTranslation(0,-(fCoilH1+fCoilH2)/4,0));
 
       //magnetized region
-      TGeoVolume *volMagRegion = new TGeoVolume("volMagRegion",IncoilBox, vacuum);
+      TGeoVolumeAssembly *volMagRegion = new TGeoVolumeAssembly("volMagRegion");
       MagnetVol->AddNode(volMagRegion, 1, new TGeoTranslation(0,0,0));
 
       //pillars for the magnet

--- a/nutaudet/NuTauMudet.cxx
+++ b/nutaudet/NuTauMudet.cxx
@@ -235,9 +235,6 @@ void NuTauMudet::ConstructGeometry()
 
   InitMedium("RPCgas");
   TGeoMedium *RPCmat =gGeoManager->GetMedium("RPCgas");
-   
-  InitMedium("vacuum");
-  TGeoMedium *vacuum =gGeoManager->GetMedium("vacuum");
     
   InitMedium("Bakelite");
   TGeoMedium *bakelite =gGeoManager->GetMedium("Bakelite");  
@@ -261,13 +258,10 @@ void NuTauMudet::ConstructGeometry()
 
   if(fDesign!=3)
     {
-      TGeoBBox *MudetBox = new TGeoBBox("NuTauMudetBox", fXRyoke/2, fYtot/2, fZtot/2);
-      TGeoVolume *volMudetBox = new TGeoVolume("volNuTauMudet", MudetBox, vacuum);
+      TGeoVolumeAssembly *volMudetBox = new TGeoVolumeAssembly("volNuTauMudet");
       tTauNuDet->AddNode(volMudetBox, 1, new TGeoTranslation(0,10*cm,fZcenter));
   
-      
-      TGeoBBox *UpYokeBox = new TGeoBBox("UpYokeBox", fXRyoke/2, fYRyoke/2, fZRyoke/2);
-      TGeoVolume *volUpYoke = new TGeoVolume("volUpYoke",UpYokeBox,vacuum);
+      TGeoVolumeAssembly *volUpYoke = new TGeoVolumeAssembly("volUpYoke");
       volMudetBox->AddNode(volUpYoke,1,new TGeoTranslation(0,fYtot/2 - fYRyoke/2,0));
       volUpYoke->SetField(retFieldU);
     
@@ -280,8 +274,7 @@ void NuTauMudet::ConstructGeometry()
       TGeoVolume *volFeYoke1 = new TGeoVolume("volFeYoke1",FeYoke1,Iron);
       volFeYoke1->SetLineColor(kGray+1);
     
-      TGeoBBox *CoilContainer = new TGeoBBox("CoilContainer",fXtot/2, fCoilH/2, 40*cm);
-      TGeoVolume *volCoilContainer = new TGeoVolume("volCoilContainer",CoilContainer,vacuum);
+      TGeoVolumeAssembly *volCoilContainer = new TGeoVolumeAssembly("volCoilContainer");
     
       TGeoBBox *Coil = new TGeoBBox("Coil",fXtot/2, fCoilH/2, fCoilW/2);
       TGeoVolume *volCoil = new TGeoVolume("volCoil",Coil,Cu);
@@ -312,8 +305,7 @@ void NuTauMudet::ConstructGeometry()
       volUpYoke->AddNode(volCoilContainer,1,new TGeoTranslation(0,fYRyoke/2 - fCoilH/2,0)); //up
       volUpYoke->AddNode(volCoilContainer,2,new TGeoTranslation(0,-fYRyoke/2 + fCoilH/2,0)); //low
     
-      TGeoBBox *LowYokeBox = new TGeoBBox("LowYokeBox", fXRyoke/2, fYRyoke/2, fZRyoke/2);
-      TGeoVolume *volLowYoke = new TGeoVolume("volLowYoke",LowYokeBox,vacuum);
+      TGeoVolumeAssembly *volLowYoke = new TGeoVolumeAssembly("volLowYoke");
       volMudetBox->AddNode(volLowYoke,1,new TGeoTranslation(0,-fYtot/2 + fYRyoke/2,0));
       volLowYoke->SetField(retFieldL);
    
@@ -334,8 +326,7 @@ void NuTauMudet::ConstructGeometry()
       volLowYoke->AddNode(volCoilContainer,4,new TGeoTranslation(0,-fYRyoke/2 + fCoilH/2,0)); //low
 
       Int_t ArmNumber = 1;
-      TGeoBBox *Arm1Box = new TGeoBBox("Arm1MudetBox", fXFe/2, fYFe/2, fZArm/2);
-      TGeoVolume *volArm1 = new TGeoVolume("volArm1Mudet", Arm1Box,vacuum);
+      TGeoVolumeAssembly *volArm1 = new TGeoVolumeAssembly("volArm1Mudet");
       TGeoUniformMagField *magField1 = new TGeoUniformMagField(0.,-fField,0.); //magnetic field arm1
       volArm1->SetField(magField1);
       volMudetBox ->AddNode(volArm1,ArmNumber,new TGeoTranslation(0,0,-(fGapMiddle+fZArm)/2));
@@ -351,8 +342,7 @@ void NuTauMudet::ConstructGeometry()
 	  volArm1->AddNode(volIron,nr + 100 + i, new TGeoTranslation(0, 0, -fZArm/2+i*(fZFe +fZRpc) +fZFe/2));
 	}
     
-      TGeoBBox *RpcContainer = new TGeoBBox("RpcContainer", fXRpc/2, fYRpc/2, fZRpc/2);
-      TGeoVolume *volRpcContainer = new TGeoVolume("volRpcContainer",RpcContainer,vacuum);
+      TGeoVolumeAssembly *volRpcContainer = new TGeoVolumeAssembly("volRpcContainer");
   
       TGeoBBox *Strip = new TGeoBBox("Strip",fXStrip/2, fYStrip/2, fZStrip/2);
       TGeoVolume *volStrip = new TGeoVolume("volStrip",Strip,Cu);
@@ -384,8 +374,7 @@ void NuTauMudet::ConstructGeometry()
       ArmNumber = 2;
       nr =  ArmNumber*1E4;
 
-      TGeoBBox *Arm2Box = new TGeoBBox("Arm2MudetBox",fXFe/2, fYFe/2, fZArm/2);
-      TGeoVolume *volArm2 = new TGeoVolume("volArm2Mudet", Arm2Box,vacuum);
+      TGeoVolumeAssembly *volArm2 = new TGeoVolumeAssembly("volArm2Mudet");
       TGeoUniformMagField *magField2 = new TGeoUniformMagField(0.,fField,0.); //magnetic field arm2
       volArm2->SetField(magField2);
       volMudetBox ->AddNode(volArm2,1,new TGeoTranslation(0,0,(fGapMiddle+fZArm)/2));
@@ -393,7 +382,7 @@ void NuTauMudet::ConstructGeometry()
 
      //different volumes for second arm
       
-      TGeoVolume *volRpcContainer2 = new TGeoVolume("volRpcContainer2",RpcContainer,vacuum);
+      TGeoVolumeAssembly *volRpcContainer2 = new TGeoVolumeAssembly("volRpcContainer2");
       TGeoVolume *volStrip2 = new TGeoVolume("volStrip2",Strip,Cu);
       
       volStrip2->SetLineColor(kRed);
@@ -445,18 +434,8 @@ void NuTauMudet::ConstructGeometry()
   if(fDesign==3)
     {
       Int_t nr = 1E4;
-      TGeoBBox *LargedetBox = new TGeoBBox("LargedetBox", fXtot/2, fYtot/2, (2*fZFe+3*fZRpc)/2);  
-      TGeoBBox *SmalldetBox = new TGeoBBox("SmalldetBox", fXtot/2, (fYtot-fdeltay)/2, fZtot/2); //solving overlapping with pillars->dividing box to an union of two different boxes
- 
-      TGeoTranslation *translationlarge = new TGeoTranslation(0,0,(fZtot-2*fZFe-3*fZRpc)/2);
-      translationlarge->SetName("translationlarge");
-      translationlarge->RegisterYourself();
-      TGeoTranslation *translationsmall = new TGeoTranslation(0,0,0);
-      translationsmall->SetName("translationsmall");
-      translationsmall->RegisterYourself();
-      TGeoCompositeShape *MudetBox = new TGeoCompositeShape("MudetBox", "LargedetBox:translationlarge + SmalldetBox:translationsmall");
             
-      TGeoVolume *volMudetBox = new TGeoVolume("volTauNuMudet", MudetBox, vacuum);
+      TGeoVolumeAssembly *volMudetBox = new TGeoVolumeAssembly("volTauNuMudet");
       tTauNuDet->AddNode(volMudetBox, 1, new TGeoTranslation(0,0,fZcenter));
 
       TGeoBBox *IronLayer = new TGeoBBox("Iron",fXFe/2, fYFe/2, fZFe/2);
@@ -471,8 +450,7 @@ void NuTauMudet::ConstructGeometry()
           else volMudetBox->AddNode(volIron1,nr + 100 + i, new TGeoTranslation(0, 0,-fZtot/2+i*fZFe+fZFe/2+(i+1)*fZRpc));
 	}
 
-      TGeoBBox *RpcContainer = new TGeoBBox("RpcContainer", fXRpc/2, fYRpc/2, fZRpc/2);
-      TGeoVolume *volRpcContainer = new TGeoVolume("volRpcContainer",RpcContainer,vacuum);
+      TGeoVolumeAssembly *volRpcContainer = new TGeoVolumeAssembly("volRpcContainer");
   
       TGeoBBox *Strip = new TGeoBBox("Strip",fXStrip/2, fYStrip/2, fZStrip/2);
       TGeoVolume *volStrip = new TGeoVolume("volStrip",Strip,Cu);
@@ -494,8 +472,7 @@ void NuTauMudet::ConstructGeometry()
       volRpc->SetLineColor(kCyan);
       volRpcContainer->AddNode(volRpc,1,new TGeoTranslation(0,0,0));
    
-      TGeoBBox *RpcContainer1 = new TGeoBBox("RpcContainer1", fXRpc/2 -fdeltax/2, fYRpc/2-fdeltay/2, fZRpc/2);
-      TGeoVolume *volRpcContainer1 = new TGeoVolume("volRpcContainer1",RpcContainer1,vacuum);
+      TGeoVolumeAssembly *volRpcContainer1 = new TGeoVolumeAssembly("volRpcContainer1");
   
       TGeoBBox *Strip1  = new TGeoBBox("Strip1",fXStrip/2-fdeltax/2, fYStrip/2-fdeltay/2, fZStrip/2);
       TGeoVolume *volStrip1  = new TGeoVolume("volStrip1",Strip1,Cu);

--- a/nutaudet/Target.cxx
+++ b/nutaudet/Target.cxx
@@ -266,9 +266,6 @@ void Target::ConstructGeometry()
   // cout << "Design = " << fDesign << endl;
   TGeoVolume *top=gGeoManager->GetTopVolume();
     
-  InitMedium("vacuum");
-  TGeoMedium *vacuum =gGeoManager->GetMedium("vacuum");
-    
   InitMedium("iron");
   TGeoMedium *Fe =gGeoManager->GetMedium("iron");
     
@@ -317,7 +314,7 @@ void Target::ConstructGeometry()
 
   //Definition of the target box containing emulsion bricks + (CES if fDesign = 0 o 1) + target trackers (TT) 
   TGeoBBox *TargetBox = new TGeoBBox("TargetBox",XDimension/2, YDimension/2, ZDimension/2);
-  TGeoVolume *volTarget = new TGeoVolume("volTarget",TargetBox,vacuum);
+  TGeoVolumeAssembly *volTarget = new TGeoVolumeAssembly("volTarget");
       
   // In both fDesign=0 & fDesign=1 the emulsion target is inserted within a magnet
   if(fDesign!=2)
@@ -369,13 +366,11 @@ void Target::ConstructGeometry()
   //
   //Volumes definition
   //
- 
-  TGeoBBox *Cell = new TGeoBBox("cell", BrickX/2, BrickY/2, CellWidth/2);
-  TGeoVolume *volCell = new TGeoVolume("Cell",Cell,vacuum);
+   
+  TGeoVolumeAssembly *volCell = new TGeoVolumeAssembly("Cell");
     
   //Brick
-  TGeoBBox *Brick = new TGeoBBox("brick", BrickX/2, BrickY/2, BrickZ/2);
-  TGeoVolume *volBrick = new TGeoVolume("Brick",Brick,vacuum);
+  TGeoVolumeAssembly *volBrick = new TGeoVolumeAssembly("Brick");
   volBrick->SetLineColor(kCyan);
   volBrick->SetTransparency(1);   
     
@@ -433,9 +428,7 @@ void Target::ConstructGeometry()
   if(fDesign!=2)
     {    
       //CES
-    
-      TGeoBBox *CES = new TGeoBBox("ces", EmulsionX/2, EmulsionY/2, CESWidth/2);
-      TGeoVolume *volCES = new TGeoVolume("CES", CES, vacuum);
+      TGeoVolumeAssembly *volCES = new TGeoVolumeAssembly("CES");
       volCES->SetTransparency(5);
       volCES->SetLineColor(kYellow-10);
       volCES->SetVisibility(kTRUE);
@@ -494,8 +487,7 @@ void Target::ConstructGeometry()
       volCell->AddNode(volBrick,1,new TGeoTranslation(0,0,-CellWidth/2 + BrickZ/2));
       volCell->AddNode(volCES,1,new TGeoTranslation(0,0,-CellWidth/2 + BrickZ + CESWidth/2));
     
-      TGeoBBox *Row = new TGeoBBox("row",XDimension/2, BrickY/2, CellWidth/2);
-      TGeoVolume *volRow = new TGeoVolume("Row",Row,vacuum);
+      TGeoVolumeAssembly *volRow = new TGeoVolumeAssembly("Row");
       volRow->SetLineColor(20);
     
       Double_t d_cl_x = -XDimension/2;
@@ -505,8 +497,7 @@ void Target::ConstructGeometry()
 	  d_cl_x += BrickX;
 	}
 
-      TGeoBBox *Wall = new TGeoBBox("wall",XDimension/2, YDimension/2, CellWidth/2);
-      TGeoVolume *volWall = new TGeoVolume("Wall",Wall,vacuum);
+      TGeoVolumeAssembly *volWall = new TGeoVolumeAssembly("Wall");
     
       Double_t d_cl_y = -YDimension/2;
       for(int k= 0; k< fNRow; k++)
@@ -544,8 +535,7 @@ void Target::ConstructGeometry()
       tTauNuDet->AddNode(volTarget,1,new TGeoTranslation(0,0,fCenterZ));
 	
    
-       TGeoBBox *Row = new TGeoBBox("row",XDimension/2, BrickY/2, CellWidth/2);
-      TGeoVolume *volRow = new TGeoVolume("Row",Row,vacuum);
+      TGeoVolumeAssembly *volRow = new TGeoVolumeAssembly("Row");
       volRow->SetLineColor(20);
     
       Double_t d_cl_x = -XDimension/2;
@@ -554,9 +544,7 @@ void Target::ConstructGeometry()
 	  volRow->AddNode(volBrick,j,new TGeoTranslation(d_cl_x+BrickX/2, 0, 0));
 	  d_cl_x += BrickX;
 	}
-
-      TGeoBBox *Wall = new TGeoBBox("wall",XDimension/2, YDimension/2, BrickZ/2);
-      TGeoVolume *volWall = new TGeoVolume("Wall",Wall,vacuum);
+      TGeoVolumeAssembly *volWall = new TGeoVolumeAssembly("Wall");
     
       Double_t d_cl_y = -YDimension/2;
       for(int k= 0; k< fNRow; k++)


### PR DESCRIPTION
Dear FairShip experts,

following @ThomasRuf 's advice in https://github.com/ShipSoft/FairShip/issues/254, I have replaced the vacuum/air TGeoVolume containing other volumes with TGeoVolumeAssembly objects, in the scripts from the charmdet and nutaudet folders I have worked on.

Now there are no more unphysical vacuum volumes, so there should be no more medium discontinuity with cave medium.

I have not changed the volume names, so I assume backward compatibility should not be affected. I have run the ShipAna and ShipReco scripts and they worked without errors.

Please have a look and tell me if there is something I need to adjust or to improve.

Best regards,
Antonio Iuliano

