### PR TITLE
Reduced thickness for CHARM1-RUN6 run (tungsten)

### DIFF
--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -60,7 +60,10 @@ with ConfigRegistry.register_config("basic") as c:
     c.Box.EmX = 12.5 * u.cm
     c.Box.EmY = 9.9 * u.cm
     c.Box.PBTh = 0.0175 * u.cm
-    c.Box.PasSlabTh = 0.1 * u.cm #passive slab in ECC (lead for July measurement, molybdenum/tungsten for SHiP target replica
+    if cTarget == 16:
+     c.Box.PasSlabTh = 0.09 * u.cm #passive slab in ECC (lead for July measurement, molybdenum/tungsten for SHiP target replica
+    else:
+     c.Box.PasSlabTh = 0.1 * u.cm #passive slab in ECC (lead for July measurement, molybdenum/tungsten for SHiP target replica
     c.Box.EPlW = 2* c.Box.EmTh + c.Box.PBTh
     c.Box.AllPW = c.Box.PasSlabTh + c.Box.EPlW
     c.Box.BrX = 12.9 *u.cm

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -61,9 +61,9 @@ with ConfigRegistry.register_config("basic") as c:
     c.Box.EmY = 9.9 * u.cm
     c.Box.PBTh = 0.0175 * u.cm
     if cTarget == 16:
-     c.Box.PasSlabTh = 0.09 * u.cm #passive slab in ECC (lead for July measurement, molybdenum/tungsten for SHiP target replica
+     c.Box.PasSlabTh = 0.09 * u.cm #passive slab in ECC (run with tungsten)
     else:
-     c.Box.PasSlabTh = 0.1 * u.cm #passive slab in ECC (lead for July measurement, molybdenum/tungsten for SHiP target replica
+     c.Box.PasSlabTh = 0.1 * u.cm #passive slab in ECC (lead for July 2018 measurement, molybdenum/tungsten for SHiP target replica)
     c.Box.EPlW = 2* c.Box.EmTh + c.Box.PBTh
     c.Box.AllPW = c.Box.PasSlabTh + c.Box.EPlW
     c.Box.BrX = 12.9 *u.cm


### PR DESCRIPTION
Dear FairShip users,

the thickness of passive plates for one of the runs last years (CH1-R6, the run using tunsgten instead of lead), was 0.9 mm instead of 1.0 mm like the others.

This may be a possible source of larger number of hits in pixel simulation with respect to data. Therefore, I have added this information to `charm-geometry_config.py`.

Best regards.
Antonio Iuliano