### PR TITLE
use latest installation method for ci in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,37 @@
 
-cc7:
+build:
   tags:
     - cvmfs
   image: alisw/alidock:cc7
   stage: build
+  variables:
+    GIT_CLONE_PATH: '$CI_BUILDS_DIR/FairShip/'
   before_script:
-    - WORK_DIR=/cvmfs/ship.cern.ch/2_July2019/sw/ source /cvmfs/ship.cern.ch/2_July2019/sw/slc7_x86-64/FairShip/latest/etc/profile.d/init.sh
-    - pip install --upgrade --user alibuild
-    - ls /cvmfs/ship.cern.ch
+    - source /cvmfs/ship.cern.ch/SHiP-2018/latest/setUp.sh
     - cd ..
-    - git clone https://github.com/siscia/shipdist
-    - pushd shipdist && git checkout simple_build && popd
   script:
-    - aliBuild -c shipdist/ --default fairship build FairShip --always-prefer-system --debug
+    - aliBuild -c $SHIPDIST --default fairship build FairShip --always-prefer-system --debug
+
+build&test:
+  tags:
+    - cvmfs
+  image: alisw/alidock:cc7
+  stage: build
+  variables:
+    GIT_CLONE_PATH: '$CI_BUILDS_DIR/FairShip'
+  before_script:
+    - source /cvmfs/ship.cern.ch/SHiP-2018/latest/setUp.sh
+    - cd ..
+    - aliBuild -c $SHIPDIST --default fairship build FairShip --always-prefer-system --debug
+    - eval `alienv load FairShip/latest`
+  script:
+    # it seems like the python script behave different if run inside the CI or if run from the classical command line. 
+    # I believe the difference is the interactivity of the shell, in the CI is not iteractive, in the shell it is iteractive.
+    # The use of `script -c` seems to fix the problem.
+    # We pipe the result of the script into tee that print to screen and to the input file at the same time.
+    # Then we grep the file created by tee for the successful signs.
+    # We don't grep directly the result of the script that, again, produce something a little different.
+    - script -c 'python $FAIRSHIP/macro/run_simScript.py --test' | tee simulation; grep 'Macro finished succesfully.' simulation
+    - script -c 'python $FAIRSHIP/macro/ShipReco.py -f ship.conical.Pythia8-TGeant4.root -g geofile_full.conical.Pythia8-TGeant4.root' | tee recostruction; grep 'finished writing tree' recostruction
+    - script -c 'python $FAIRSHIP/macro/ShipAna.py -f ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root' | tee analysis; grep 'finished making plots' analysis
 


### PR DESCRIPTION
Let's use the latest CVMFS installation method in gitlab CI.

The practical result is that for each PR we can automatically compile the test and run the python physic pipeline.

Examples of compilation: https://gitlab.cern.ch/smosciat/FairShip/-/jobs/5089863
Example of physics pipeline: https://gitlab.cern.ch/smosciat/FairShip/-/jobs/5089864

The gitlab repository is set in such a way that, periodically, it fetches the latest PR from github and run all the test we have defined in this file.

Ready to merge.