### PR TITLE
Dictionary fixes in order to support Python 3.

### DIFF
--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -56,7 +56,7 @@ viewsI = {1:[0,1],2:[0,2],3:[0],4:[0]}
 viewC = {0:"_x",1:"_u",2:"_v"}
 
 muSources = {'eta':221,'omega':223,'phi':333,'rho0':113,'eta_prime':331}
-muSourcesIDs = muSources.values()
+muSourcesIDs = list(muSources.values())
 rnr       = ROOT.TRandom()
 #-----prepare python exit-----------------------------------------------
 def pyExit():
@@ -780,7 +780,7 @@ DT={}
 def compareAlignment():
  ut.bookHist(h,'alignCompare','compare Alignments',100,-120.,120.,100,-120.,120.)
  ut.bookHist(h,'alignCompareDiffs','compare Alignments',100,-1.,1.)
- keys = xpos.keys()
+ keys = list(xpos.keys())
  keys.sort()
  for d in keys:
    test = ROOT.MufluxSpectrometerHit(d,0.)
@@ -2151,7 +2151,7 @@ def findDTClusters(removeBigClusters=True):
      if removeBigClusters:
       clustersPerLayer = {}
       for l in range(4):
-       clustersPerLayer[l] = dict(enumerate(grouper(allHits[l].keys(),1), 1))
+       clustersPerLayer[l] = dict(enumerate(grouper(list(allHits[l].keys()),1), 1))
        for Acl in clustersPerLayer[l]:
         if len(clustersPerLayer[l][Acl])>cuts['maxClusterSize']: # kill cross talk brute force
            for x in clustersPerLayer[l][Acl]:
@@ -2891,7 +2891,7 @@ def plotSigmaRes():
  ROOT.gROOT.FindObject('c1').cd()
  h['resDistr'].Draw()
 def calculateRTcorrection():
-  hkeys = h.keys()
+  hkeys = list(h.keys())
   for hist in hkeys:
    if hist.find('biasResDist')!=0: continue
    if not hist.find('proj')<0: continue
@@ -2942,7 +2942,7 @@ def calculateRTcorrection():
    h[x].Draw('same')
 
 def analyzeSingleDT():
- keys = xpos.keys()
+ keys = list(xpos.keys())
  keys.sort()
  for detID in keys:
     histo = h['biasResX_'+str(detID)+'_projx']
@@ -3058,7 +3058,7 @@ def DTeffWithRPCTracks(Nevents=0,onlyPlotting=False):
        vbot,vtop = strawPositionsBotTop[hit.GetDetectorID()]
        pos[(vbot[2]+vtop[2])/2.]=(vbot[0]+vtop[0])/2.
      if len(pos)<3: continue # 1 RPC point + >1 DT point
-     coefficients = numpy.polyfit(pos.keys(),pos.values(),1)
+     coefficients = numpy.polyfit(list(pos.keys()),list(pos.values()),1)
      Ntot[tag_s] += 1
      nhits={1:0,2:0,3:0,4:0}
      for s in range(1,5):
@@ -4576,7 +4576,7 @@ def analyzeRTrel():
     rc = h[x+'Tmax'].Fill(RTrelations[fname]['tMinAndTmax'][x][1])
   ut.bookCanvas(h,'RTMins','RT Min',1200,900,7,5)
   ut.bookCanvas(h,'RTMaxs','RT Max',1200,900,7,5)
-  keys = RTrelations[fnames[0]]['tMinAndTmax'].keys()
+  keys = list(RTrelations[fnames[0]]['tMinAndTmax'].keys())
   keys.sort()
   for n in range(1,35):
    tc = h['RTMins'].cd(n)

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -56,7 +56,6 @@ viewsI = {1:[0,1],2:[0,2],3:[0],4:[0]}
 viewC = {0:"_x",1:"_u",2:"_v"}
 
 muSources = {'eta':221,'omega':223,'phi':333,'rho0':113,'eta_prime':331}
-muSourcesIDs = list(muSources.values())
 rnr       = ROOT.TRandom()
 #-----prepare python exit-----------------------------------------------
 def pyExit():
@@ -780,9 +779,7 @@ DT={}
 def compareAlignment():
  ut.bookHist(h,'alignCompare','compare Alignments',100,-120.,120.,100,-120.,120.)
  ut.bookHist(h,'alignCompareDiffs','compare Alignments',100,-1.,1.)
- keys = list(xpos.keys())
- keys.sort()
- for d in keys:
+ for d in sorted(xpos.keys()):
    test = ROOT.MufluxSpectrometerHit(d,0.)
    test.MufluxSpectrometerEndPoints(vbot,vtop)
    statnb,vnb,pnb,lnb,view,channelID,tdcId,nRT = stationInfo(test)
@@ -2891,8 +2888,7 @@ def plotSigmaRes():
  ROOT.gROOT.FindObject('c1').cd()
  h['resDistr'].Draw()
 def calculateRTcorrection():
-  hkeys = list(h.keys())
-  for hist in hkeys:
+  for hist in h.keys():
    if hist.find('biasResDist')!=0: continue
    if not hist.find('proj')<0: continue
    if hist == 'biasResDist2' : continue
@@ -2942,9 +2938,7 @@ def calculateRTcorrection():
    h[x].Draw('same')
 
 def analyzeSingleDT():
- keys = list(xpos.keys())
- keys.sort()
- for detID in keys:
+ for detID in sorted(xpos.keys()):
     histo = h['biasResX_'+str(detID)+'_projx']
     mean,rms = -999.,0.
     if histo.GetSumOfWeights()>25:
@@ -4666,7 +4660,7 @@ def checkForDiMuon():
   for t in sTree.MCTrack:
    if abs(t.GetPdgCode())!=13: continue
    moID  = abs(sTree.MCTrack[t.GetMotherId()].GetPdgCode())
-   if moID in muSourcesIDs: 
+   if moID in muSources.values():
      boost = True
      break
    pName = t.GetProcName().Data()

--- a/charmdet/runReconstruction.py
+++ b/charmdet/runReconstruction.py
@@ -47,9 +47,7 @@ def getFilesFromEOS():
   rc = os.system("xrdcp -f $EOSSHIP"+fname+" "+newName)
   tmp[newName]=fileList[fname]
 
- fnames = list(tmp.keys())
- fnames.sort()
- return tmp,fnames
+ return tmp,sorted(tmp.keys())
 
 def getFilesLocal():
 # list of files
@@ -69,9 +67,7 @@ def getFilesLocal():
 
  Nfiles = len(fileList)
 
- fnames = list(fileList.keys())
- fnames.sort()
- return fileList,fnames
+ return fileList,sorted(fileList.keys())
 
 def recoStep0(local=False):
  if local: tmp,fnames = getFilesLocal()
@@ -464,9 +460,8 @@ def pot():
     if name!='slices':
      if name not in scalerStat:scalerStat[name]=0
      scalerStat[name]+=s
- keys = list(scalerStat.keys())
- keys.sort()
- for k in keys: print(k,':',scalerStat[k])
+ for k in sorted(scalerStat.keys()):
+   print(k,':',scalerStat[k])
 
 def makeDTEfficiency(merge=False):
  cmd = "hadd -f DTEff.root "

--- a/charmdet/runReconstruction.py
+++ b/charmdet/runReconstruction.py
@@ -47,7 +47,7 @@ def getFilesFromEOS():
   rc = os.system("xrdcp -f $EOSSHIP"+fname+" "+newName)
   tmp[newName]=fileList[fname]
 
- fnames = tmp.keys()
+ fnames = list(tmp.keys())
  fnames.sort()
  return tmp,fnames
 
@@ -69,7 +69,7 @@ def getFilesLocal():
 
  Nfiles = len(fileList)
 
- fnames = fileList.keys()
+ fnames = list(fileList.keys())
  fnames.sort()
  return fileList,fnames
 
@@ -464,7 +464,7 @@ def pot():
     if name!='slices':
      if name not in scalerStat:scalerStat[name]=0
      scalerStat[name]+=s
- keys = scalerStat.keys()
+ keys = list(scalerStat.keys())
  keys.sort()
  for k in keys: print(k,':',scalerStat[k])
 

--- a/geometry/config_tester.py
+++ b/geometry/config_tester.py
@@ -32,7 +32,7 @@ def main(arguments):
         logger.info("paramters: %s" % arguments.params)
     ConfigRegistry.loadpy(arguments.config_file, **arguments.params)
     # ConfigRegistry.loadpy(arguments.config_file, muShieldDesign=2, targetOpt=5)
-    for k, v in ConfigRegistry().iteritems():
+    for k, v in ConfigRegistry().items():
         print("%s: %s" % (k, v))
 
 if __name__ == '__main__':

--- a/housekeeping/cpplint/cpplint.py
+++ b/housekeeping/cpplint/cpplint.py
@@ -840,7 +840,7 @@ class _CppLintState(object):
 
   def PrintErrorCounts(self):
     """Print a summary of errors by category, and the total."""
-    for category, count in self.errors_by_category.iteritems():
+    for category, count in self.errors_by_category.items():
       sys.stderr.write('Category \'%s\' errors found: %d\n' %
                        (category, count))
     sys.stderr.write('Total errors found: %d\n' % self.error_count)
@@ -4701,7 +4701,7 @@ def _GetTextInside(text, start_pattern):
 
   # Give opening punctuations to get the matching close-punctuations.
   matching_punctuation = {'(': ')', '{': '}', '[': ']'}
-  closing_punctuation = set(matching_punctuation.itervalues())
+  closing_punctuation = set(matching_punctuation.values())
 
   # Find the position to start extracting text.
   match = re.search(start_pattern, text, re.M)
@@ -5671,7 +5671,7 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
 
   # include_dict is modified during iteration, so we iterate over a copy of
   # the keys.
-  header_keys = include_dict.keys()
+  header_keys = list(include_dict.keys())
   for header in header_keys:
     (same_module, common_path) = FilesBelongToSameModule(abs_filename, header)
     fullpath = common_path + header

--- a/housekeeping/cpplint/cpplint.py
+++ b/housekeeping/cpplint/cpplint.py
@@ -5671,8 +5671,7 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
 
   # include_dict is modified during iteration, so we iterate over a copy of
   # the keys.
-  header_keys = list(include_dict.keys())
-  for header in header_keys:
+  for header in include_dict.keys():
     (same_module, common_path) = FilesBelongToSameModule(abs_filename, header)
     fullpath = common_path + header
     if same_module and UpdateIncludeState(fullpath, include_dict, io):

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -359,7 +359,7 @@ class DrawTracks(ROOT.FairTask):
       lam = (zEx+fPos.Z())/fMom.Z()
       hitlist[zEx+fPos.Z()] = [fPos.X()+lam*fMom.X(),fPos.Y()+lam*fMom.Y()]
 # sort in z
-   lz = hitlist.keys()
+   lz = list(hitlist.keys())
    if len(lz)>1:
     lz.sort()
     for z in lz:  DTrack.SetNextPoint(hitlist[z][0],hitlist[z][1],z)
@@ -1154,7 +1154,7 @@ def DrawSimpleMCTracks():
    z = fPos.Z() + delZ
    slx,sly = fMom.X()/fMom.Z(),fMom.Y()/fMom.Z()
    hitlist[z] = [fPos.X()+slx*delZ,fPos.Y()+sly*delZ]
-   lz = hitlist.keys()
+   lz = list(hitlist.keys())
    for z in lz:  DTrack.SetNextPoint(hitlist[z][0],hitlist[z][1],z)
    p = pdg.GetParticle(fT.GetPdgCode()) 
    if p : pName = p.GetName()

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -1154,8 +1154,8 @@ def DrawSimpleMCTracks():
    z = fPos.Z() + delZ
    slx,sly = fMom.X()/fMom.Z(),fMom.Y()/fMom.Z()
    hitlist[z] = [fPos.X()+slx*delZ,fPos.Y()+sly*delZ]
-   lz = list(hitlist.keys())
-   for z in lz:  DTrack.SetNextPoint(hitlist[z][0],hitlist[z][1],z)
+   for z in hitlist.keys():
+    DTrack.SetNextPoint(hitlist[z][0],hitlist[z][1],z)
    p = pdg.GetParticle(fT.GetPdgCode()) 
    if p : pName = p.GetName()
    else:  pName =  str(fT.GetPdgCode())

--- a/macro/obsolete/ShipAnaWithVertexing.py
+++ b/macro/obsolete/ShipAnaWithVertexing.py
@@ -219,7 +219,7 @@ def myEventLoop(N):
      for tr in fittedTracks:
       xx  = fittedTracks[tr].getFittedState()
       PosDir[tr] = [xx.getPos(),xx.getDir()]
-     keys = fittedTracks.keys()
+     keys = list(fittedTracks.keys())
      t1,t2 = keys[0],keys[1] 
      xv,yv,zv,doca = myVertex(t1,t2,PosDir)
      h['Doca'].Fill(dist)  

--- a/muonShieldOptimization/compactingBackgroundProduction.py
+++ b/muonShieldOptimization/compactingBackgroundProduction.py
@@ -144,7 +144,7 @@ def addAllHistograms():
   ut.readHists(h,path+fname)
   if i==0:
     h[1012].Draw()
- tmp = h.keys()
+ tmp = list(h.keys())
  for x in tmp:
    if h[x].GetName().find('proj')>0: rc = h.pop(x)
  ut.writeHists(h,"pythia8_Geant4_"+ecut+"_c"+str(Nmax)+"-histos.root")

--- a/muonShieldOptimization/compactingBackgroundProduction.py
+++ b/muonShieldOptimization/compactingBackgroundProduction.py
@@ -144,8 +144,7 @@ def addAllHistograms():
   ut.readHists(h,path+fname)
   if i==0:
     h[1012].Draw()
- tmp = list(h.keys())
- for x in tmp:
+ for x in h.keys():
    if h[x].GetName().find('proj')>0: rc = h.pop(x)
  ut.writeHists(h,"pythia8_Geant4_"+ecut+"_c"+str(Nmax)+"-histos.root")
  

--- a/muonShieldOptimization/extractMuonsAndUpdateWeight.py
+++ b/muonShieldOptimization/extractMuonsAndUpdateWeight.py
@@ -8,7 +8,7 @@ path =  '/eos/experiment/ship/data/Mbias/background-prod-2018/'
 muSources = {'eta':221,'omega':223,'phi':333,'rho0':113,'eta_prime':331}
 charmExtern = [4332,4232,4132,4232,4122,431,411,421]
 
-muSourcesIDs = muSources.values()
+muSourcesIDs = list(muSources.values())
 
 # for 10GeV Yandex Production 65.041 Billion PoT, weight = 768.75 for 5E13 pot
 weightMbias = 768.75

--- a/muonShieldOptimization/extractMuonsAndUpdateWeight.py
+++ b/muonShieldOptimization/extractMuonsAndUpdateWeight.py
@@ -8,8 +8,6 @@ path =  '/eos/experiment/ship/data/Mbias/background-prod-2018/'
 muSources = {'eta':221,'omega':223,'phi':333,'rho0':113,'eta_prime':331}
 charmExtern = [4332,4232,4132,4232,4122,431,411,421]
 
-muSourcesIDs = list(muSources.values())
-
 # for 10GeV Yandex Production 65.041 Billion PoT, weight = 768.75 for 5E13 pot
 weightMbias = 768.75
 
@@ -38,7 +36,7 @@ def muonUpdateWeight(sTree,diMuboost,xSecboost,noCharm=True):
    elif not pName.find('Positron annihilation')<0:
      t.MultiplyWeight(1./xSecboost)
    elif not pName.find('Primary particle')<0 or not pName.find('Decay')<0:
-     if moID in muSourcesIDs:
+     if moID in muSources.values():
        t.MultiplyWeight(1./diMuboost)
  return nMu
 

--- a/muonShieldOptimization/run_reco.py
+++ b/muonShieldOptimization/run_reco.py
@@ -113,7 +113,7 @@ def executeSimple(prefixes,reset=False):
           time.sleep(10)
  nJobs = len(proc)
  while nJobs > 0:
-  procAna = proc.keys()
+  procAna = list(proc.keys())
   nJobs = len(proc)
   procAna.sort()
   print('debug ',nJobs)

--- a/muonShieldOptimization/run_reco.py
+++ b/muonShieldOptimization/run_reco.py
@@ -113,11 +113,9 @@ def executeSimple(prefixes,reset=False):
           time.sleep(10)
  nJobs = len(proc)
  while nJobs > 0:
-  procAna = list(proc.keys())
   nJobs = len(proc)
-  procAna.sort()
   print('debug ',nJobs)
-  for p in procAna: 
+  for p in sorted(proc.keys()):
     os.chdir('./'+p) 
     nproc = 100
     while nproc > ncores : 

--- a/muonShieldOptimization/study_muEloss.py
+++ b/muonShieldOptimization/study_muEloss.py
@@ -214,8 +214,7 @@ def makeSummaryPlot():
  Gpdg = h['Gpdg']
  Gpdg.SetMarkerColor(ROOT.kRed)
  Gpdg.SetMarkerStyle(20)
- keys = list(pdg.keys())
- keys.sort()
+ keys = sorted(pdg.keys())
  for n in range(len(keys)):
   Gpdg.SetPoint(n,keys[n],pdg[keys[n]])
  density= 2.413

--- a/muonShieldOptimization/study_muEloss.py
+++ b/muonShieldOptimization/study_muEloss.py
@@ -214,7 +214,7 @@ def makeSummaryPlot():
  Gpdg = h['Gpdg']
  Gpdg.SetMarkerColor(ROOT.kRed)
  Gpdg.SetMarkerStyle(20)
- keys = pdg.keys()
+ keys = list(pdg.keys())
  keys.sort()
  for n in range(len(keys)):
   Gpdg.SetPoint(n,keys[n],pdg[keys[n]])

--- a/python/ShipGeoConfig.py
+++ b/python/ShipGeoConfig.py
@@ -77,7 +77,7 @@ class ConfigRegistry(dict):
     @staticmethod
     def keys():
         registry = ConfigRegistry()
-        return [k for k, v in registry.iteritems()] 
+        return [k for k, v in registry.items()]
 
     @staticmethod
     def get(name):
@@ -101,7 +101,7 @@ class AttrDict(dict):
 
     def clone(self):
         result = AttrDict()
-        for k, v in self.iteritems():
+        for k, v in self.items():
             if isinstance(v, AttrDict):
                 result[k] = v.clone()
             else:
@@ -121,7 +121,7 @@ class Config(AttrDict):
 
     def clone(self):
         result = Config()
-        for k, v in self.iteritems():
+        for k, v in self.items():
             if isinstance(v, AttrDict):
                 result[k] = v.clone()
             else:

--- a/python/checkMagFields.py
+++ b/python/checkMagFields.py
@@ -41,7 +41,7 @@ def run():
     if f.GetBx(x,y,z)>0: rc=h['Bx+'].Fill(z,x,y,f.GetBx(x,y,z)/u.tesla) 
     if f.GetBy(x,y,z)<0: rc=h['By-'].Fill(z,x,y,-f.GetBy(x,y,z)/u.tesla)
     if f.GetBy(x,y,z)>0: rc=h['By+'].Fill(z,x,y,f.GetBy(x,y,z)/u.tesla) 
- hkeys = h.keys()
+ hkeys = list(h.keys())
  for x in hkeys:
   hi = h[x]
   if hi.ClassName()=='TH3F':

--- a/python/checkMagFields.py
+++ b/python/checkMagFields.py
@@ -41,8 +41,7 @@ def run():
     if f.GetBx(x,y,z)>0: rc=h['Bx+'].Fill(z,x,y,f.GetBx(x,y,z)/u.tesla) 
     if f.GetBy(x,y,z)<0: rc=h['By-'].Fill(z,x,y,-f.GetBy(x,y,z)/u.tesla)
     if f.GetBy(x,y,z)>0: rc=h['By+'].Fill(z,x,y,f.GetBy(x,y,z)/u.tesla) 
- hkeys = list(h.keys())
- for x in hkeys:
+ for x in h.keys():
   hi = h[x]
   if hi.ClassName()=='TH3F':
    h[x+'_xz']=h[x].Project3D('xy')

--- a/python/pi0Reco.py
+++ b/python/pi0Reco.py
@@ -27,7 +27,7 @@ def findPi0(sTree,secVertex):
   recoGammas[gamma] = ROOT.TLorentzVector(direction.X()/norm*P,direction.Y()/norm*P,direction.Z()/norm*P,P)
   sTree.MCTrack[mc].GetStartVertex(V)
  if len(recoGammas)==0: return []
- listOfGammas=recoGammas.values()
+ listOfGammas=list(recoGammas.values())
  for g1 in range(len(listOfGammas)-1):
   for g2 in range(g1+1,len(listOfGammas)):
     pi0 = listOfGammas[g1] + listOfGammas[g2]

--- a/python/pythia8_conf_utils.py
+++ b/python/pythia8_conf_utils.py
@@ -34,7 +34,7 @@ def getmaxsumbrrpvsusy(h,histograms,mass,couplings):
            sumbrs[meson]+=getbr_rpvsusy(h,histoname,mass,coupling)
        except:
            sumbrs[meson]=getbr_rpvsusy(h,histoname,mass,coupling)
-    print(sumbrs.values())
+    print(list(sumbrs.values()))
     maxsumbr=max(sumbrs.values())
     return maxsumbr
 

--- a/python/shipPatRec_old.py
+++ b/python/shipPatRec_old.py
@@ -1310,7 +1310,7 @@ def ptrack(zlayer,ptrackhits,nrwant,window):
 
 # get first and last plane number (needs to be consecutive, and also contains empty planes
 # should be included in the list!
- planes=zlayer.keys()
+ planes=list(zlayer.keys())
  planes.sort()
  i_1=planes[0]
  i_2=planes[len(planes)-1]

--- a/python/shipPatRec_prev.py
+++ b/python/shipPatRec_prev.py
@@ -1310,7 +1310,7 @@ def ptrack(zlayer,ptrackhits,nrwant,window):
 
 # get first and last plane number (needs to be consecutive, and also contains empty planes
 # should be included in the list!
- planes=zlayer.keys()
+ planes=list(zlayer.keys())
  planes.sort()
  i_1=planes[0]
  i_2=planes[len(planes)-1]

--- a/python/test_shipGeoConfig.py
+++ b/python/test_shipGeoConfig.py
@@ -13,7 +13,7 @@ class TestSingleConfig(unittest.TestCase):
             c.width = 20
 
     def test_len(self):
-        assert len(ConfigRegistry.keys()) == 1, ConfigRegistry.keys()
+        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
 
     def test_key(self):
         assert self.key in ConfigRegistry.keys()
@@ -92,7 +92,7 @@ with ConfigRegistry.register_config("basic") as c:
         ConfigRegistry.loadpys(config)
 
     def test_len(self):
-        assert len(ConfigRegistry.keys()) == 1, ConfigRegistry.keys()
+        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
 
     def test_key(self):
         assert self.key in ConfigRegistry.keys()
@@ -141,15 +141,15 @@ with ConfigRegistry.register_config("basic") as c:
     def test_true(self):
         c = ConfigRegistry.loadpys(self.config, MU_SHIELD_ENABLED=True)
         self.assertTrue("muShield" in c)
-        assert len(ConfigRegistry.keys()) == 1, ConfigRegistry.keys()
         assert self.key in ConfigRegistry.keys()
+        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
         assert ConfigRegistry[self.key].Bfield.max  == 1.5*u.kilogauss
         assert ConfigRegistry[self.key].muShield.dZ1 == 2.5*u.m
 
     def test_false(self):
         ConfigRegistry.loadpys(self.config, MU_SHIELD_ENABLED=False)
-        assert len(ConfigRegistry.keys()) == 1, ConfigRegistry.keys()
         assert self.key in ConfigRegistry.keys()
+        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
         assert ConfigRegistry[self.key].Bfield.max  == 1.5*u.kilogauss
         self.assertTrue("muShield" not in ConfigRegistry[self.key])
 

--- a/python/test_shipGeoConfig.py
+++ b/python/test_shipGeoConfig.py
@@ -13,7 +13,7 @@ class TestSingleConfig(unittest.TestCase):
             c.width = 20
 
     def test_len(self):
-        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
+        assert len(ConfigRegistry.keys()) == 1, list(ConfigRegistry.keys())
 
     def test_key(self):
         assert self.key in ConfigRegistry.keys()
@@ -92,7 +92,7 @@ with ConfigRegistry.register_config("basic") as c:
         ConfigRegistry.loadpys(config)
 
     def test_len(self):
-        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
+        assert len(ConfigRegistry.keys()) == 1, list(ConfigRegistry.keys())
 
     def test_key(self):
         assert self.key in ConfigRegistry.keys()
@@ -142,14 +142,14 @@ with ConfigRegistry.register_config("basic") as c:
         c = ConfigRegistry.loadpys(self.config, MU_SHIELD_ENABLED=True)
         self.assertTrue("muShield" in c)
         assert self.key in ConfigRegistry.keys()
-        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
+        assert len(ConfigRegistry.keys()) == 1, list(ConfigRegistry.keys())
         assert ConfigRegistry[self.key].Bfield.max  == 1.5*u.kilogauss
         assert ConfigRegistry[self.key].muShield.dZ1 == 2.5*u.m
 
     def test_false(self):
         ConfigRegistry.loadpys(self.config, MU_SHIELD_ENABLED=False)
         assert self.key in ConfigRegistry.keys()
-        assert len(list(ConfigRegistry.keys())) == 1, list(ConfigRegistry.keys())
+        assert len(ConfigRegistry.keys()) == 1, list(ConfigRegistry.keys())
         assert ConfigRegistry[self.key].Bfield.max  == 1.5*u.kilogauss
         self.assertTrue("muShield" not in ConfigRegistry[self.key])
 


### PR DESCRIPTION
Run `futurize -wn --fix=dict **/*.py`, then manually discard some changes where
wrapping the iterator in a `list()` is unnecessary.
- When iterating over a temporary object, keep the iterator.
- When checking membership (`in`) with a temporary object, keep the iterator.