### PR TITLE
Use Python 3 `range`.

### DIFF
--- a/housekeeping/cpplint/cpplint.py
+++ b/housekeeping/cpplint/cpplint.py
@@ -41,6 +41,7 @@ We do a small hack, which is to ignore //'s with "'s after them on the
 same line, but it is far from perfect (in either direction).
 """
 
+from builtins import range
 import codecs
 import copy
 import getopt
@@ -1395,7 +1396,7 @@ def FindEndOfExpressionInLine(line, startpos, stack):
     On finding an unclosed expression: (-1, None)
     Otherwise: (-1, new stack at end of this line)
   """
-  for i in xrange(startpos, len(line)):
+  for i in range(startpos, len(line)):
     char = line[i]
     if char in '([{':
       # Found start of parenthesized expression, push to expression stack
@@ -1624,7 +1625,7 @@ def CheckForCopyright(filename, lines, error):
 
   # We'll say it should occur by line 10. Don't forget there's a
   # dummy line at the front.
-  for line in xrange(1, min(len(lines), 11)):
+  for line in range(1, min(len(lines), 11)):
     if re.search(r'Copyright', lines[line], re.I): break
   else:                       # means no copyright line was found
     error(filename, 0, 'legal/copyright', 5,
@@ -1752,7 +1753,7 @@ def CheckForHeaderGuard(filename, clean_lines, error):
   # contain any "//" comments at all, it could be that the compiler
   # only wants "/**/" comments, look for those instead.
   no_single_line_comments = True
-  for i in xrange(1, len(raw_lines) - 1):
+  for i in range(1, len(raw_lines) - 1):
     line = raw_lines[i]
     if Match(r'^(?:(?:\'(?:\.|[^\'])*\')|(?:"(?:\.|[^"])*")|[^\'"])*//', line):
       no_single_line_comments = False
@@ -2093,7 +2094,7 @@ class _ClassInfo(_BlockInfo):
     # If there is a DISALLOW macro, it should appear near the end of
     # the class.
     seen_last_thing_in_class = False
-    for i in xrange(linenum - 1, self.starting_linenum, -1):
+    for i in range(linenum - 1, self.starting_linenum, -1):
       match = Search(
           r'\b(DISALLOW_COPY_AND_ASSIGN|DISALLOW_IMPLICIT_CONSTRUCTORS)\(' +
           self.name + r'\)',
@@ -2879,7 +2880,7 @@ def CheckForFunctionLengths(filename, clean_lines, linenum,
 
   if starting_func:
     body_found = False
-    for start_linenum in xrange(linenum, clean_lines.NumLines()):
+    for start_linenum in range(linenum, clean_lines.NumLines()):
       start_line = lines[start_linenum]
       joined_line += ' ' + start_line.lstrip()
       if Search(r'(;|})', start_line):  # Declarations and trivial functions
@@ -3363,7 +3364,7 @@ def CheckBracesSpacing(filename, clean_lines, linenum, error):
     trailing_text = ''
     if endpos > -1:
       trailing_text = endline[endpos:]
-    for offset in xrange(endlinenum + 1,
+    for offset in range(endlinenum + 1,
                          min(endlinenum + 3, clean_lines.NumLines() - 1)):
       trailing_text += clean_lines.elided[offset]
     if not Match(r'^[\s}]*[{.;,)<>\]:]', trailing_text):
@@ -3534,7 +3535,7 @@ def IsRValueType(typenames, clean_lines, nesting_state, linenum, column):
 
     # Look for the previous 'for(' in the previous lines.
     before_text = match_symbol.group(1)
-    for i in xrange(start - 1, max(start - 6, 0), -1):
+    for i in range(start - 1, max(start - 6, 0), -1):
       before_text = clean_lines.elided[i] + before_text
     if Search(r'for\s*\([^{};]*$', before_text):
       # This is the condition inside a for-loop
@@ -3662,12 +3663,12 @@ def IsRValueAllowed(clean_lines, linenum, typenames):
     True if line is within the region where RValue references are allowed.
   """
   # Allow region marked by PUSH/POP macros
-  for i in xrange(linenum, 0, -1):
+  for i in range(linenum, 0, -1):
     line = clean_lines.elided[i]
     if Match(r'GOOGLE_ALLOW_RVALUE_REFERENCES_(?:PUSH|POP)', line):
       if not line.endswith('PUSH'):
         return False
-      for j in xrange(linenum, clean_lines.NumLines(), 1):
+      for j in range(linenum, clean_lines.NumLines(), 1):
         line = clean_lines.elided[j]
         if Match(r'GOOGLE_ALLOW_RVALUE_REFERENCES_(?:PUSH|POP)', line):
           return line.endswith('POP')
@@ -4230,7 +4231,7 @@ def CheckCheck(filename, clean_lines, linenum, error):
     expression = lines[linenum][start_pos + 1:end_pos - 1]
   else:
     expression = lines[linenum][start_pos + 1:]
-    for i in xrange(linenum + 1, end_line):
+    for i in range(linenum + 1, end_line):
       expression += lines[i]
     expression += last_line[0:end_pos - 1]
 
@@ -5008,7 +5009,7 @@ def IsDerivedFunction(clean_lines, linenum):
     virt-specifier.
   """
   # Scan back a few lines for start of current function
-  for i in xrange(linenum, max(-1, linenum - 10), -1):
+  for i in range(linenum, max(-1, linenum - 10), -1):
     match = Match(r'^([^()]*\w+)\(', clean_lines.elided[i])
     if match:
       # Look for "override" after the matching closing parenthesis
@@ -5029,7 +5030,7 @@ def IsOutOfLineMethodDefinition(clean_lines, linenum):
     True if current line contains an out-of-line method definition.
   """
   # Scan back a few lines for start of current function
-  for i in xrange(linenum, max(-1, linenum - 10), -1):
+  for i in range(linenum, max(-1, linenum - 10), -1):
     if Match(r'^([^()]*\w+)\(', clean_lines.elided[i]):
       return Match(r'^[^()]*\w+::\w+\(', clean_lines.elided[i]) is not None
   return False
@@ -5045,7 +5046,7 @@ def IsInitializerList(clean_lines, linenum):
     True if current line appears to be inside constructor initializer
     list, False otherwise.
   """
-  for i in xrange(linenum, 1, -1):
+  for i in range(linenum, 1, -1):
     line = clean_lines.elided[i]
     if i == linenum:
       remove_function_body = Match(r'^(.*)\{\s*$', line)
@@ -5146,7 +5147,7 @@ def CheckForNonConstReference(filename, clean_lines, linenum,
           # Found the matching < on an earlier line, collect all
           # pieces up to current line.
           line = ''
-          for i in xrange(startline, linenum + 1):
+          for i in range(startline, linenum + 1):
             line += clean_lines.elided[i].strip()
 
   # Check for non-const references in function parameters.  A single '&' may
@@ -5170,7 +5171,7 @@ def CheckForNonConstReference(filename, clean_lines, linenum,
   # appear inside the second set of parentheses on the current line as
   # opposed to the first set.
   if linenum > 0:
-    for i in xrange(linenum - 1, max(0, linenum - 10), -1):
+    for i in range(linenum - 1, max(0, linenum - 10), -1):
       previous_line = clean_lines.elided[i]
       if not Search(r'[),]\s*$', previous_line):
         break
@@ -5201,7 +5202,7 @@ def CheckForNonConstReference(filename, clean_lines, linenum,
     # Don't see a whitelisted function on this line.  Actually we
     # didn't see any function name on this line, so this is likely a
     # multi-line parameter list.  Try a bit harder to catch this case.
-    for i in xrange(2):
+    for i in range(2):
       if (linenum > i and
           Search(whitelisted_functions, clean_lines.elided[linenum - i - 1])):
         return
@@ -5363,7 +5364,7 @@ def CheckCStyleCast(filename, clean_lines, linenum, cast_type, pattern, error):
   # Try expanding current context to see if we one level of
   # parentheses inside a macro.
   if linenum > 0:
-    for i in xrange(linenum - 1, max(0, linenum - 5), -1):
+    for i in range(linenum - 1, max(0, linenum - 5), -1):
       context = clean_lines.elided[i] + context
   if Match(r'.*\b[_A-Z][_A-Z0-9]*\s*\((?:\([^()]*\)|[^()])*$', context):
     return False
@@ -5622,7 +5623,7 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
   required = {}  # A map of header name to linenumber and the template entity.
                  # Example of required: { '<functional>': (1219, 'less<>') }
 
-  for linenum in xrange(clean_lines.NumLines()):
+  for linenum in range(clean_lines.NumLines()):
     line = clean_lines.elided[linenum]
     if not line or line[0] == '#':
       continue
@@ -5778,7 +5779,7 @@ def CheckRedundantVirtual(filename, clean_lines, linenum, error):
   end_col = -1
   end_line = -1
   start_col = len(virtual.group(2))
-  for start_line in xrange(linenum, min(linenum + 3, clean_lines.NumLines())):
+  for start_line in range(linenum, min(linenum + 3, clean_lines.NumLines())):
     line = clean_lines.elided[start_line][start_col:]
     parameter_list = Match(r'^([^(]*)\(', line)
     if parameter_list:
@@ -5793,7 +5794,7 @@ def CheckRedundantVirtual(filename, clean_lines, linenum, error):
 
   # Look for "override" or "final" after the parameter list
   # (possibly on the next few lines).
-  for i in xrange(end_line, min(end_line + 3, clean_lines.NumLines())):
+  for i in range(end_line, min(end_line + 3, clean_lines.NumLines())):
     line = clean_lines.elided[i][end_col:]
     match = Search(r'\b(override|final)\b', line)
     if match:
@@ -6026,7 +6027,7 @@ def ProcessFileData(filename, file_extension, lines, error,
   if file_extension == 'h':
     CheckForHeaderGuard(filename, clean_lines, error)
 
-  for line in xrange(clean_lines.NumLines()):
+  for line in range(clean_lines.NumLines()):
     ProcessLine(filename, file_extension, clean_lines, line,
                 include_state, function_state, nesting_state, error,
                 extra_check_functions)

--- a/python/MufluxDigi.py
+++ b/python/MufluxDigi.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import os
 import ROOT
 import shipunit as u

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import os
 import ROOT
 import MufluxPatRec

--- a/python/shipPatRec_old.py
+++ b/python/shipPatRec_old.py
@@ -4,6 +4,7 @@
 #for documentation, see CERN-SHiP-NOTE-2015-002, https://cds.cern.ch/record/2005715/files/main.pdf
 #17-04-2015 comments to EvH
 from __future__ import print_function
+from builtins import range
 import ROOT, os
 import shipunit  as u
 import math
@@ -922,8 +923,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     py=0.
     pz=0.
     m=0
-    if firsttwo==True: looplist=reversed(range(len(trcandv1[t]))) 
-    else: looplist=range(len(trcandv1[t])) 
+    if firsttwo==True: looplist=reversed(list(range(len(trcandv1[t]))))
+    else: looplist=list(range(len(trcandv1[t])))
     for ipl in looplist:      
       indx= trcandv1[t][ipl]
       if indx>-1: 
@@ -1055,8 +1056,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       pzMC=0.
       stereotanMCv=0.
       stereocstMCv=0.
-      if firsttwo==True: looplist=reversed(range(len(trcandv2[t1]))) 
-      else: looplist=range(len(trcandv2[t1]))  
+      if firsttwo==True: looplist=reversed(list(range(len(trcandv2[t1]))))
+      else: looplist=list(range(len(trcandv2[t1])))
       for ipl in looplist:      
         indx= trcandv2[t1][ipl]
         if indx>-1:       

--- a/python/shipPatRec_prev.py
+++ b/python/shipPatRec_prev.py
@@ -4,6 +4,7 @@
 #for documentation, see CERN-SHiP-NOTE-2015-002, https://cds.cern.ch/record/2005715/files/main.pdf
 #17-04-2015 comments to EvH
 from __future__ import print_function
+from builtins import range
 import ROOT, os
 import shipunit  as u
 import math
@@ -922,8 +923,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     py=0.
     pz=0.
     m=0
-    if firsttwo==True: looplist=reversed(range(len(trcandv1[t]))) 
-    else: looplist=range(len(trcandv1[t])) 
+    if firsttwo==True: looplist=reversed(list(range(len(trcandv1[t]))))
+    else: looplist=list(range(len(trcandv1[t])))
     for ipl in looplist:      
       indx= trcandv1[t][ipl]
       if indx>-1: 
@@ -1055,8 +1056,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       pzMC=0.
       stereotanMCv=0.
       stereocstMCv=0.
-      if firsttwo==True: looplist=reversed(range(len(trcandv2[t1]))) 
-      else: looplist=range(len(trcandv2[t1]))  
+      if firsttwo==True: looplist=reversed(list(range(len(trcandv2[t1]))))
+      else: looplist=list(range(len(trcandv2[t1])))
       for ipl in looplist:      
         indx= trcandv2[t1][ipl]
         if indx>-1:       

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 # Mikhail Hushchyn, mikhail.hushchyn@cern.ch
 
+from builtins import range
 import ROOT
 import numpy
 


### PR DESCRIPTION
Run `futurize -wn --fix=xrange_with_import **/*.py`, then discard useless `list()` where the lazy Python 3 behaviour is desired.

Discard the imports in files where `range`/`xrange` is not used.

There are very few places where we want to keep the Python 2 behaviour. In these rare cases, I just kept `range` wrapped in a `list()`.