### PR TITLE
`cPickle` -> `pickle` & add aliases for Python 2.

### DIFF
--- a/python/ShipGeoConfig.py
+++ b/python/ShipGeoConfig.py
@@ -1,6 +1,8 @@
+from future import standard_library
+standard_library.install_aliases()
 import os
 import re
-import cPickle
+import pickle
 from contextlib import contextmanager
 
 
@@ -114,7 +116,7 @@ class Config(AttrDict):
         super(Config, self).__init__(*args, **kwargs)
 
     def loads(self, buff):
-        rv = cPickle.loads(buff)
+        rv = pickle.loads(buff)
         self.clear()
         self.update(rv)
         return self
@@ -129,7 +131,7 @@ class Config(AttrDict):
         return result
 
     def dumps(self):
-        return cPickle.dumps(self)
+        return pickle.dumps(self)
 
     def load(self, filename):
         with open(expand_env(filename)) as fh:


### PR DESCRIPTION
`futurize -wn --fix=future_standard_library **/*.py` and select relevant fixes.

~**NEEDS REVIEW** (and testing):~ `pickle` is currently listed as unsupported in the `futurize`
  documentation. Someone who is familiar with pickling should have a closer look.

If it does not work, I guess we can just test for `sys.version_info[0]` like we did for the ROOT pickler.