### PR TITLE
WIP: `__builtin__` -> `builtins` & add aliases for Python 2.

### DIFF
--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 #import yep
+from future import standard_library
+standard_library.install_aliases()
 import ROOT,os,time,sys,operator,atexit
 ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 
 from decorators import *
-import __builtin__ as builtin
+import builtins as builtin
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -3,6 +3,8 @@
 #geoFile   = '/eos/experiment/ship/data/muflux/run_fixedtarget/19april2018/geofile_full.root'
 from __future__ import print_function
 from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
 debug = False#False
 
 withNoStrawSmearing = None # True   for debugging purposes
@@ -31,7 +33,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys,getopt
-import __builtin__ as builtin
+import builtins as builtin
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
 from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
 from argparse import ArgumentParser
 
 withHists = True
@@ -19,7 +21,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys
-import __builtin__ as builtin
+import builtins as builtin
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function
 from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
 firstEvent = 0
 dy         = None
 
@@ -18,7 +20,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys,getopt
-import __builtin__ as builtin
+import builtins as builtin
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 from __future__ import division
 # Mikhail Hushchyn, mikhail.hushchyn@cern.ch
 
+from future import standard_library
+standard_library.install_aliases()
 from builtins import range
 import ROOT
 import numpy
@@ -15,7 +17,7 @@ from rootpyPickler import Unpickler
 
 # For modules
 import shipDet_conf
-import __builtin__ as builtin
+import builtins as builtin
 # import TrackExtrapolateTool
 
 # For track pattern recognition


### PR DESCRIPTION
`futurize -wn --fix=future_standard_library **/*.py` and select relevant fixes.

It seems like this should be a simple rename, so I would expect it to be safe.

**NEEDS REVIEW** (and testing): Not sure why we use `__builtin__` in the first place. Someone who is familiar with this usage should have a look to make sure that `builtins` is indeed equivalent.