### PR TITLE
Use global_variables module instead of polluting __builtins__

### DIFF
--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -6,7 +6,7 @@ import ROOT,os
 #ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 import numpy
 from decorators import *
-import config
+import global_variables
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------
@@ -77,7 +77,7 @@ else:
 #-------------------------------geometry initialization
 from ShipGeoConfig import ConfigRegistry
 ShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = 1, cTarget = 1)
-config.ShipGeo = ShipGeo
+global_variables.ShipGeo = ShipGeo
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine

--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -6,7 +6,7 @@ import ROOT,os
 #ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 import numpy
 from decorators import *
-import globals
+import config
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------
@@ -77,7 +77,7 @@ else:
 #-------------------------------geometry initialization
 from ShipGeoConfig import ConfigRegistry
 ShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = 1, cTarget = 1)
-globals.ShipGeo = ShipGeo
+config.ShipGeo = ShipGeo
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine

--- a/charmdet/CharmdetHitPositions.py
+++ b/charmdet/CharmdetHitPositions.py
@@ -6,7 +6,7 @@ import ROOT,os
 #ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 import numpy
 from decorators import *
-import builtins as builtin
+import globals
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------
@@ -77,7 +77,7 @@ else:
 #-------------------------------geometry initialization
 from ShipGeoConfig import ConfigRegistry
 ShipGeo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = 1, cTarget = 1)
-builtin.ShipGeo = ShipGeo
+globals.ShipGeo = ShipGeo
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -4,7 +4,7 @@ import ROOT,os,time,sys,operator,atexit
 ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 
 from decorators import *
-import config
+import global_variables
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------
@@ -120,7 +120,7 @@ else:
  fgeo = ROOT.TFile.Open(options.geoFile)
  upkl    = Unpickler(options.geoFile)
  ShipGeo = upkl.load('ShipGeo')
-config.ShipGeo = ShipGeo
+global_variables.ShipGeo = ShipGeo
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -4,7 +4,7 @@ import ROOT,os,time,sys,operator,atexit
 ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 
 from decorators import *
-import __builtin__ as builtin
+import globals
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------
@@ -120,7 +120,7 @@ else:
  fgeo = ROOT.TFile.Open(options.geoFile)
  upkl    = Unpickler(options.geoFile)
  ShipGeo = upkl.load('ShipGeo')
-builtin.ShipGeo = ShipGeo
+globals.ShipGeo = ShipGeo
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -4,7 +4,7 @@ import ROOT,os,time,sys,operator,atexit
 ROOT.gROOT.ProcessLine('typedef std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, std::vector<MufluxSpectrometerHit*>>>> nestedList;')
 
 from decorators import *
-import globals
+import config
 ROOT.gStyle.SetPalette(ROOT.kGreenPink)
 PDG = ROOT.TDatabasePDG.Instance()
 # -----Timer--------------------------------------------------------
@@ -120,7 +120,7 @@ else:
  fgeo = ROOT.TFile.Open(options.geoFile)
  upkl    = Unpickler(options.geoFile)
  ShipGeo = upkl.load('ShipGeo')
-globals.ShipGeo = ShipGeo
+config.ShipGeo = ShipGeo
 import charmDet_conf
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -3,7 +3,7 @@
 #geoFile   = '/eos/experiment/ship/data/muflux/run_fixedtarget/19april2018/geofile_full.root'
 from __future__ import print_function
 from __future__ import division
-import globals
+import config
 debug = False#False
 
 withNoStrawSmearing = None # True   for debugging purposes
@@ -344,21 +344,21 @@ modules = charmDet_conf.configure(run,ShipGeo)
 fgeo.FAIRGeom
 
 # make global variables
-globals.debug    = debug
-globals.withT0 = withT0
-globals.realPR = realPR
+config.debug = debug
+config.withT0 = withT0
+config.realPR = realPR
 
-globals.ShipGeo = ShipGeo
-globals.modules = modules
+config.ShipGeo = ShipGeo
+config.modules = modules
 
-globals.withNoStrawSmearing = withNoStrawSmearing
-globals.withNTaggerHits = withNTaggerHits
-globals.withDist2Wire = withDist2Wire
-globals.h    = h
-globals.log  = log
-globals.simulation = simulation
+config.withNoStrawSmearing = withNoStrawSmearing
+config.withNTaggerHits = withNTaggerHits
+config.withDist2Wire = withDist2Wire
+config.h = h
+config.log = log
+config.simulation = simulation
 iEvent = 0
-globals.iEvent  = iEvent
+config.iEvent = iEvent
 
 # import reco tasks
 import MufluxDigiReco

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -357,8 +357,7 @@ config.withDist2Wire = withDist2Wire
 config.h = h
 config.log = log
 config.simulation = simulation
-iEvent = 0
-config.iEvent = iEvent
+config.iEvent = 0
 
 # import reco tasks
 import MufluxDigiReco
@@ -366,11 +365,13 @@ SHiP = MufluxDigiReco.MufluxDigiReco(outFile)
 
 nEvents   = min(SHiP.sTree.GetEntries(),nEvents)
 # main loop
-for iEvent in range(firstEvent, nEvents):
- if iEvent%1000 == 0 or debug: print('event ',iEvent)
- SHiP.iEvent = iEvent
- rc    = SHiP.sTree.GetEvent(iEvent) 
- if simulation: SHiP.digitize() 
+for config.iEvent in range(firstEvent, nEvents):
+    if config.iEvent % 1000 == 0 or config.debug:
+        print('event ', config.iEvent)
+    SHiP.iEvent = config.iEvent
+    rc = SHiP.sTree.GetEvent(config.iEvent)
+    if config.simulation:
+        SHiP.digitize()
  # IS BROKEN SHiP.reconstruct()
  # memory monitoring
  # mem_monitor() 

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -3,6 +3,7 @@
 #geoFile   = '/eos/experiment/ship/data/muflux/run_fixedtarget/19april2018/geofile_full.root'
 from __future__ import print_function
 from __future__ import division
+import globals
 debug = False#False
 
 withNoStrawSmearing = None # True   for debugging purposes
@@ -31,7 +32,6 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys,getopt
-import __builtin__ as builtin
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf
@@ -344,21 +344,21 @@ modules = charmDet_conf.configure(run,ShipGeo)
 fgeo.FAIRGeom
 
 # make global variables
-builtin.debug    = debug
-builtin.withT0 = withT0
-builtin.realPR = realPR
+globals.debug    = debug
+globals.withT0 = withT0
+globals.realPR = realPR
 
-builtin.ShipGeo = ShipGeo
-builtin.modules = modules
+globals.ShipGeo = ShipGeo
+globals.modules = modules
 
-builtin.withNoStrawSmearing = withNoStrawSmearing
-builtin.withNTaggerHits = withNTaggerHits
-builtin.withDist2Wire = withDist2Wire
-builtin.h    = h
-builtin.log  = log
-builtin.simulation = simulation
+globals.withNoStrawSmearing = withNoStrawSmearing
+globals.withNTaggerHits = withNTaggerHits
+globals.withDist2Wire = withDist2Wire
+globals.h    = h
+globals.log  = log
+globals.simulation = simulation
 iEvent = 0
-builtin.iEvent  = iEvent
+globals.iEvent  = iEvent
 
 # import reco tasks
 import MufluxDigiReco

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -3,7 +3,7 @@
 #geoFile   = '/eos/experiment/ship/data/muflux/run_fixedtarget/19april2018/geofile_full.root'
 from __future__ import print_function
 from __future__ import division
-import config
+import global_variables
 debug = False#False
 
 withNoStrawSmearing = None # True   for debugging purposes
@@ -343,20 +343,20 @@ modules = charmDet_conf.configure(run,ShipGeo)
 fgeo.FAIRGeom
 
 # make global variables
-config.debug = debug
-config.withT0 = withT0
-config.realPR = realPR
+global_variables.debug = debug
+global_variables.withT0 = withT0
+global_variables.realPR = realPR
 
-config.ShipGeo = ShipGeo
-config.modules = modules
+global_variables.ShipGeo = ShipGeo
+global_variables.modules = modules
 
-config.withNoStrawSmearing = withNoStrawSmearing
-config.withNTaggerHits = withNTaggerHits
-config.withDist2Wire = withDist2Wire
-config.h = h
-config.log = log
-config.simulation = simulation
-config.iEvent = 0
+global_variables.withNoStrawSmearing = withNoStrawSmearing
+global_variables.withNTaggerHits = withNTaggerHits
+global_variables.withDist2Wire = withDist2Wire
+global_variables.h = h
+global_variables.log = log
+global_variables.simulation = simulation
+global_variables.iEvent = 0
 
 # import reco tasks
 import MufluxDigiReco
@@ -364,12 +364,12 @@ SHiP = MufluxDigiReco.MufluxDigiReco(outFile)
 
 nEvents   = min(SHiP.sTree.GetEntries(),nEvents)
 # main loop
-for config.iEvent in range(firstEvent, nEvents):
-    if config.iEvent % 1000 == 0 or config.debug:
-        print('event ', config.iEvent)
-    SHiP.iEvent = config.iEvent
-    rc = SHiP.sTree.GetEvent(config.iEvent)
-    if config.simulation:
+for global_variables.iEvent in range(firstEvent, nEvents):
+    if global_variables.iEvent % 1000 == 0 or global_variables.debug:
+        print('event ', global_variables.iEvent)
+    SHiP.iEvent = global_variables.iEvent
+    rc = SHiP.sTree.GetEvent(global_variables.iEvent)
+    if global_variables.simulation:
         SHiP.digitize()
  # IS BROKEN SHiP.reconstruct()
  # memory monitoring

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -12,7 +12,6 @@ withNTaggerHits = 0
 nEvents    = 10000
 firstEvent = 0
 withHists = True
-vertexing = True
 dy  = None
 saveDisk  = False # remove input file
 realPR = ''
@@ -49,7 +48,7 @@ except getopt.GetoptError:
         sys.exit()
 for o, a in opts:
         if o in ("--noVertexing",):
-            vertexing = False
+            print("WARNING: --noVertexing option not currently used by script.")
         if o in ("--noStrawSmearing",):
             withNoStrawSmearing = True
         if o in ("--withT0",):
@@ -67,7 +66,7 @@ for o, a in opts:
         if o in ("-Y",):
             dy = float(a)
         if o in ("--ecalDebugDraw",):
-            print("WARNING: EcalDebugDraw option not currently used by script.")
+            print("WARNING: --ecalDebugDraw option not currently used by script.")
         if o in ("--saveDisk",):
             saveDisk = True
         if o in ("--realPR",):
@@ -82,8 +81,9 @@ if not dy:
     dy = float( tmp[1]+'.'+tmp[2] )
   except:
     dy = None
-print('configured to process ',nEvents,' events from ' ,inputFile, \
-      ' starting with event ',firstEvent, ' with option Yheight = ',dy,' with vertexing',vertexing,' and real pattern reco',realPR=="_PR")
+print('configured to process ', nEvents, ' events from ', inputFile,
+      ' starting with event ', firstEvent, ' with option Yheight = ', dy,
+      ' with vertexing', False,' and real pattern reco',realPR=="_PR")
 if not inputFile.find('_rec.root') < 0: 
   outFile   = inputFile
   inputFile = outFile.replace('_rec.root','.root') 

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -67,7 +67,7 @@ for o, a in opts:
         if o in ("-Y",):
             dy = float(a)
         if o in ("--ecalDebugDraw",):
-            EcalDebugDraw = True
+            print("WARNING: EcalDebugDraw option not currently used by script.")
         if o in ("--saveDisk",):
             saveDisk = True
         if o in ("--realPR",):

--- a/macro/MufluxReco.py
+++ b/macro/MufluxReco.py
@@ -15,7 +15,6 @@ withHists = True
 vertexing = True
 dy  = None
 saveDisk  = False # remove input file
-pidProton = False # if true, take truth, if False fake with pion mass
 realPR = ''
 withT0 = False
 

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -46,8 +46,7 @@ parser.add_argument("-dy",               dest="dy", help="Max height of tank", r
 parser.add_argument("--Debug",           dest="Debug", help="Switch on debugging", required=False, action="store_true")
 
 options = parser.parse_args()
-if options.noVertexing: vertexing = False
-else: vertexing = True
+vertexing = not options.noVertexing
  
 if options.EcalDebugDraw: ROOT.gSystem.Load("libASImage")
 
@@ -60,8 +59,9 @@ if not options.dy:
   except:
     dy = None
 
-print('configured to process ',options.nEvents,' events from ' ,options.inputFile, \
-      ' starting with event ',options.firstEvent, ' with option Yheight = ',dy,' with vertexing',vertexing,' and real pattern reco ',options.realPR)
+print('configured to process ', options.nEvents, ' events from ', options.inputFile,
+      ' starting with event ', options.firstEvent, ' with option Yheight = ' ,dy,
+      ' with vertexing', vertexing, ' and real pattern reco ', options.realPR)
 if not options.inputFile.find('_rec.root') < 0: 
   outFile   = options.inputFile
   options.inputFile = outFile.replace('_rec.root','.root') 

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -19,7 +19,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys
-import globals
+import config
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf
@@ -113,21 +113,21 @@ if hasattr(ShipGeo.Bfield,"fieldMap"):
   fieldMaker = geomGeant4.addVMCFields(ShipGeo, '', True,withVirtualMC = False)
 
 # make global variables
-globals.debug    = options.Debug
-globals.fieldMaker = fieldMaker
-globals.pidProton = pidProton
-globals.withT0 = options.withT0
-globals.realPR = options.realPR
-globals.vertexing = vertexing
-globals.ecalGeoFile = ecalGeoFile
-globals.ShipGeo = ShipGeo
-globals.modules = modules
-globals.EcalDebugDraw  = options.EcalDebugDraw
-globals.withNoStrawSmearing = options.withNoStrawSmearing
-globals.h    = h
-globals.log  = log
+config.debug = options.Debug
+config.fieldMaker = fieldMaker
+config.pidProton = pidProton
+config.withT0 = options.withT0
+config.realPR = options.realPR
+config.vertexing = vertexing
+config.ecalGeoFile = ecalGeoFile
+config.ShipGeo = ShipGeo
+config.modules = modules
+config.EcalDebugDraw = options.EcalDebugDraw
+config.withNoStrawSmearing = options.withNoStrawSmearing
+config.h = h
+config.log = log
 iEvent = 0
-globals.iEvent  = iEvent
+config.iEvent = iEvent
 
 # import reco tasks
 import shipDigiReco

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -19,7 +19,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys
-import __builtin__ as builtin
+import globals
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf
@@ -113,21 +113,21 @@ if hasattr(ShipGeo.Bfield,"fieldMap"):
   fieldMaker = geomGeant4.addVMCFields(ShipGeo, '', True,withVirtualMC = False)
 
 # make global variables
-builtin.debug    = options.Debug
-builtin.fieldMaker = fieldMaker
-builtin.pidProton = pidProton
-builtin.withT0 = options.withT0
-builtin.realPR = options.realPR
-builtin.vertexing = vertexing
-builtin.ecalGeoFile = ecalGeoFile
-builtin.ShipGeo = ShipGeo
-builtin.modules = modules
-builtin.EcalDebugDraw  = options.EcalDebugDraw
-builtin.withNoStrawSmearing = options.withNoStrawSmearing
-builtin.h    = h
-builtin.log  = log
+globals.debug    = options.Debug
+globals.fieldMaker = fieldMaker
+globals.pidProton = pidProton
+globals.withT0 = options.withT0
+globals.realPR = options.realPR
+globals.vertexing = vertexing
+globals.ecalGeoFile = ecalGeoFile
+globals.ShipGeo = ShipGeo
+globals.modules = modules
+globals.EcalDebugDraw  = options.EcalDebugDraw
+globals.withNoStrawSmearing = options.withNoStrawSmearing
+globals.h    = h
+globals.log  = log
 iEvent = 0
-builtin.iEvent  = iEvent
+globals.iEvent  = iEvent
 
 # import reco tasks
 import shipDigiReco

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -126,8 +126,7 @@ config.EcalDebugDraw = options.EcalDebugDraw
 config.withNoStrawSmearing = options.withNoStrawSmearing
 config.h = h
 config.log = log
-iEvent = 0
-config.iEvent = iEvent
+config.iEvent = 0
 
 # import reco tasks
 import shipDigiReco
@@ -135,12 +134,13 @@ import shipDigiReco
 SHiP = shipDigiReco.ShipDigiReco(outFile,fgeo)
 options.nEvents   = min(SHiP.sTree.GetEntries(),options.nEvents)
 # main loop
-for iEvent in range(options.firstEvent, options.nEvents):
- if iEvent%1000 == 0 or options.Debug: print('event ',iEvent)
- rc    = SHiP.sTree.GetEvent(iEvent) 
- SHiP.digitize()
- SHiP.reconstruct()
+for config.iEvent in range(options.firstEvent, options.nEvents):
+    if config.iEvent % 1000 == 0 or config.debug:
+        print('event ', config.iEvent)
+    rc = SHiP.sTree.GetEvent(config.iEvent)
+    SHiP.digitize()
+    SHiP.reconstruct()
  # memory monitoring
- # mem_monitor() 
+ # mem_monitor()
 # end loop over events
 SHiP.finish()

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -19,7 +19,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys
-import config
+import global_variables
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf
@@ -113,20 +113,20 @@ if hasattr(ShipGeo.Bfield,"fieldMap"):
   fieldMaker = geomGeant4.addVMCFields(ShipGeo, '', True,withVirtualMC = False)
 
 # make global variables
-config.debug = options.Debug
-config.fieldMaker = fieldMaker
-config.pidProton = pidProton
-config.withT0 = options.withT0
-config.realPR = options.realPR
-config.vertexing = vertexing
-config.ecalGeoFile = ecalGeoFile
-config.ShipGeo = ShipGeo
-config.modules = modules
-config.EcalDebugDraw = options.EcalDebugDraw
-config.withNoStrawSmearing = options.withNoStrawSmearing
-config.h = h
-config.log = log
-config.iEvent = 0
+global_variables.debug = options.Debug
+global_variables.fieldMaker = fieldMaker
+global_variables.pidProton = pidProton
+global_variables.withT0 = options.withT0
+global_variables.realPR = options.realPR
+global_variables.vertexing = vertexing
+global_variables.ecalGeoFile = ecalGeoFile
+global_variables.ShipGeo = ShipGeo
+global_variables.modules = modules
+global_variables.EcalDebugDraw = options.EcalDebugDraw
+global_variables.withNoStrawSmearing = options.withNoStrawSmearing
+global_variables.h = h
+global_variables.log = log
+global_variables.iEvent = 0
 
 # import reco tasks
 import shipDigiReco
@@ -134,10 +134,10 @@ import shipDigiReco
 SHiP = shipDigiReco.ShipDigiReco(outFile,fgeo)
 options.nEvents   = min(SHiP.sTree.GetEntries(),options.nEvents)
 # main loop
-for config.iEvent in range(options.firstEvent, options.nEvents):
-    if config.iEvent % 1000 == 0 or config.debug:
-        print('event ', config.iEvent)
-    rc = SHiP.sTree.GetEvent(config.iEvent)
+for global_variables.iEvent in range(options.firstEvent, options.nEvents):
+    if global_variables.iEvent % 1000 == 0 or global_variables.debug:
+        print('event ', global_variables.iEvent)
+    rc = SHiP.sTree.GetEvent(global_variables.iEvent)
     SHiP.digitize()
     SHiP.reconstruct()
  # memory monitoring

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -18,7 +18,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys,getopt
-import globals
+import config
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf
@@ -58,11 +58,11 @@ modules = charmDet_conf.configure(run,ShipGeo)
 fgeo.FAIRGeom
 
 # make global variables
-globals.debug    = options.debug
-globals.ShipGeo = ShipGeo
+config.debug = options.debug
+config.ShipGeo = ShipGeo
 
 iEvent = 0
-globals.iEvent  = iEvent
+config.iEvent = iEvent
 
 # import reco tasks
 import MufluxDigi

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -18,7 +18,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys,getopt
-import config
+import global_variables
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf
@@ -58,10 +58,10 @@ modules = charmDet_conf.configure(run,ShipGeo)
 fgeo.FAIRGeom
 
 # make global variables
-config.debug = options.debug
-config.ShipGeo = ShipGeo
+global_variables.debug = options.debug
+global_variables.ShipGeo = ShipGeo
 
-config.iEvent = 0
+global_variables.iEvent = 0
 
 # import reco tasks
 import MufluxDigi
@@ -69,11 +69,11 @@ SHiP = MufluxDigi.MufluxDigi(outFile)
 
 nEvents   = min(SHiP.sTree.GetEntries(),int(options.nEvents))
 # main loop
-for config.iEvent in range(firstEvent, nEvents):
-    if config.iEvent % 50000 == 0 or config.debug:
-        print('event ', config.iEvent, nEvents - firstEvent)
-    SHiP.iEvent = config.iEvent
-    rc = SHiP.sTree.GetEvent(config.iEvent)
+for global_variables.iEvent in range(firstEvent, nEvents):
+    if global_variables.iEvent % 50000 == 0 or global_variables.debug:
+        print('event ', global_variables.iEvent, nEvents - firstEvent)
+    SHiP.iEvent = global_variables.iEvent
+    rc = SHiP.sTree.GetEvent(global_variables.iEvent)
     SHiP.digitize()
  # memory monitoring
  # mem_monitor()

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -18,7 +18,7 @@ def mem_monitor():
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
 import ROOT,os,sys,getopt
-import __builtin__ as builtin
+import globals
 import rootUtils as ut
 import shipunit as u
 import shipRoot_conf
@@ -58,11 +58,11 @@ modules = charmDet_conf.configure(run,ShipGeo)
 fgeo.FAIRGeom
 
 # make global variables
-builtin.debug    = options.debug
-builtin.ShipGeo = ShipGeo
+globals.debug    = options.debug
+globals.ShipGeo = ShipGeo
 
 iEvent = 0
-builtin.iEvent  = iEvent
+globals.iEvent  = iEvent
 
 # import reco tasks
 import MufluxDigi

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -71,7 +71,8 @@ SHiP = MufluxDigi.MufluxDigi(outFile)
 nEvents   = min(SHiP.sTree.GetEntries(),int(options.nEvents))
 # main loop
 for iEvent in range(firstEvent, nEvents):
- if iEvent%50000 == 0 or debug: print('event ',iEvent,nEvents-firstEvent)
+ if iEvent % 50000 == 0 or config.debug:
+     print('event ', iEvent, nEvents - firstEvent)
  SHiP.iEvent = iEvent
  rc    = SHiP.sTree.GetEvent(iEvent) 
  SHiP.digitize() 

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -61,8 +61,7 @@ fgeo.FAIRGeom
 config.debug = options.debug
 config.ShipGeo = ShipGeo
 
-iEvent = 0
-config.iEvent = iEvent
+config.iEvent = 0
 
 # import reco tasks
 import MufluxDigi
@@ -70,14 +69,14 @@ SHiP = MufluxDigi.MufluxDigi(outFile)
 
 nEvents   = min(SHiP.sTree.GetEntries(),int(options.nEvents))
 # main loop
-for iEvent in range(firstEvent, nEvents):
- if iEvent % 50000 == 0 or config.debug:
-     print('event ', iEvent, nEvents - firstEvent)
- SHiP.iEvent = iEvent
- rc    = SHiP.sTree.GetEvent(iEvent) 
- SHiP.digitize() 
+for config.iEvent in range(firstEvent, nEvents):
+    if config.iEvent % 50000 == 0 or config.debug:
+        print('event ', config.iEvent, nEvents - firstEvent)
+    SHiP.iEvent = config.iEvent
+    rc = SHiP.sTree.GetEvent(config.iEvent)
+    SHiP.digitize()
  # memory monitoring
- # mem_monitor() 
- 
+ # mem_monitor()
+
 # end loop over events
 SHiP.finish()

--- a/python/MufluxDigi.py
+++ b/python/MufluxDigi.py
@@ -3,6 +3,7 @@ from __future__ import division
 from builtins import range
 import os
 import ROOT
+import config
 import shipunit as u
 from array import array
 
@@ -74,9 +75,9 @@ class MufluxDigi:
         ROOT.gRandom.SetSeed()
         self.PDG = ROOT.TDatabasePDG.Instance()
         # for the digitizing and reconstruction step
-        self.v_drift       = ShipGeo['MufluxSpectrometer']['v_drift']
-        self.sigma_spatial = ShipGeo['MufluxSpectrometer']['sigma_spatial']
-        self.viewangle     = ShipGeo['MufluxSpectrometer']['ViewvAngle']
+        self.v_drift       = config.ShipGeo['MufluxSpectrometer']['v_drift']
+        self.sigma_spatial = config.ShipGeo['MufluxSpectrometer']['sigma_spatial']
+        self.viewangle     = config.ShipGeo['MufluxSpectrometer']['ViewvAngle']
 
         self.gMan  = ROOT.gGeoManager
 

--- a/python/MufluxDigi.py
+++ b/python/MufluxDigi.py
@@ -3,7 +3,7 @@ from __future__ import division
 from builtins import range
 import os
 import ROOT
-import config
+import global_variables
 import shipunit as u
 from array import array
 
@@ -75,9 +75,9 @@ class MufluxDigi:
         ROOT.gRandom.SetSeed()
         self.PDG = ROOT.TDatabasePDG.Instance()
         # for the digitizing and reconstruction step
-        self.v_drift       = config.ShipGeo['MufluxSpectrometer']['v_drift']
-        self.sigma_spatial = config.ShipGeo['MufluxSpectrometer']['sigma_spatial']
-        self.viewangle     = config.ShipGeo['MufluxSpectrometer']['ViewvAngle']
+        self.v_drift       = global_variables.ShipGeo['MufluxSpectrometer']['v_drift']
+        self.sigma_spatial = global_variables.ShipGeo['MufluxSpectrometer']['sigma_spatial']
+        self.viewangle     = global_variables.ShipGeo['MufluxSpectrometer']['ViewvAngle']
 
         self.gMan  = ROOT.gGeoManager
 

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -1195,11 +1195,11 @@ class MufluxDigiReco:
 
         # hit smearing
         if self.sTree.GetBranch("MufluxSpectrometerPoint"):
-            if withT0:
+            if config.withT0:
                 self.SmearedHits = self.withT0Estimate()
                 self.TaggerHits = self.muonTaggerHits_mc()
             else:
-                self.SmearedHits = self.smearHits(withNoStrawSmearing)
+                self.SmearedHits = self.smearHits(config.withNoStrawSmearing)
                 self.TaggerHits = self.muonTaggerHits_mc()
         elif self.sTree.GetBranch("Digi_MufluxSpectrometerHits"):
             self.SmearedHits = self.smearHits_realData()
@@ -1342,7 +1342,7 @@ class MufluxDigiReco:
             # approximate covariance
             covM = ROOT.TMatrixDSym(6)
             resolution = self.sigma_spatial
-            if withT0:
+            if config.withT0:
                 resolution = resolution*1.4 # worse resolution due to t0 estimate
             for i in range(3):
                 covM[i][i] = resolution*resolution
@@ -1395,7 +1395,7 @@ class MufluxDigiReco:
             # approximate covariance
             covM = ROOT.TMatrixDSym(6)
             resolution = self.sigma_spatial
-            if withT0:
+            if config.withT0:
                 resolution = resolution*1.4 # worse resolution due to t0 estimate
             for i in range(3):
                 covM[i][i] = resolution*resolution
@@ -1446,7 +1446,7 @@ class MufluxDigiReco:
             # approximate covariance
             covM = ROOT.TMatrixDSym(6)
             resolution = self.sigma_spatial
-            if withT0:
+            if config.withT0:
                 resolution = resolution*1.4 # worse resolution due to t0 estimate
             for i in range(3):
                 covM[i][i] = resolution*resolution

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -132,7 +132,7 @@ class MufluxDigiReco:
         self.fitter      = ROOT.genfit.DAF()
         self.fitter.setMaxIterations(20)
 
-        if debug:
+        if config.debug:
 
             # self.fitter.setDebugLvl(1) # produces lot of printout
             output_dir = 'pics/'
@@ -1474,7 +1474,7 @@ class MufluxDigiReco:
                 theTrack.insertPoint(tp)  # add point to Track
             trackCandidates_noT4.append([theTrack,atrack])
 
-        if debug:
+        if config.debug:
 
             z_hits_y = []
             x_hits_y = []
@@ -1995,11 +1995,11 @@ class MufluxDigiReco:
 
             # make track persistent
             nTrack   = self.fGenFitArray.GetEntries()
-            if not debug:
+            if not config.debug:
                 theTrack.prune("CFL")  #  http://sourceforge.net/p/genfit/code/HEAD/tree/trunk/core/include/Track.h#l280
             self.fGenFitArray[nTrack] = theTrack
             self.fitTrack2MC.push_back(atrack)
-            if debug:
+            if config.debug:
                 print('save track',theTrack,chi2,nM,fitStatus.isFitConverged())
 
         self.fitTracks.Fill()

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from builtins import range
-import config
-from config import h
+import global_variables
+from global_variables import h
 import os
 import ROOT
 import MufluxPatRec
@@ -97,7 +97,7 @@ class MufluxDigiReco:
          self.header  = ROOT.FairEventHeader()
          self.eventHeader  = self.sTree.Branch("ShipEventHeader",self.header,32000,-1)
          self.fitTrack2MC  = ROOT.std.vector('int')()
-         self.mcLink = self.sTree.Branch("fitTrack2MC" + config.realPR, self.fitTrack2MC, 32000, -1)
+         self.mcLink = self.sTree.Branch("fitTrack2MC" + global_variables.realPR, self.fitTrack2MC, 32000, -1)
          self.digiMufluxSpectrometer    = ROOT.TClonesArray("MufluxSpectrometerHit")
          self.digiMufluxSpectrometerBranch   = self.sTree.Branch("Digi_MufluxSpectrometerHits",self.digiMufluxSpectrometer,32000,-1)
         #muon taggger
@@ -110,13 +110,13 @@ class MufluxDigiReco:
         # fitted tracks
         self.fGenFitArray = ROOT.TClonesArray("genfit::Track")
         self.fGenFitArray.BypassStreamer(ROOT.kFALSE)
-        self.fitTracks = self.sTree.Branch("FitTracks" + config.realPR, self.fGenFitArray, 32000, -1)
+        self.fitTracks = self.sTree.Branch("FitTracks" + global_variables.realPR, self.fGenFitArray, 32000, -1)
 
         self.PDG = ROOT.TDatabasePDG.Instance()
         # for the digitizing and reconstruction step
-        self.v_drift       = config.modules["MufluxSpectrometer"].TubeVdrift()
-        self.sigma_spatial = config.modules["MufluxSpectrometer"].TubeSigmaSpatial()
-        self.viewangle     = config.modules["MufluxSpectrometer"].ViewAngle()
+        self.v_drift       = global_variables.modules["MufluxSpectrometer"].TubeVdrift()
+        self.sigma_spatial = global_variables.modules["MufluxSpectrometer"].TubeSigmaSpatial()
+        self.viewangle     = global_variables.modules["MufluxSpectrometer"].ViewAngle()
 
         # access ShipTree
         self.sTree.GetEvent(0)
@@ -133,7 +133,7 @@ class MufluxDigiReco:
         self.fitter      = ROOT.genfit.DAF()
         self.fitter.setMaxIterations(20)
 
-        if config.debug:
+        if global_variables.debug:
 
             # self.fitter.setDebugLvl(1) # produces lot of printout
             output_dir = 'pics/'
@@ -329,7 +329,7 @@ class MufluxDigiReco:
         t0 = 0.
         key = -1
         SmearedHits = []
-        v_drift = config.modules["MufluxSpectrometer"].TubeVdrift()
+        v_drift = global_variables.modules["MufluxSpectrometer"].TubeVdrift()
         z1 = stop.z()
         for aDigi in self.digiMufluxSpectrometer:
             key+=1
@@ -362,7 +362,7 @@ class MufluxDigiReco:
             detID = ahit.GetDetectorID()
             top = ROOT.TVector3()
             bot = ROOT.TVector3()
-            config.modules["MufluxSpectrometer"].TubeEndPoints(detID, bot, top)
+            global_variables.modules["MufluxSpectrometer"].TubeEndPoints(detID, bot, top)
             # MufluxSpectrometerHit::MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop)
             #distance to wire, and smear it.
             dw  = ahit.dist2Wire()
@@ -432,7 +432,7 @@ class MufluxDigiReco:
         # Taken from charmdet/drifttubeMonitoring.py
         # rt relation, drift time to distance, drift time?
         tMinAndTmax = {1:[587,1860],2:[587,1860],3:[610,2300],4:[610,2100]}
-        R = config.ShipGeo.MufluxSpectrometer.InnerTubeDiameter/2. #  = 3.63*u.cm
+        R = global_variables.ShipGeo.MufluxSpectrometer.InnerTubeDiameter/2. #  = 3.63*u.cm
         # parabola
         if function == 'parabola' or 'rtTDC'+str(s)+'000_x' not in h:
             p1p2 = {1:[688.,7.01],2:[688.,7.01],3:[923.,4.41],4:[819.,0.995]}
@@ -458,7 +458,7 @@ class MufluxDigiReco:
             top = ROOT.TVector3()
             bot = ROOT.TVector3()
             bot, top = self.correctAlignment(ahit)
-            # config.modules["MufluxSpectrometer"].TubeEndPoints(detID, bot, top)
+            # global_variables.modules["MufluxSpectrometer"].TubeEndPoints(detID, bot, top)
             # ahit.MufluxSpectrometerEndPoints(bot,top)
             # MufluxSpectrometerHit::MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop)
             # distance to wire.
@@ -1196,11 +1196,11 @@ class MufluxDigiReco:
 
         # hit smearing
         if self.sTree.GetBranch("MufluxSpectrometerPoint"):
-            if config.withT0:
+            if global_variables.withT0:
                 self.SmearedHits = self.withT0Estimate()
                 self.TaggerHits = self.muonTaggerHits_mc()
             else:
-                self.SmearedHits = self.smearHits(config.withNoStrawSmearing)
+                self.SmearedHits = self.smearHits(global_variables.withNoStrawSmearing)
                 self.TaggerHits = self.muonTaggerHits_mc()
         elif self.sTree.GetBranch("Digi_MufluxSpectrometerHits"):
             self.SmearedHits = self.smearHits_realData()
@@ -1209,7 +1209,7 @@ class MufluxDigiReco:
             print('No branches "MufluxSpectrometer" or "Digi_MufluxSpectrometerHits".')
             return nTrack
 
-        if config.realPR:
+        if global_variables.realPR:
 
             # Do real PatRec
             track_hits = MufluxPatRec.execute(self.SmearedHits, self.TaggerHits, withNTaggerHits, withDist2Wire)
@@ -1343,7 +1343,7 @@ class MufluxDigiReco:
             # approximate covariance
             covM = ROOT.TMatrixDSym(6)
             resolution = self.sigma_spatial
-            if config.withT0:
+            if global_variables.withT0:
                 resolution = resolution*1.4 # worse resolution due to t0 estimate
             for i in range(3):
                 covM[i][i] = resolution*resolution
@@ -1396,7 +1396,7 @@ class MufluxDigiReco:
             # approximate covariance
             covM = ROOT.TMatrixDSym(6)
             resolution = self.sigma_spatial
-            if config.withT0:
+            if global_variables.withT0:
                 resolution = resolution*1.4 # worse resolution due to t0 estimate
             for i in range(3):
                 covM[i][i] = resolution*resolution
@@ -1447,7 +1447,7 @@ class MufluxDigiReco:
             # approximate covariance
             covM = ROOT.TMatrixDSym(6)
             resolution = self.sigma_spatial
-            if config.withT0:
+            if global_variables.withT0:
                 resolution = resolution*1.4 # worse resolution due to t0 estimate
             for i in range(3):
                 covM[i][i] = resolution*resolution
@@ -1475,7 +1475,7 @@ class MufluxDigiReco:
                 theTrack.insertPoint(tp)  # add point to Track
             trackCandidates_noT4.append([theTrack,atrack])
 
-        if config.debug:
+        if global_variables.debug:
 
             z_hits_y = []
             x_hits_y = []
@@ -1996,11 +1996,11 @@ class MufluxDigiReco:
 
             # make track persistent
             nTrack   = self.fGenFitArray.GetEntries()
-            if not config.debug:
+            if not global_variables.debug:
                 theTrack.prune("CFL")  #  http://sourceforge.net/p/genfit/code/HEAD/tree/trunk/core/include/Track.h#l280
             self.fGenFitArray[nTrack] = theTrack
             self.fitTrack2MC.push_back(atrack)
-            if config.debug:
+            if global_variables.debug:
                 print('save track',theTrack,chi2,nM,fitStatus.isFitConverged())
 
         self.fitTracks.Fill()
@@ -2013,5 +2013,5 @@ class MufluxDigiReco:
         self.sTree.Write()
         ut.errorSummary()
         ut.writeHists(h,"recohists.root")
-        # if config.realPR:
+        # if global_variables.realPR:
         #     ut.writeHists(shipPatRec.h,"recohists_patrec.root")

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from builtins import range
+import config
 import os
 import ROOT
 import MufluxPatRec
@@ -95,7 +96,7 @@ class MufluxDigiReco:
          self.header  = ROOT.FairEventHeader()
          self.eventHeader  = self.sTree.Branch("ShipEventHeader",self.header,32000,-1)
          self.fitTrack2MC  = ROOT.std.vector('int')()
-         self.mcLink      = self.sTree.Branch("fitTrack2MC"+realPR,self.fitTrack2MC,32000,-1)
+         self.mcLink = self.sTree.Branch("fitTrack2MC" + config.realPR, self.fitTrack2MC, 32000, -1)
          self.digiMufluxSpectrometer    = ROOT.TClonesArray("MufluxSpectrometerHit")
          self.digiMufluxSpectrometerBranch   = self.sTree.Branch("Digi_MufluxSpectrometerHits",self.digiMufluxSpectrometer,32000,-1)
         #muon taggger
@@ -108,7 +109,7 @@ class MufluxDigiReco:
         # fitted tracks
         self.fGenFitArray = ROOT.TClonesArray("genfit::Track")
         self.fGenFitArray.BypassStreamer(ROOT.kFALSE)
-        self.fitTracks   = self.sTree.Branch("FitTracks"+realPR,  self.fGenFitArray,32000,-1)
+        self.fitTracks = self.sTree.Branch("FitTracks" + config.realPR, self.fGenFitArray, 32000, -1)
 
         self.PDG = ROOT.TDatabasePDG.Instance()
         # for the digitizing and reconstruction step
@@ -1207,7 +1208,7 @@ class MufluxDigiReco:
             print('No branches "MufluxSpectrometer" or "Digi_MufluxSpectrometerHits".')
             return nTrack
 
-        if realPR:
+        if config.realPR:
 
             # Do real PatRec
             track_hits = MufluxPatRec.execute(self.SmearedHits, self.TaggerHits, withNTaggerHits, withDist2Wire)
@@ -2011,4 +2012,5 @@ class MufluxDigiReco:
         self.sTree.Write()
         ut.errorSummary()
         ut.writeHists(h,"recohists.root")
-        # if realPR: ut.writeHists(shipPatRec.h,"recohists_patrec.root")
+        # if config.realPR:
+        #     ut.writeHists(shipPatRec.h,"recohists_patrec.root")

--- a/python/MufluxDigiReco.py
+++ b/python/MufluxDigiReco.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from builtins import range
 import config
+from config import h
 import os
 import ROOT
 import MufluxPatRec
@@ -113,9 +114,9 @@ class MufluxDigiReco:
 
         self.PDG = ROOT.TDatabasePDG.Instance()
         # for the digitizing and reconstruction step
-        self.v_drift       = modules["MufluxSpectrometer"].TubeVdrift()
-        self.sigma_spatial = modules["MufluxSpectrometer"].TubeSigmaSpatial()
-        self.viewangle     = modules["MufluxSpectrometer"].ViewAngle()
+        self.v_drift       = config.modules["MufluxSpectrometer"].TubeVdrift()
+        self.sigma_spatial = config.modules["MufluxSpectrometer"].TubeSigmaSpatial()
+        self.viewangle     = config.modules["MufluxSpectrometer"].ViewAngle()
 
         # access ShipTree
         self.sTree.GetEvent(0)
@@ -328,7 +329,7 @@ class MufluxDigiReco:
         t0 = 0.
         key = -1
         SmearedHits = []
-        v_drift = modules["MufluxSpectrometer"].TubeVdrift()
+        v_drift = config.modules["MufluxSpectrometer"].TubeVdrift()
         z1 = stop.z()
         for aDigi in self.digiMufluxSpectrometer:
             key+=1
@@ -361,7 +362,7 @@ class MufluxDigiReco:
             detID = ahit.GetDetectorID()
             top = ROOT.TVector3()
             bot = ROOT.TVector3()
-            modules["MufluxSpectrometer"].TubeEndPoints(detID,bot,top)
+            config.modules["MufluxSpectrometer"].TubeEndPoints(detID, bot, top)
             # MufluxSpectrometerHit::MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop)
             #distance to wire, and smear it.
             dw  = ahit.dist2Wire()
@@ -431,7 +432,7 @@ class MufluxDigiReco:
         # Taken from charmdet/drifttubeMonitoring.py
         # rt relation, drift time to distance, drift time?
         tMinAndTmax = {1:[587,1860],2:[587,1860],3:[610,2300],4:[610,2100]}
-        R = ShipGeo.MufluxSpectrometer.InnerTubeDiameter/2. #  = 3.63*u.cm
+        R = config.ShipGeo.MufluxSpectrometer.InnerTubeDiameter/2. #  = 3.63*u.cm
         # parabola
         if function == 'parabola' or 'rtTDC'+str(s)+'000_x' not in h:
             p1p2 = {1:[688.,7.01],2:[688.,7.01],3:[923.,4.41],4:[819.,0.995]}
@@ -457,7 +458,7 @@ class MufluxDigiReco:
             top = ROOT.TVector3()
             bot = ROOT.TVector3()
             bot, top = self.correctAlignment(ahit)
-            # modules["MufluxSpectrometer"].TubeEndPoints(detID,bot,top)
+            # config.modules["MufluxSpectrometer"].TubeEndPoints(detID, bot, top)
             # ahit.MufluxSpectrometerEndPoints(bot,top)
             # MufluxSpectrometerHit::MufluxSpectrometerEndPoints(TVector3 &vbot, TVector3 &vtop)
             # distance to wire.

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -780,9 +780,9 @@ class ShipDigiReco:
      # Note: top.z()==bot.z() unless misaligned, so only add key 'z' to smearedHit
      if abs(stop.y()) == abs(start.y()):
        config.h['disty'].Fill(smear)
-     else if abs(stop.y()) > abs(start.y()):
+     elif abs(stop.y()) > abs(start.y()):
        config.h['distu'].Fill(smear)
-     else if abs(stop.y()) < abs(start.y()):
+     elif abs(stop.y()) < abs(start.y()):
        config.h['distv'].Fill(smear)
 
   return SmearedHits

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -147,7 +147,7 @@ class ShipDigiReco:
 # Match reco to MC
    ecalMatch=ROOT.ecalMatch('ecalMatch',0)
    self.caloTasks.append(ecalMatch)
-   if EcalDebugDraw:
+   if config.EcalDebugDraw:
  # ecal drawer: Draws calorimeter structure, incoming particles, clusters, maximums
     ecalDrawer=ROOT.ecalDrawer("clusterFinder",10)
     self.caloTasks.append(ecalDrawer)
@@ -174,7 +174,8 @@ class ShipDigiReco:
    self.ecalReconstructed = ecalReco.InitPython(self.sTree.EcalClusters, self.ecalStructure, self.ecalCalib)
    self.EcalReconstructed = self.sTree.Branch("EcalReconstructed",self.ecalReconstructed,32000,-1)
    ecalMatch.InitPython(self.ecalStructure, self.ecalReconstructed, self.sTree.MCTrack)
-   if EcalDebugDraw: ecalDrawer.InitPython(self.sTree.MCTrack, self.sTree.EcalPoint, self.ecalStructure, self.ecalClusters)
+   if config.EcalDebugDraw:
+     ecalDrawer.InitPython(self.sTree.MCTrack, self.sTree.EcalPoint, self.ecalStructure, self.ecalClusters)
   else:
    ecalClusters      = ROOT.TClonesArray("ecalCluster") 
    ecalReconstructed = ROOT.TClonesArray("ecalReconstructed") 

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
 from __future__ import division
 import os,ROOT,shipVertex,shipDet_conf
-if realPR == "Prev": import shipPatRec_prev as shipPatRec # The previous version of the pattern recognition
+import config
+if config.realPR == "Prev":
+  import shipPatRec_prev as shipPatRec # The previous version of the pattern recognition
 else: import shipPatRec
 import shipunit as u
 import rootUtils as ut
@@ -798,9 +800,9 @@ class ShipDigiReco:
   nTrack = -1
   trackCandidates = []
   
-  if realPR:
+  if config.realPR:
     # Do real PatRec
-    track_hits = shipPatRec.execute(self.SmearedHits, ShipGeo, realPR)
+    track_hits = shipPatRec.execute(self.SmearedHits, ShipGeo, config.realPR)
     # Create hitPosLists for track fit
     for i_track in track_hits.keys():
       atrack = track_hits[i_track]
@@ -1025,4 +1027,5 @@ class ShipDigiReco:
   self.sTree.Write()
   ut.errorSummary()
   ut.writeHists(h,"recohists.root")
-  if realPR: shipPatRec.finalize()
+  if config.realPR:
+    shipPatRec.finalize()

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
 from __future__ import division
 import os,ROOT,shipVertex,shipDet_conf
-import config
-if config.realPR == "Prev":
+import global_variables
+if global_variables.realPR == "Prev":
   import shipPatRec_prev as shipPatRec # The previous version of the pattern recognition
 else: import shipPatRec
 import shipunit as u
@@ -92,8 +92,8 @@ class ShipDigiReco:
   self.digiMuon    = ROOT.TClonesArray("muonHit")
   self.digiMuonBranch=self.sTree.Branch("Digi_muonHits",self.digiMuon,32000,-1)
 # for the digitizing step
-  self.v_drift = config.modules["Strawtubes"].StrawVdrift()
-  self.sigma_spatial = config.modules["Strawtubes"].StrawSigmaSpatial()
+  self.v_drift = global_variables.modules["Strawtubes"].StrawVdrift()
+  self.sigma_spatial = global_variables.modules["Strawtubes"].StrawSigmaSpatial()
 # optional if present, splitcalCluster
   if self.sTree.GetBranch("splitcalPoint"):
    self.digiSplitcal = ROOT.TClonesArray("splitcalHit") 
@@ -105,10 +105,10 @@ class ShipDigiReco:
   self.caloTasks = []  
   if self.sTree.GetBranch("EcalPoint") and not self.sTree.GetBranch("splitcalPoint"):
 # Creates. exports and fills calorimeter structure
-   dflag = 10 if config.debug else 0
-   ecalGeo = config.ecalGeoFile + 'z' + str(config.ShipGeo.ecal.z) + ".geo"
+   dflag = 10 if global_variables.debug else 0
+   ecalGeo = global_variables.ecalGeoFile + 'z' + str(global_variables.ShipGeo.ecal.z) + ".geo"
    if not ecalGeo in os.listdir(os.environ["FAIRSHIP"]+"/geometry"):
-     shipDet_conf.makeEcalGeoFile(config.ShipGeo.ecal.z, config.ShipGeo.ecal.File)
+     shipDet_conf.makeEcalGeoFile(global_variables.ShipGeo.ecal.z, global_variables.ShipGeo.ecal.File)
    ecalFiller=ROOT.ecalStructureFiller("ecalFiller", dflag,ecalGeo)
    ecalFiller.SetUseMCPoints(ROOT.kTRUE)
    ecalFiller.StoreTrackInformation()
@@ -148,7 +148,7 @@ class ShipDigiReco:
 # Match reco to MC
    ecalMatch=ROOT.ecalMatch('ecalMatch',0)
    self.caloTasks.append(ecalMatch)
-   if config.EcalDebugDraw:
+   if global_variables.EcalDebugDraw:
  # ecal drawer: Draws calorimeter structure, incoming particles, clusters, maximums
     ecalDrawer=ROOT.ecalDrawer("clusterFinder",10)
     self.caloTasks.append(ecalDrawer)
@@ -156,7 +156,7 @@ class ShipDigiReco:
    import shipPid
    self.caloTasks.append(shipPid.Task(self))
 # prepare vertexing
-  self.Vertexing = shipVertex.Task(config.h, self.sTree)
+  self.Vertexing = shipVertex.Task(global_variables.h, self.sTree)
 # setup random number generator 
   self.random = ROOT.TRandom()
   ROOT.gRandom.SetSeed(13)
@@ -175,7 +175,7 @@ class ShipDigiReco:
    self.ecalReconstructed = ecalReco.InitPython(self.sTree.EcalClusters, self.ecalStructure, self.ecalCalib)
    self.EcalReconstructed = self.sTree.Branch("EcalReconstructed",self.ecalReconstructed,32000,-1)
    ecalMatch.InitPython(self.ecalStructure, self.ecalReconstructed, self.sTree.MCTrack)
-   if config.EcalDebugDraw:
+   if global_variables.EcalDebugDraw:
      ecalDrawer.InitPython(self.sTree.MCTrack, self.sTree.EcalPoint, self.ecalStructure, self.ecalClusters)
   else:
    ecalClusters      = ROOT.TClonesArray("ecalCluster") 
@@ -188,7 +188,7 @@ class ShipDigiReco:
   self.geoMat =  ROOT.genfit.TGeoMaterialInterface()
 #
   self.bfield = ROOT.genfit.FairShipFields()
-  self.bfield.setField(config.fieldMaker.getGlobalField())
+  self.bfield.setField(global_variables.fieldMaker.getGlobalField())
   self.fM = ROOT.genfit.FieldManager.getInstance()
   self.fM.init(self.bfield)
   ROOT.genfit.MaterialEffects.getInstance().init(self.geoMat)
@@ -198,7 +198,7 @@ class ShipDigiReco:
   #fitter          = ROOT.genfit.KalmanFitterRefTrack()
   self.fitter      = ROOT.genfit.DAF()
   self.fitter.setMaxIterations(50)
-  if config.debug:
+  if global_variables.debug:
     self.fitter.setDebugLvl(1) # produces lot of printout
   #set to True if "real" pattern recognition is required also
 
@@ -217,7 +217,7 @@ class ShipDigiReco:
    if len(self.caloTasks)>0:
     self.EcalClusters.Fill()
     self.EcalReconstructed.Fill()
-   if config.vertexing:
+   if global_variables.vertexing:
 # now go for 2-track combinations
     self.Vertexing.execute()
 
@@ -733,8 +733,8 @@ class ShipDigiReco:
   t0 = 0.
   key = -1
   SmearedHits = []
-  v_drift = config.modules["Strawtubes"].StrawVdrift()
-  config.modules["Strawtubes"].StrawEndPoints(10002001, start, stop)
+  v_drift = global_variables.modules["Strawtubes"].StrawVdrift()
+  global_variables.modules["Strawtubes"].StrawEndPoints(10002001, start, stop)
   z1 = stop.z()
   for aDigi in self.digiStraw:
     key+=1
@@ -743,7 +743,7 @@ class ShipDigiReco:
 # don't use hits from straw veto
     station = int(detID//10000000)
     if station > 4 : continue
-    config.modules["Strawtubes"].StrawEndPoints(detID, start, stop)
+    global_variables.modules["Strawtubes"].StrawEndPoints(detID, start, stop)
     delt1 = (start[2]-z1)/u.speedOfLight
     t0+=aDigi.GetDigi()-delt1
     SmearedHits.append( {'digiHit':key,'xtop':stop.x(),'ytop':stop.y(),'z':stop.z(),'xbot':start.x(),'ybot':start.y(),'dist':aDigi.GetDigi(), 'detID':detID} )
@@ -758,8 +758,8 @@ class ShipDigiReco:
  # smear strawtube points
   SmearedHits = []
   key = -1
-  v_drift = config.modules["Strawtubes"].StrawVdrift()
-  config.modules["Strawtubes"].StrawEndPoints(10002001, start, stop)
+  v_drift = global_variables.modules["Strawtubes"].StrawVdrift()
+  global_variables.modules["Strawtubes"].StrawEndPoints(10002001, start, stop)
   z1 = stop.z()
   for aDigi in self.digiStraw:
      key+=1
@@ -768,7 +768,7 @@ class ShipDigiReco:
 # don't use hits from straw veto
      station = int(detID//10000000)
      if station > 4 : continue
-     config.modules["Strawtubes"].StrawEndPoints(detID, start, stop)
+     global_variables.modules["Strawtubes"].StrawEndPoints(detID, start, stop)
    #distance to wire
      delt1 = (start[2]-z1)/u.speedOfLight
      p=self.sTree.strawtubesPoint[key]
@@ -779,11 +779,11 @@ class ShipDigiReco:
      SmearedHits.append( {'digiHit':key,'xtop':stop.x(),'ytop':stop.y(),'z':stop.z(),'xbot':start.x(),'ybot':start.y(),'dist':smear, 'detID':detID} )
      # Note: top.z()==bot.z() unless misaligned, so only add key 'z' to smearedHit
      if abs(stop.y()) == abs(start.y()):
-       config.h['disty'].Fill(smear)
+       global_variables.h['disty'].Fill(smear)
      elif abs(stop.y()) > abs(start.y()):
-       config.h['distu'].Fill(smear)
+       global_variables.h['distu'].Fill(smear)
      elif abs(stop.y()) < abs(start.y()):
-       config.h['distv'].Fill(smear)
+       global_variables.h['distv'].Fill(smear)
 
   return SmearedHits
   
@@ -797,18 +797,18 @@ class ShipDigiReco:
   self.fitTrack2MC.clear()
 
 #   
-  if config.withT0:
+  if global_variables.withT0:
     self.SmearedHits = self.withT0Estimate()
   # old procedure, not including estimation of t0 
   else:
-    self.SmearedHits = self.smearHits(config.withNoStrawSmearing)
+    self.SmearedHits = self.smearHits(global_variables.withNoStrawSmearing)
 
   nTrack = -1
   trackCandidates = []
   
-  if config.realPR:
+  if global_variables.realPR:
     # Do real PatRec
-    track_hits = shipPatRec.execute(self.SmearedHits, config.ShipGeo, config.realPR)
+    track_hits = shipPatRec.execute(self.SmearedHits, global_variables.ShipGeo, global_variables.realPR)
     # Create hitPosLists for track fit
     for i_track in track_hits.keys():
       atrack = track_hits[i_track]
@@ -865,7 +865,7 @@ class ShipDigiReco:
     nM = meas.size()
     if nM < 25 : continue                          # not enough hits to make a good trackfit 
     if len(stationCrossed[atrack]) < 3 : continue  # not enough stations crossed to make a good trackfit 
-    if config.debug:
+    if global_variables.debug:
        mctrack = self.sTree.MCTrack[atrack]
     # charge = self.PDG.GetParticle(pdg).Charge()/(3.)
     posM = ROOT.TVector3(0, 0, 0)
@@ -873,7 +873,7 @@ class ShipDigiReco:
 # approximate covariance
     covM = ROOT.TMatrixDSym(6)
     resolution = self.sigma_spatial
-    if config.withT0:
+    if global_variables.withT0:
       resolution *= 1.4 # worse resolution due to t0 estimate
     for  i in range(3):   covM[i][i] = resolution*resolution
     covM[0][0]=resolution*resolution*100.
@@ -894,7 +894,7 @@ class ShipDigiReco:
       tp = ROOT.genfit.TrackPoint(theTrack) # note how the point is told which track it belongs to 
       measurement = ROOT.genfit.WireMeasurement(m,hitCov,1,6,tp) # the measurement is told which trackpoint it belongs to
       # print measurement.getMaxDistance()
-      measurement.setMaxDistance(config.ShipGeo.strawtubes.InnerStrawDiameter / 2.)
+      measurement.setMaxDistance(global_variables.ShipGeo.strawtubes.InnerStrawDiameter / 2.)
       # measurement.setLeftRightResolution(-1)
       tp.addRawMeasurement(measurement) # package measurement in the TrackPoint                                          
       theTrack.insertPoint(tp)  # add point to Track
@@ -911,14 +911,14 @@ class ShipDigiReco:
 # do the fit
     try:  self.fitter.processTrack(theTrack) # processTrackWithRep(theTrack,rep,True)
     except: 
-      if config.debug:
+      if global_variables.debug:
         print("genfit failed to fit track")
       error = "genfit failed to fit track"
       ut.reportError(error)
       continue
 #check
     if not theTrack.checkConsistency():
-     if config.debug:
+     if global_variables.debug:
        print('Problem with track after fit, not consistent', atrack, theTrack)
      error = "Problem with track after fit, not consistent"
      ut.reportError(error)
@@ -933,14 +933,14 @@ class ShipDigiReco:
     fitStatus   = theTrack.getFitStatus()
     nmeas = fitStatus.getNdf()   
     chi2        = fitStatus.getChi2()/nmeas   
-    config.h['chi2'].Fill(chi2)
+    global_variables.h['chi2'].Fill(chi2)
 # make track persistent
     nTrack   = self.fGenFitArray.GetEntries()
-    if not config.debug:
+    if not global_variables.debug:
       theTrack.prune("CFL")  # http://sourceforge.net/p/genfit/code/HEAD/tree/trunk/core/include/Track.h#l280
     self.fGenFitArray[nTrack] = theTrack
     # self.fitTrack2MC.push_back(atrack)
-    if config.debug:
+    if global_variables.debug:
      print('save track',theTrack,chi2,nmeas,fitStatus.isFitConverged())
     # Save MC link
     track_ids = []
@@ -960,7 +960,7 @@ class ShipDigiReco:
   self.fitTracks.Fill()
   self.mcLink.Fill()
 # debug 
-  if config.debug:
+  if global_variables.debug:
    print('save tracklets:') 
    for x in self.sTree.Tracklets:
     print(x.getType(),x.getList().size())
@@ -994,7 +994,7 @@ class ShipDigiReco:
      except:
       error =  "shipDigiReco::findVetoHitOnTrack extrapolation did not worked"
       ut.reportError(error)
-      if config.debug:
+      if global_variables.debug:
         print(error)
       continue
      dist = (rep.getPos(state) - vetoHitPos).Mag()
@@ -1037,6 +1037,6 @@ class ShipDigiReco:
   print('finished writing tree')
   self.sTree.Write()
   ut.errorSummary()
-  ut.writeHists(config.h,"recohists.root")
-  if config.realPR:
+  ut.writeHists(global_variables.h,"recohists.root")
+  if global_variables.realPR:
     shipPatRec.finalize()

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -793,9 +793,11 @@ class ShipDigiReco:
   self.fitTrack2MC.clear()
 
 #   
-  if withT0:  self.SmearedHits = self.withT0Estimate()
+  if config.withT0:
+    self.SmearedHits = self.withT0Estimate()
   # old procedure, not including estimation of t0 
-  else:       self.SmearedHits = self.smearHits(withNoStrawSmearing)
+  else:
+    self.SmearedHits = self.smearHits(config.withNoStrawSmearing)
 
   nTrack = -1
   trackCandidates = []
@@ -867,7 +869,8 @@ class ShipDigiReco:
 # approximate covariance
     covM = ROOT.TMatrixDSym(6)
     resolution = self.sigma_spatial
-    if withT0: resolution = resolution*1.4 # worse resolution due to t0 estimate
+    if config.withT0:
+      resolution *= 1.4 # worse resolution due to t0 estimate
     for  i in range(3):   covM[i][i] = resolution*resolution
     covM[0][0]=resolution*resolution*100.
     for  i in range(3,6): covM[i][i] = ROOT.TMath.Power(resolution / nM / ROOT.TMath.Sqrt(3), 2)

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -216,7 +216,7 @@ class ShipDigiReco:
    if len(self.caloTasks)>0:
     self.EcalClusters.Fill()
     self.EcalReconstructed.Fill()
-   if vertexing:
+   if config.vertexing:
 # now go for 2-track combinations
     self.Vertexing.execute()
 

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -106,7 +106,7 @@ class ShipDigiReco:
   if self.sTree.GetBranch("EcalPoint") and not self.sTree.GetBranch("splitcalPoint"):
 # Creates. exports and fills calorimeter structure
    dflag = 10 if config.debug else 0
-   ecalGeo = ecalGeoFile+'z'+str(ShipGeo.ecal.z)+".geo"
+   ecalGeo = config.ecalGeoFile + 'z' + str(ShipGeo.ecal.z) + ".geo"
    if not ecalGeo in os.listdir(os.environ["FAIRSHIP"]+"/geometry"): shipDet_conf.makeEcalGeoFile(ShipGeo.ecal.z,ShipGeo.ecal.File)
    ecalFiller=ROOT.ecalStructureFiller("ecalFiller", dflag,ecalGeo)
    ecalFiller.SetUseMCPoints(ROOT.kTRUE)

--- a/python/shipPatRec.py
+++ b/python/shipPatRec.py
@@ -3,12 +3,13 @@ from __future__ import division
 __author__ = 'Mikhail Hushchyn'
 
 import numpy as np
+import config
 
 # Globals
 ReconstructibleMCTracks = []
 theTracks = []
 
-r_scale = ShipGeo.strawtubes.InnerStrawDiameter / 1.975
+r_scale = config.ShipGeo.strawtubes.InnerStrawDiameter / 1.975
 
 def initialize(fgeo):
     pass

--- a/python/shipPatRec.py
+++ b/python/shipPatRec.py
@@ -3,13 +3,13 @@ from __future__ import division
 __author__ = 'Mikhail Hushchyn'
 
 import numpy as np
-import config
+import global_variables
 
 # Globals
 ReconstructibleMCTracks = []
 theTracks = []
 
-r_scale = config.ShipGeo.strawtubes.InnerStrawDiameter / 1.975
+r_scale = global_variables.ShipGeo.strawtubes.InnerStrawDiameter / 1.975
 
 def initialize(fgeo):
     pass

--- a/python/shipPatRec_prev.py
+++ b/python/shipPatRec_prev.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from builtins import range
 import ROOT, os
 import config
+from config import ShipGeo
 import shipunit  as u
 import math
 import copy

--- a/python/shipPatRec_prev.py
+++ b/python/shipPatRec_prev.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 from builtins import range
 import ROOT, os
+import config
 import shipunit  as u
 import math
 import copy
@@ -210,14 +211,15 @@ def initialize(fGeo):
      z34layerv2[i]=[Zpos_u]
 
    VetoStationZ = ShipGeo.vetoStation.z
-   if debug==1: print("VetoStation midpoint z=",VetoStationZ)
+   if config.debug:
+     print("VetoStation midpoint z=", VetoStationZ)
    VetoStationEndZ=VetoStationZ+(ShipGeo.strawtubes.DeltazView+ShipGeo.strawtubes.OuterStrawDiameter)/2
    for i in range(1,5):   
      if i==1: TStationz = ShipGeo.TrackStation1.z
      if i==2: TStationz = ShipGeo.TrackStation2.z  
      if i==3: TStationz = ShipGeo.TrackStation3.z  
      if i==4: TStationz = ShipGeo.TrackStation4.z 
-     if debug==1:
+     if config.debug:
        print("TrackStation",i," midpoint z=",TStationz) 
        for vnb in range(0,4):
          for pnb in range (0,2):
@@ -238,7 +240,8 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   rc = sTree.GetEvent(iEvent) 
   nMCTracks = sTree.MCTrack.GetEntriesFast()   
 
-  if debug==1: print("event nbr",iEvent,"has",nMCTracks,"tracks")
+  if config.debug:
+    print("event nbr", iEvent, "has", nMCTracks, "tracks")
   #1. MCTrackIDs: list of tracks decaying after the last tstation and originating before the first
   for i in reversed(range(nMCTracks)):
      atrack = sTree.MCTrack.At(i) 
@@ -271,7 +274,8 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
              if mothertrackZ < TStation1StartZ and mothertrackZ > VetoStationEndZ:
 	       if motherId not in MCTrackIDs:
 	           MCTrackIDs.append(motherId)
-  if debug==1: print("Tracks with origin in decay volume",MCTrackIDs)	 
+  if config.debug:
+    print("Tracks with origin in decay volume", MCTrackIDs)	 
   if len(MCTrackIDs)==0: return MCTrackIDs
     
   #2. hitsinTimeDet: list of tracks with hits in TimeDet	   
@@ -297,18 +301,21 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   for item in itemstoremove:
       MCTrackIDs.remove(item)	   	  	  
 
-  if debug==1: print("Tracks with hits in timedet",MCTrackIDs) 
+  if config.debug:
+    print("Tracks with hits in timedet", MCTrackIDs) 
   if len(MCTrackIDs)==0: return MCTrackIDs
   #4. Find straws that have multiple hits
   nHits = sTree.strawtubesPoint.GetEntriesFast()  
   hitstraws={}
   duplicatestrawhit=[]
-  if debug==1: print("Nbr of Rawhits=",nHits)
+  if config.debug:
+    print("Nbr of Rawhits=", nHits)
 
   for i in range(nHits):
     ahit = sTree.strawtubesPoint[i]
     if (str(ahit.GetDetectorID())[:1]=="5") : 
-       if debug==1: print("Hit in straw Veto detector. Rejecting.")
+       if config.debug:
+	 print("Hit in straw Veto detector. Rejecting.")
        continue
     strawname=str(ahit.GetDetectorID())
     
@@ -332,7 +339,8 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   trackoutsidestations=[]
   for i in range(nHits):
     if i in  duplicatestrawhit: 
-       if debug==1: print("Duplicate hit",i,"not reconstructible, rejecting.")
+       if config.debug:
+	 print("Duplicate hit", i, "not reconstructible, rejecting.")
        continue  
     ahit = sTree.strawtubesPoint[i] 
     #is hit inside acceptance? if not mark the track as bad   
@@ -341,7 +349,8 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
           trackoutsidestations.append(ahit.GetTrackID())
     if ahit.GetTrackID() not in MCTrackIDs:
        #hit on not reconstructible track
-       if debug==1: print("Hit not on reconstructible track. Rejecting.")
+       if config.debug:
+	 print("Hit not on reconstructible track. Rejecting.")
        continue	  
     #group hits per tracking station, key = trackid
     if str(ahit.GetDetectorID())[:1]=="1" :
@@ -397,7 +406,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   for item in itemstoremove:
       MCTrackIDs.remove(item)	
 
-  if debug==1: 
+  if config.debug: 
      print("tracks_with_hits_in_all_stations",tracks_with_hits_in_all_stations)
      print("Tracks with hits in all stations & inside acceptance ellipse",MCTrackIDs)   
   if len(MCTrackIDs)==0: return MCTrackIDs   
@@ -434,8 +443,10 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
         itemstoremove.append(item)
   for item in itemstoremove:
       MCTrackIDs.remove(item)	
-      if debug==1: print("After removing the non HNL track, MCTrackIDs",MCTrackIDs)
-  if debug==1: print("Tracks with HNL mother",MCTrackIDs) 
+      if config.debug:
+	print("After removing the non HNL track, MCTrackIDs", MCTrackIDs)
+  if config.debug:
+    print("Tracks with HNL mother", MCTrackIDs) 
   
   #8. check if the tracks are HNL children 
   mufound=0
@@ -451,15 +462,18 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
 	   nu_mufound+=1  
 	   itemstoremove.append(item)
       except:
-        if debug==1: print("Unknown particle with pdg code:",sTree.MCTrack.At(item).GetPdgCode())	
+        if config.debug:
+	  print("Unknown particle with pdg code:", sTree.MCTrack.At(item).GetPdgCode())	
     if reconstructiblerequired == 1 :
       if mufound!=1  and pifound!=1: 
-          if debug==1: print("No reconstructible pion or muon.") 
+          if config.debug:
+	    print("No reconstructible pion or muon.") 
 	  MCTrackIDs=[]   
     if reconstructiblerequired == 2 : 
       if threeprong == 1 :       
           if mufound!=2 or nu_mufound!=1 : 
-            if debug==1: print("No reconstructible mu-mu-nu.")  
+            if config.debug:
+	      print("No reconstructible mu-mu-nu.")  
 	    MCTrackIDs=[]
 	  else:
 	    #remove the neutrino from MCTrackIDs for the rest
@@ -467,12 +481,14 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
                MCTrackIDs.remove(item)	
       else:         
           if mufound!=1 or pifound!=1 : 
-            if debug==1: print("No reconstructible pion and muon.")  
+            if config.debug:
+	      print("No reconstructible pion and muon.")  
 	    MCTrackIDs=[]     
   if len(MCTrackIDs)>0:
      rc=h['nbrhits'].Fill(nHits)
      rc=h['nbrtracks'].Fill(nMCTracks)
-  if debug==1: print("Tracks with required HNL decay particles",MCTrackIDs) 	     
+  if config.debug:
+    print("Tracks with required HNL decay particles", MCTrackIDs) 	     
   return MCTrackIDs
 
 def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
@@ -509,7 +525,8 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
           
   #the following code prints some histograms related to the MC hits  
   strawname=''
-  if debug==1: print("nbr of hits=",nHits,"in event",iEvent)
+  if config.debug:
+    print("nbr of hits=", nHits, "in event", iEvent)
   station1hits={}
   station12xhits={}
   station12yhits={}
@@ -669,7 +686,8 @@ def Digitization(sTree,SmearedHits):
     StrawRawLink[j]=[sTree.strawtubesPoint[i]]
     j=j+1 
 
-  if debug==1: print("Nbr of digitized hits",j)  
+  if config.debug:
+    print("Nbr of digitized hits", j)  
   return StrawRaw,StrawRawLink
          
 def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTracks): 
@@ -698,11 +716,19 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
      #y hits for horizontal straws
      rawhits[j]=copy.deepcopy(((StrawRaw[item][1]+StrawRaw[item][4])/2,(StrawRaw[item][2]+StrawRaw[item][5])/2,StrawRaw[item][6]))
      if firsttwo==True: 
-       if debug==1: print("rawhits[",j,"]=",rawhits[j],"trackid",StrawRawLink[item][0].GetTrackID(),"strawname",StrawRawLink[item][0].GetDetectorID(),"true x",StrawRawLink[item][0].GetX(),"true y",StrawRawLink[item][0].GetY(),"true z",StrawRawLink[item][0].GetZ())
+       if config.debug:
+	 print(
+	     "rawhits[", j, "]=", rawhits[j],
+	     "trackid", StrawRawLink[item][0].GetTrackID(),
+	     "strawname", StrawRawLink[item][0].GetDetectorID(),
+	     "true x", StrawRawLink[item][0].GetX(),
+	     "true y", StrawRawLink[item][0].GetY(),
+	     "true z", StrawRawLink[item][0].GetZ()
+	     )
      j=j+1    
       
   sortedrawhits=OrderedDict(sorted(rawhits.items(),key=lambda t:t[1][1])) 
-  if debug==1: 
+  if config.debug: 
      print(" ")
      print("horizontal view (y) hits ordered by plane: plane nr, zlayer, hits")
 
@@ -725,7 +751,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	   a.append(float(sortedrawhits[item][0]))
 	else: 
 	   #This should never happen - duplicate hits are already removed at digitization
-	   if debug==1: print(" wire hit again",sortedrawhits[item],"strawname=", StrawRawLink[item][0].GetDetectorID())
+	   if config.debug:
+	     print(" wire hit again", sortedrawhits[item], "strawname=", StrawRawLink[item][0].GetDetectorID())
 	   a.append(float(sortedrawhits[item][0]))
 	   duplicates.append(float(zlayer[i][0]))  
     a.sort()   
@@ -742,7 +769,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     #indicate which hit has been used    
     b=len(a)*[0]
     hits[i]=[a,b,c,d]
-    if debug==1: print(i,zlayer[i],hits[i]) 
+    if config.debug:
+      print(i, zlayer[i], hits[i]) 
     
     # split hits up by trackid for debugging 
 
@@ -774,15 +802,24 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   removetrackids=[]
   for t in trcandv1:
     trackids=[]
-    if debug==1: 
+    if config.debug: 
        print(' ')
        print('track found in Y view:',t,' indices of hits in planes',trcandv1[t])
     for ipl in range(len(trcandv1[t])):      
       indx= trcandv1[t][ipl]
       if indx>-1:     
- 	if debug==1: print('   plane nr, z-position, y of hit, trackid:',ipl,zlayer[ipl],hits[ipl][0][indx],StrawRawLink[hits[ipl][2][indx]][0].GetTrackID())
+ 	if config.debug:
+	  print(
+	      '   plane nr, z-position, y of hit, trackid:',
+	      ipl, zlayer[ipl], hits[ipl][0][indx],
+	      StrawRawLink[hits[ipl][2][indx]][0].GetTrackID()
+	  )
 	trackids.append(StrawRawLink[hits[ipl][2][indx]][0].GetTrackID())				
-    if debug==1: print("   Largest fraction of hits in Y view:",fracMCsame(trackids)[0],"on MC track with id",fracMCsame(trackids)[1])
+    if config.debug:
+      print(
+	  "   Largest fraction of hits in Y view:", fracMCsame(trackids)[0],
+	  "on MC track with id",fracMCsame(trackids)[1]
+	  )
     if firsttwo==True: 
        h['fracsame12-y'].Fill(fracMCsame(trackids)[0])
     else: 
@@ -794,11 +831,13 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
              foundhorizontaltrackids.append(fracMCsame(trackids)[1])
        else:
           #this track is not reconstructible, remove it
-          if debug==1: print("Y view track with trackid",fracMCsame(trackids)[1],"is not reconstructible. Removing it.")
+          if config.debug:
+	    print("Y view track with trackid", fracMCsame(trackids)[1], "is not reconstructible. Removing it.")
           removetrackids.append(t) 
 
        if (len(foundhorizontaltrackids) == 0 or len(horizontaltrackids)==0 ): 
-          if debug==1: print("No reconstructible Y view tracks found.")
+          if config.debug:
+	    print("No reconstructible Y view tracks found.")
           if monitor==True : return 0,[],[],[],[],[],[],{},{},{},{},{}
   
   for i in range(0,len(removetrackids)):
@@ -819,20 +858,21 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
         if firsttwo==True: 
           if len(foundhorizontaltrackids)>=len(ReconstructibleMCTracks) : reconstructiblehorizontalidsfound12+=1
           else : 
-             if debug==1: 
+             if config.debug: 
 	       print("!!!!!!!!!!!!!!!! Difference between Y-view tracks found and reconstructible tracks (station 1&2). Quitting patrec.")
                debugevent(iEvent,False,y2,y3,ymin2,yother,z2,z3,zmin2,zother,foundhorizontaltrackids)	  
 	     return 0,[],[],[],[],[],[],{},{},{},{},{}
         else: 
           if len(foundhorizontaltrackids)>=len(ReconstructibleMCTracks) : reconstructiblehorizontalidsfound34+=1
           else : 
-             if debug==1: 
+             if config.debug: 
 	       print("!!!!!!!!!!!!!!!! Difference between Y-view tracks found and reconstructible tracks (station 3&4). Quitting patrec.")
 	       debugevent(iEvent,False,y2,y3,ymin2,yother,z2,z3,zmin2,zother,foundhorizontaltrackids)
 	     return 0,[],[],[],[],[],[],{},{},{},{},{}
 
      if len(foundhorizontaltrackids) != reconstructiblerequired :
-       if debug==1: print(len(foundhorizontaltrackids),"Y view tracks found, but ",reconstructiblerequired,"required.")
+       if config.debug:
+	 print(len(foundhorizontaltrackids), "Y view tracks found, but ", reconstructiblerequired, "required.")
        return 0,[],[],[],[],[],[],{},{},{},{},{} 
   else:
      if firsttwo==True: reconstructiblehorizontalidsfound12+=1
@@ -840,12 +880,15 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 
 
   if nrtrcandv1==0 : 
-    if debug==1: print("0 tracks found in Y view. Reconstructible:",len(ReconstructibleMCTracks))
+    if config.debug:
+      print("0 tracks found in Y view. Reconstructible:", len(ReconstructibleMCTracks))
     if monitor==True: return 0,[],[],[],[],[],[],{},{},{},{},{}
   else : 
-    if debug==1: print(nrtrcandv1,"tracks found in Y view. Reconstructible:",len(ReconstructibleMCTracks))
+    if config.debug:
+      print(nrtrcandv1, "tracks found in Y view. Reconstructible:", len(ReconstructibleMCTracks))
    
-  if debug==1: print("***************** Start of Stereo PatRec **************************")  
+  if config.debug:
+    print("***************** Start of Stereo PatRec **************************")  
 
   v2hits={}
   v2hitsMC={}
@@ -856,12 +899,19 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   for item in StrawRaw:  
      rawxhits[j]=copy.deepcopy((StrawRaw[item][0],StrawRaw[item][1],StrawRaw[item][3],StrawRaw[item][4],StrawRaw[item][2],StrawRaw[item][6]))
      if firsttwo==True: 
-       if debug==1: print("rawxhits[",j,"]=",rawxhits[j],"trackid",StrawRawLink[item][0].GetTrackID(),"true x",StrawRawLink[item][0].GetX(),"true y",StrawRawLink[item][0].GetY())
+       if config.debug:
+	 print(
+	     "rawxhits[", j, "]=", rawxhits[j],
+	     "trackid", StrawRawLink[item][0].GetTrackID(),
+	     "true x", StrawRawLink[item][0].GetX(),
+	     "true y",StrawRawLink[item][0].GetY()
+	     )
      j=j+1  
  
   sortedrawxhits=OrderedDict(sorted(rawxhits.items(),key=lambda t:t[1][4])) 
 
-  if debug==1: print("stereo view hits ordered by plane:")
+  if config.debug:
+    print("stereo view hits ordered by plane:")
   for i in range(i1,i2+1):
     xb=[]
     yb=[]
@@ -881,7 +931,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	d.append(float(sortedrawxhits[item][5]))
     uvview[i]=[xb,yb,xt,yt,c,d]
 
-    if debug==1: print('   uv hits, z,xb,yb,xt,yt,dist    ',i,zlayerv2[i],uvview[i][0],uvview[i][1],uvview[i][2],uvview[i][3],uvview[i][4],uvview[i][5])
+    if config.debug:
+      print(
+	  '   uv hits, z,xb,yb,xt,yt,dist    ',
+	  i, zlayerv2[i], uvview[i][0], uvview[i][1], uvview[i][2],
+	  uvview[i][3], uvview[i][4], uvview[i][5]
+	  )
 
   # now do pattern recognition in view perpendicular to first search view
   # loop over tracks found in Y view, and intersect this "plane"
@@ -891,7 +946,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   ntracks=0 
   trackkey=0 
   tracks={}
-  if debug==1:
+  if config.debug:
     if (firsttwo==True) :  
       print('Loop over tracks found in Y view, stations 1&2')
     else :  
@@ -915,7 +970,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     #linear "fit" to track found in this view 
 
     fitt,fitc=fitline(trcandv1[t],hits,zlayer,resolution)
-    if debug==1: print('   Track nr',t,'in Y view: tangent, constant=',fitt,fitc)
+    if config.debug:
+      print('   Track nr', t, 'in Y view: tangent, constant=', fitt, fitc)
 
     tan=0.
     cst=0.
@@ -928,7 +984,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     for ipl in looplist:      
       indx= trcandv1[t][ipl]
       if indx>-1: 
- 	if debug==1: print('      Plane nr, z-position, y of hit:',ipl,zlayer[ipl],hits[ipl][0][indx])
+ 	if config.debug:
+	  print('      Plane nr, z-position, y of hit:', ipl, zlayer[ipl], hits[ipl][0][indx])
         hitpoint=[zlayer[ipl],hits[ipl][0][indx]]
 	rc=h['disthittoYviewtrack'].Fill(dist2line(fitt,fitc,hitpoint))
 	#if px==0. : px=StrawRawLink[hits[ipl][2][indx]][0].GetPx()
@@ -938,13 +995,14 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	py=StrawRawLink[hits[ipl][2][indx]][0].GetPy()
 	pz=StrawRawLink[hits[ipl][2][indx]][0].GetPz()
 	ptmp=math.sqrt(px**2+py**2+pz**2)
-	if debug==1:
+	if config.debug:
 	    print("      p",ptmp,"px",px,"py",py,"pz",pz)
 	if tan==0. : tan=py/pz
 	if cst==0. : cst=StrawRawLink[hits[ipl][2][indx]][0].GetY()-tan*zlayer[ipl][0]
 	rc=h['disthittoYviewMCtrack'].Fill(dist2line(tan,cst,hitpoint))
 
-    if debug==1: print('   Track nr',t,'in Y view: MC tangent, MC constant=',tan,cst)	
+    if config.debug:
+      print('   Track nr', t, 'in Y view: MC tangent, MC constant=', tan, cst)	
     
     for ipl in range(len(trcandv1[t])):      
       indx= trcandv1[t][ipl]
@@ -1011,7 +1069,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	  e.append(distances[xcleanunsorted.index(item)]) 
       #fill hits info for ptrack, "b" records if hit has been used in ptrack
       v2hits[ipl]=[xclean,b,d,e]
-      if debug==1: print('      Plane,z, projected hits:',ipl,zlayerv2[ipl],v2hits[ipl])
+      if config.debug:
+	print('      Plane,z, projected hits:', ipl , zlayerv2[ipl], v2hits[ipl])
       
       for item in range(len(v2hits[ipl][0])): 
 	if StrawRawLink[v2hits[ipl][2][item]][0].GetTrackID() == 3:
@@ -1037,18 +1096,21 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     else:
        nrtrcandv2,trcandv2=ptrack(zlayerv2,v2hits,6,15.)
     if len(trcandv2)>1: 
-      if debug==1: print("   len(trcandv2) in stereo",len(trcandv2))
+      if config.debug:
+	print("   len(trcandv2) in stereo", len(trcandv2))
     
     nstereotracks=0
     if nrtrcandv2==0 : 
-      if debug==1: print("   0 tracks found in stereo view, for Y-view track nr",t)
+      if config.debug:
+	print("   0 tracks found in stereo view, for Y-view track nr", t)
     
 
     #if firsttwo==True: totalstereo12=reconstructiblestereoidsfound12
     #else: totalstereo34==reconstructiblestereoidsfound34
     
     for t1 in trcandv2:
-      if debug==1: print('   Track belonging to Y-view view track',t,'found in stereo view:',t1,trcandv2[t1])      
+      if config.debug:
+	print('   Track belonging to Y-view view track', t, 'found in stereo view:', t1, trcandv2[t1])      
       
       stereofitt,stereofitc=fitline(trcandv2[t1],v2hits,zlayerv2,resolution)
 
@@ -1087,7 +1149,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
         indx= trcandv2[t1][ipl]
         if indx>-1: 
 	  stereotrackids.append(StrawRawLink[v2hits[ipl][2][indx]][0].GetTrackID())     
-	  if debug==1: print("      plane nr, zpos, x of hit, hitid, trackid",ipl,zlayerv2[ipl],v2hits[ipl][0][indx],v2hits[ipl][2][indx],StrawRawLink[v2hits[ipl][2][indx]][0].GetTrackID())	
+	  if config.debug:
+	    print(
+		"      plane nr, zpos, x of hit, hitid, trackid",
+		ipl, zlayerv2[ipl], v2hits[ipl][0][indx], v2hits[ipl][2][indx],
+		StrawRawLink[v2hits[ipl][2][indx]][0].GetTrackID()
+		)	
 	  xdiff=v2hits[ipl][0][indx]-StrawRawLink[v2hits[ipl][2][indx]][0].GetX()
 	  h['digi-truevstruex'].Fill(xdiff)
 	if ipl<5:	
@@ -1122,14 +1189,20 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if firsttwo==True: h['fracsame12-stereo'].Fill(fracMCsame(stereotrackids)[0])
       else: h['fracsame34-stereo'].Fill(fracMCsame(stereotrackids)[0])
       
-      if debug==1: 
+      if config.debug: 
          print("      Largest fraction of hits in stereo view:",fracMCsame(stereotrackids)[0],"on MC track with id",fracMCsame(stereotrackids)[1])    
          #check if this trackid is the same as the track from the Y-view it belongs to
          if monitor==True: print("      fracMCsame(stereotrackids)[1]", fracMCsame(stereotrackids)[1],"foundhorizontaltrackids[",t-1,"]",foundhorizontaltrackids[t-1])
       
       if monitor==True: 
          if fracMCsame(stereotrackids)[1] != horizontaltrackids[t-1] :
-            if debug==1: print("      Stereo track with trackid",fracMCsame(stereotrackids)[1] ,"does not belong to the Y-view track with id=",horizontaltrackids[t-1])
+            if config.debug:
+	      print(
+		  "      Stereo track with trackid",
+		  fracMCsame(stereotrackids)[1],
+		  "does not belong to the Y-view track with id=",
+		  horizontaltrackids[t-1]
+		  )
             continue
       
          #check if this trackid belongs to a reconstructible track
@@ -1137,7 +1210,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
             if fracMCsame(stereotrackids)[1] not in foundstereotrackids: 
 	       foundstereotrackids.append(fracMCsame(stereotrackids)[1])
          else:
-            if debug==1: print("      Stereo track with trackid",fracMCsame(stereotrackids)[1] ,"is not reconstructible. Removing it.")
+            if config.debug:
+	      print(
+		  "      Stereo track with trackid",
+		  fracMCsame(stereotrackids)[1], 
+		  "is not reconstructible. Removing it."
+		  )
 	    continue
       else:
           if fracMCsame(stereotrackids)[1] not in foundstereotrackids: 
@@ -1147,7 +1225,11 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       alltrackids=y11trackids+stereo11trackids+stereo12trackids+y12trackids+y21trackids+stereo21trackids+stereo22trackids+y22trackids 
       if firsttwo==True: h['fracsame12'].Fill(fracMCsame(alltrackids)[0])
       else: h['fracsame34'].Fill(fracMCsame(alltrackids)[0])      
-      if debug==1: print("      Largest fraction of hits in horizontal and stereo view:",fracMCsame(alltrackids)[0],"on MC track with id",fracMCsame(alltrackids)[1])
+      if config.debug:
+	print(
+	    "      Largest fraction of hits in horizontal and stereo view:", fracMCsame(alltrackids)[0],
+	    "on MC track with id", fracMCsame(alltrackids)[1]
+	    )
       
       #calculate efficiency after joining horizontal and stereo tracks
       if monitor==True: 
@@ -1180,7 +1262,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
                stereotan[trackkey*1000+nstereotracks]=stereotanMCv
                stereocst[trackkey*1000+nstereotracks]=stereocstMCv 
          else:
-            if debug==1: print("Track with trackid",fracMCsame(alltrackids)[1] ,"is not reconstructible. Removing it.")
+            if config.debug:
+	      print("Track with trackid", fracMCsame(alltrackids)[1], "is not reconstructible. Removing it.")
 	    continue
       else:
 	   if fracMCsame(alltrackids)[1] not in foundtrackids:
@@ -1216,7 +1299,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if firsttwo==True: reconstructiblestereoidsfound12+=1
       else: reconstructiblestereoidsfound34+=1    
     else:     
-      if debug==1:
+      if config.debug:
          debugevent(iEvent,True,v2y2,v2y3,v2ymin2,v2yother,v2z2,v2z3,v2zmin2,v2zother,foundstereotrackids)
          print("Nbr of reconstructible tracks after stereo",len(foundstereotrackids)," but ",len(ReconstructibleMCTracks)," reconstructible tracks in this event. Quitting.")
       return 0,[],[],[],[],[],[],{},{},{},{},{}
@@ -1225,7 +1308,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if firsttwo==True: reconstructibleidsfound12+=1
       else: reconstructibleidsfound34+=1  
     else: 
-      if debug==1: 
+      if config.debug: 
          debugevent(iEvent,True,v2y2,v2y3,v2ymin2,v2yother,v2z2,v2z3,v2zmin2,v2zother,foundstereotrackids)
          print("Nbr of reconstructed tracks ",len(foundtrackids)," but",len(ReconstructibleMCTracks)," reconstructible tracks in this event. Quitting.")
       return 0,[],[],[],[],[],[],{},{},{},{},{}
@@ -1240,7 +1323,8 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 
 def TrackFit(hitPosList,theTrack,charge,pinv): 
    global theTracks
-   if debug==1: fitter.setDebugLvl(1)
+   if config.debug:
+     fitter.setDebugLvl(1)
    resolution = ShipGeo.strawtubes.sigma_spatial    
    hitCov = ROOT.TMatrixDSym(7)
    hitCov[6][6] = resolution*resolution
@@ -1253,19 +1337,20 @@ def TrackFit(hitPosList,theTrack,charge,pinv):
      tp.addRawMeasurement(measurement) # package measurement in the TrackPoint                                          
      theTrack.insertPoint(tp)  # add point to Track
    theTracks.append(theTrack)
-   if not debug == 1: return # leave track fitting shipDigiReco
+   if not config.debug:
+     return # leave track fitting to shipDigiReco
 #check
    if not theTrack.checkConsistency():
-     if debug==1: print('Problem with track before fit, not consistent',theTrack)
+     print('Problem with track before fit, not consistent', theTrack)
      return
 # do the fit
    try:  fitter.processTrack(theTrack)
    except: 
-     if debug==1: print("genfit failed to fit track")
+     print("genfit failed to fit track")
      return
 #check
    if not theTrack.checkConsistency():
-     if debug==1: print('Problem with track after fit, not consistent',theTrack)
+     print('Problem with track after fit, not consistent', theTrack)
      return  
     
       
@@ -1604,7 +1689,8 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
  reconstructibles34=0
  theTracks=[]
  
- if debug==1: print("************* PatRect START **************")  
+ if config.debug:
+   print("************* PatRect START **************")  
     
  nShits=sTree.strawtubesPoint.GetEntriesFast() 
  nMCTracks = sTree.MCTrack.GetEntriesFast() 
@@ -1623,9 +1709,15 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	        reconstructibles12+=1
 		tracksfound.append(item)
 		
-       if debug==1: print("tracksfound",tracksfound,"reconstructibles12",reconstructibles12,"ReconstructibleMCTracks",ReconstructibleMCTracks)	
+       if config.debug:
+	 print(
+	     "tracksfound", tracksfound,
+	     "reconstructibles12", reconstructibles12,
+	     "ReconstructibleMCTracks", ReconstructibleMCTracks
+	     )	
        if len(tracksfound)==0 and len(ReconstructibleMCTracks)>0: 
-         if debug==1: print("No tracks found in event after stations 1&2. Rejecting event.")
+         if config.debug:
+	   print("No tracks found in event after stations 1&2. Rejecting event.")
          return
     
      nr34tracks,tracks34,hitids34,xtan34,xcst34,stereotan34,stereocst34,px34,py34,pz34,fraction34,trackid34=PatRec(False,z34layer,z34layerv2,StrawRaw,StrawRawLink,ReconstructibleMCTracks)
@@ -1638,12 +1730,13 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	        reconstructibles34+=1 
 		tracksfound.append(item)
       if len(tracksfound)==0 and len(ReconstructibleMCTracks)>0: 
-        if debug==1: print("No tracks found in event after stations 3&4. Rejecting event.")
+        if config.debug:
+	  print("No tracks found in event after stations 3&4. Rejecting event.")
         return
       MatchedReconstructibleMCTracks=len(ReconstructibleMCTracks)*[0]  
 
 
-     if debug==1:
+     if config.debug:
       if (nr12tracks>0) : 
        print(nr12tracks,"tracks12  ",tracks12)
        print("hitids12  ",hitids12)
@@ -1714,7 +1807,12 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
          p2y=py34[item1]
          p2z=pz34[item1]
          p2true=1./math.sqrt(p2x**2+p2y**2+p2z**2)
-         if debug==1: print("Matching 1&2 track",item,"with 3&4 track",item1,"dx",dx,"dy",dy,"alpha",alpha,"pinv",pinv,"1/p2true",p2true)
+         if config.debug:
+	   print(
+	       "Matching 1&2 track", item,
+	       "with 3&4 track", item1,
+	       "dx", dx, "dy", dy, "alpha", alpha, "pinv", pinv, "1/p2true", p2true
+	       )
          rc=h['dx-matchedtracks'].Fill(dx)
          rc=h['dy-matchedtracks'].Fill(dy)
          if ((abs(dx)<20) & (abs(dy)<2)) :
@@ -1738,22 +1836,25 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	      if (falsepositivethistrack==0 & falsenegativethistrack==0):
 	        totalaftermatching+=1
 	      else: 
-	        if debug==1: print("Charge from track deflection doesn't match MC truth. Rejecting it.")
+	        if config.debug:
+		  print("Charge from track deflection doesn't match MC truth. Rejecting it.")
 	        break
 	    else:
 	      if matches==0: 
 	        matches==1
 	        totalaftermatching+=1
 
-	    if debug==1: 
+	    if config.debug: 
 	       print("******* MATCH FOUND stations 12 track id",trackid12[item],"(fraction",fraction12[item]*100,"%) and stations 34 track id",trackid34[item1],"(fraction",fraction34[item1]*100,"%)")
 	       print("******* Reconstructible tracks ids",ReconstructibleMCTracks)
 	    
 	    rc=h['matchedtrackefficiency'].Fill(fraction12[item],fraction34[item1])
 	    for k,v in enumerate(ReconstructibleMCTracks):
-	      if debug==1: print("MatchedReconstructibleMCTracks",MatchedReconstructibleMCTracks,"k",k,"v",v)
+	      if config.debug:
+		print("MatchedReconstructibleMCTracks", MatchedReconstructibleMCTracks, "k", k, "v", v)
 	      if v not in MatchedReconstructibleMCTracks:
-	        if debug==1: print("ReconstructibleMCTracks",ReconstructibleMCTracks,"trackid34[item1]",trackid34[item1])
+	        if config.debug:
+		  print("ReconstructibleMCTracks", ReconstructibleMCTracks, "trackid34[item1]", trackid34[item1])
 	        if v==trackid34[item1]: MatchedReconstructibleMCTracks[k]=v
 	    p2true=p2true*int(charge)
 	    rc=h['pinvvstruepinv'].Fill(p2true,pinv)
@@ -1778,7 +1879,8 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	            hitPosList.append(m)
                nM = len(hitPosList)
                if nM<25:
-                 if debug==1: print("Only",nM,"hits on this track. Insufficient for fitting.")
+                 if config.debug:
+		   print("Only", nM, "hits on this track. Insufficient for fitting.")
                  return
 	       #all particles are assumed to be muons
                if int(charge)<0:
@@ -1806,9 +1908,15 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	       TrackFit(hitPosList,theTrack,charge,pinv)
                fittedtrackids.append(trackid34[item1])
          else :
-	    if debug==1: print("******* MATCH NOT FOUND stations 12 track id",trackid12[item],"(fraction",fraction12[item]*100,"%) and stations 34 track id",trackid34[item1],"(fraction",fraction34[item1]*100,"%)")
+	    if config.debug:
+	      print(
+		  "******* MATCH NOT FOUND stations 12 track id", trackid12[item],
+		  "(fraction", fraction12[item]*100, "%) and stations 34 track id", trackid34[item1],
+		  "(fraction", fraction34[item1]*100, "%)"
+		  )
             if trackid12[item]==trackid34[item1] : 
-	       if debug==1: print("trackids the same, but not matched.")
+	       if config.debug:
+		 print("trackids the same, but not matched.")
        
  else: 
       #remove events with >500 hits
@@ -1822,4 +1930,5 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
  
  
 def finalize(): 
-   if debug==1: ut.writeHists(h,"recohists_patrec.root")
+   if config.debug:
+     ut.writeHists(h,"recohists_patrec.root")

--- a/python/shipPatRec_prev.py
+++ b/python/shipPatRec_prev.py
@@ -6,8 +6,8 @@
 from __future__ import print_function
 from builtins import range
 import ROOT, os
-import config
-from config import ShipGeo
+import global_variables
+from global_variables import ShipGeo
 import shipunit  as u
 import math
 import copy
@@ -212,7 +212,7 @@ def initialize(fGeo):
      z34layerv2[i]=[Zpos_u]
 
    VetoStationZ = ShipGeo.vetoStation.z
-   if config.debug:
+   if global_variables.debug:
      print("VetoStation midpoint z=", VetoStationZ)
    VetoStationEndZ=VetoStationZ+(ShipGeo.strawtubes.DeltazView+ShipGeo.strawtubes.OuterStrawDiameter)/2
    for i in range(1,5):   
@@ -220,7 +220,7 @@ def initialize(fGeo):
      if i==2: TStationz = ShipGeo.TrackStation2.z  
      if i==3: TStationz = ShipGeo.TrackStation3.z  
      if i==4: TStationz = ShipGeo.TrackStation4.z 
-     if config.debug:
+     if global_variables.debug:
        print("TrackStation",i," midpoint z=",TStationz) 
        for vnb in range(0,4):
          for pnb in range (0,2):
@@ -241,7 +241,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   rc = sTree.GetEvent(iEvent) 
   nMCTracks = sTree.MCTrack.GetEntriesFast()   
 
-  if config.debug:
+  if global_variables.debug:
     print("event nbr", iEvent, "has", nMCTracks, "tracks")
   #1. MCTrackIDs: list of tracks decaying after the last tstation and originating before the first
   for i in reversed(range(nMCTracks)):
@@ -275,7 +275,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
              if mothertrackZ < TStation1StartZ and mothertrackZ > VetoStationEndZ:
 	       if motherId not in MCTrackIDs:
 	           MCTrackIDs.append(motherId)
-  if config.debug:
+  if global_variables.debug:
     print("Tracks with origin in decay volume", MCTrackIDs)	 
   if len(MCTrackIDs)==0: return MCTrackIDs
     
@@ -302,20 +302,20 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   for item in itemstoremove:
       MCTrackIDs.remove(item)	   	  	  
 
-  if config.debug:
+  if global_variables.debug:
     print("Tracks with hits in timedet", MCTrackIDs) 
   if len(MCTrackIDs)==0: return MCTrackIDs
   #4. Find straws that have multiple hits
   nHits = sTree.strawtubesPoint.GetEntriesFast()  
   hitstraws={}
   duplicatestrawhit=[]
-  if config.debug:
+  if global_variables.debug:
     print("Nbr of Rawhits=", nHits)
 
   for i in range(nHits):
     ahit = sTree.strawtubesPoint[i]
     if (str(ahit.GetDetectorID())[:1]=="5") : 
-       if config.debug:
+       if global_variables.debug:
 	 print("Hit in straw Veto detector. Rejecting.")
        continue
     strawname=str(ahit.GetDetectorID())
@@ -340,7 +340,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   trackoutsidestations=[]
   for i in range(nHits):
     if i in  duplicatestrawhit: 
-       if config.debug:
+       if global_variables.debug:
 	 print("Duplicate hit", i, "not reconstructible, rejecting.")
        continue  
     ahit = sTree.strawtubesPoint[i] 
@@ -350,7 +350,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
           trackoutsidestations.append(ahit.GetTrackID())
     if ahit.GetTrackID() not in MCTrackIDs:
        #hit on not reconstructible track
-       if config.debug:
+       if global_variables.debug:
 	 print("Hit not on reconstructible track. Rejecting.")
        continue	  
     #group hits per tracking station, key = trackid
@@ -407,7 +407,7 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
   for item in itemstoremove:
       MCTrackIDs.remove(item)	
 
-  if config.debug: 
+  if global_variables.debug: 
      print("tracks_with_hits_in_all_stations",tracks_with_hits_in_all_stations)
      print("Tracks with hits in all stations & inside acceptance ellipse",MCTrackIDs)   
   if len(MCTrackIDs)==0: return MCTrackIDs   
@@ -444,9 +444,9 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
         itemstoremove.append(item)
   for item in itemstoremove:
       MCTrackIDs.remove(item)	
-      if config.debug:
+      if global_variables.debug:
 	print("After removing the non HNL track, MCTrackIDs", MCTrackIDs)
-  if config.debug:
+  if global_variables.debug:
     print("Tracks with HNL mother", MCTrackIDs) 
   
   #8. check if the tracks are HNL children 
@@ -463,17 +463,17 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
 	   nu_mufound+=1  
 	   itemstoremove.append(item)
       except:
-        if config.debug:
+        if global_variables.debug:
 	  print("Unknown particle with pdg code:", sTree.MCTrack.At(item).GetPdgCode())	
     if reconstructiblerequired == 1 :
       if mufound!=1  and pifound!=1: 
-          if config.debug:
+          if global_variables.debug:
 	    print("No reconstructible pion or muon.") 
 	  MCTrackIDs=[]   
     if reconstructiblerequired == 2 : 
       if threeprong == 1 :       
           if mufound!=2 or nu_mufound!=1 : 
-            if config.debug:
+            if global_variables.debug:
 	      print("No reconstructible mu-mu-nu.")  
 	    MCTrackIDs=[]
 	  else:
@@ -482,13 +482,13 @@ def getReconstructibleTracks(iEvent,sTree,sGeo):
                MCTrackIDs.remove(item)	
       else:         
           if mufound!=1 or pifound!=1 : 
-            if config.debug:
+            if global_variables.debug:
 	      print("No reconstructible pion and muon.")  
 	    MCTrackIDs=[]     
   if len(MCTrackIDs)>0:
      rc=h['nbrhits'].Fill(nHits)
      rc=h['nbrtracks'].Fill(nMCTracks)
-  if config.debug:
+  if global_variables.debug:
     print("Tracks with required HNL decay particles", MCTrackIDs) 	     
   return MCTrackIDs
 
@@ -526,7 +526,7 @@ def SmearHits(iEvent,sTree,modules,SmearedHits,ReconstructibleMCTracks):
           
   #the following code prints some histograms related to the MC hits  
   strawname=''
-  if config.debug:
+  if global_variables.debug:
     print("nbr of hits=", nHits, "in event", iEvent)
   station1hits={}
   station12xhits={}
@@ -687,7 +687,7 @@ def Digitization(sTree,SmearedHits):
     StrawRawLink[j]=[sTree.strawtubesPoint[i]]
     j=j+1 
 
-  if config.debug:
+  if global_variables.debug:
     print("Nbr of digitized hits", j)  
   return StrawRaw,StrawRawLink
          
@@ -717,7 +717,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
      #y hits for horizontal straws
      rawhits[j]=copy.deepcopy(((StrawRaw[item][1]+StrawRaw[item][4])/2,(StrawRaw[item][2]+StrawRaw[item][5])/2,StrawRaw[item][6]))
      if firsttwo==True: 
-       if config.debug:
+       if global_variables.debug:
 	 print(
 	     "rawhits[", j, "]=", rawhits[j],
 	     "trackid", StrawRawLink[item][0].GetTrackID(),
@@ -729,7 +729,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
      j=j+1    
       
   sortedrawhits=OrderedDict(sorted(rawhits.items(),key=lambda t:t[1][1])) 
-  if config.debug: 
+  if global_variables.debug: 
      print(" ")
      print("horizontal view (y) hits ordered by plane: plane nr, zlayer, hits")
 
@@ -752,7 +752,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	   a.append(float(sortedrawhits[item][0]))
 	else: 
 	   #This should never happen - duplicate hits are already removed at digitization
-	   if config.debug:
+	   if global_variables.debug:
 	     print(" wire hit again", sortedrawhits[item], "strawname=", StrawRawLink[item][0].GetDetectorID())
 	   a.append(float(sortedrawhits[item][0]))
 	   duplicates.append(float(zlayer[i][0]))  
@@ -770,7 +770,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     #indicate which hit has been used    
     b=len(a)*[0]
     hits[i]=[a,b,c,d]
-    if config.debug:
+    if global_variables.debug:
       print(i, zlayer[i], hits[i]) 
     
     # split hits up by trackid for debugging 
@@ -803,20 +803,20 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   removetrackids=[]
   for t in trcandv1:
     trackids=[]
-    if config.debug: 
+    if global_variables.debug: 
        print(' ')
        print('track found in Y view:',t,' indices of hits in planes',trcandv1[t])
     for ipl in range(len(trcandv1[t])):      
       indx= trcandv1[t][ipl]
       if indx>-1:     
- 	if config.debug:
+ 	if global_variables.debug:
 	  print(
 	      '   plane nr, z-position, y of hit, trackid:',
 	      ipl, zlayer[ipl], hits[ipl][0][indx],
 	      StrawRawLink[hits[ipl][2][indx]][0].GetTrackID()
 	  )
 	trackids.append(StrawRawLink[hits[ipl][2][indx]][0].GetTrackID())				
-    if config.debug:
+    if global_variables.debug:
       print(
 	  "   Largest fraction of hits in Y view:", fracMCsame(trackids)[0],
 	  "on MC track with id",fracMCsame(trackids)[1]
@@ -832,12 +832,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
              foundhorizontaltrackids.append(fracMCsame(trackids)[1])
        else:
           #this track is not reconstructible, remove it
-          if config.debug:
+          if global_variables.debug:
 	    print("Y view track with trackid", fracMCsame(trackids)[1], "is not reconstructible. Removing it.")
           removetrackids.append(t) 
 
        if (len(foundhorizontaltrackids) == 0 or len(horizontaltrackids)==0 ): 
-          if config.debug:
+          if global_variables.debug:
 	    print("No reconstructible Y view tracks found.")
           if monitor==True : return 0,[],[],[],[],[],[],{},{},{},{},{}
   
@@ -859,20 +859,20 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
         if firsttwo==True: 
           if len(foundhorizontaltrackids)>=len(ReconstructibleMCTracks) : reconstructiblehorizontalidsfound12+=1
           else : 
-             if config.debug: 
+             if global_variables.debug: 
 	       print("!!!!!!!!!!!!!!!! Difference between Y-view tracks found and reconstructible tracks (station 1&2). Quitting patrec.")
                debugevent(iEvent,False,y2,y3,ymin2,yother,z2,z3,zmin2,zother,foundhorizontaltrackids)	  
 	     return 0,[],[],[],[],[],[],{},{},{},{},{}
         else: 
           if len(foundhorizontaltrackids)>=len(ReconstructibleMCTracks) : reconstructiblehorizontalidsfound34+=1
           else : 
-             if config.debug: 
+             if global_variables.debug: 
 	       print("!!!!!!!!!!!!!!!! Difference between Y-view tracks found and reconstructible tracks (station 3&4). Quitting patrec.")
 	       debugevent(iEvent,False,y2,y3,ymin2,yother,z2,z3,zmin2,zother,foundhorizontaltrackids)
 	     return 0,[],[],[],[],[],[],{},{},{},{},{}
 
      if len(foundhorizontaltrackids) != reconstructiblerequired :
-       if config.debug:
+       if global_variables.debug:
 	 print(len(foundhorizontaltrackids), "Y view tracks found, but ", reconstructiblerequired, "required.")
        return 0,[],[],[],[],[],[],{},{},{},{},{} 
   else:
@@ -881,14 +881,14 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 
 
   if nrtrcandv1==0 : 
-    if config.debug:
+    if global_variables.debug:
       print("0 tracks found in Y view. Reconstructible:", len(ReconstructibleMCTracks))
     if monitor==True: return 0,[],[],[],[],[],[],{},{},{},{},{}
   else : 
-    if config.debug:
+    if global_variables.debug:
       print(nrtrcandv1, "tracks found in Y view. Reconstructible:", len(ReconstructibleMCTracks))
    
-  if config.debug:
+  if global_variables.debug:
     print("***************** Start of Stereo PatRec **************************")  
 
   v2hits={}
@@ -900,7 +900,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   for item in StrawRaw:  
      rawxhits[j]=copy.deepcopy((StrawRaw[item][0],StrawRaw[item][1],StrawRaw[item][3],StrawRaw[item][4],StrawRaw[item][2],StrawRaw[item][6]))
      if firsttwo==True: 
-       if config.debug:
+       if global_variables.debug:
 	 print(
 	     "rawxhits[", j, "]=", rawxhits[j],
 	     "trackid", StrawRawLink[item][0].GetTrackID(),
@@ -911,7 +911,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
  
   sortedrawxhits=OrderedDict(sorted(rawxhits.items(),key=lambda t:t[1][4])) 
 
-  if config.debug:
+  if global_variables.debug:
     print("stereo view hits ordered by plane:")
   for i in range(i1,i2+1):
     xb=[]
@@ -932,7 +932,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	d.append(float(sortedrawxhits[item][5]))
     uvview[i]=[xb,yb,xt,yt,c,d]
 
-    if config.debug:
+    if global_variables.debug:
       print(
 	  '   uv hits, z,xb,yb,xt,yt,dist    ',
 	  i, zlayerv2[i], uvview[i][0], uvview[i][1], uvview[i][2],
@@ -947,7 +947,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
   ntracks=0 
   trackkey=0 
   tracks={}
-  if config.debug:
+  if global_variables.debug:
     if (firsttwo==True) :  
       print('Loop over tracks found in Y view, stations 1&2')
     else :  
@@ -971,7 +971,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     #linear "fit" to track found in this view 
 
     fitt,fitc=fitline(trcandv1[t],hits,zlayer,resolution)
-    if config.debug:
+    if global_variables.debug:
       print('   Track nr', t, 'in Y view: tangent, constant=', fitt, fitc)
 
     tan=0.
@@ -985,7 +985,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     for ipl in looplist:      
       indx= trcandv1[t][ipl]
       if indx>-1: 
- 	if config.debug:
+ 	if global_variables.debug:
 	  print('      Plane nr, z-position, y of hit:', ipl, zlayer[ipl], hits[ipl][0][indx])
         hitpoint=[zlayer[ipl],hits[ipl][0][indx]]
 	rc=h['disthittoYviewtrack'].Fill(dist2line(fitt,fitc,hitpoint))
@@ -996,13 +996,13 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	py=StrawRawLink[hits[ipl][2][indx]][0].GetPy()
 	pz=StrawRawLink[hits[ipl][2][indx]][0].GetPz()
 	ptmp=math.sqrt(px**2+py**2+pz**2)
-	if config.debug:
+	if global_variables.debug:
 	    print("      p",ptmp,"px",px,"py",py,"pz",pz)
 	if tan==0. : tan=py/pz
 	if cst==0. : cst=StrawRawLink[hits[ipl][2][indx]][0].GetY()-tan*zlayer[ipl][0]
 	rc=h['disthittoYviewMCtrack'].Fill(dist2line(tan,cst,hitpoint))
 
-    if config.debug:
+    if global_variables.debug:
       print('   Track nr', t, 'in Y view: MC tangent, MC constant=', tan, cst)	
     
     for ipl in range(len(trcandv1[t])):      
@@ -1070,7 +1070,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 	  e.append(distances[xcleanunsorted.index(item)]) 
       #fill hits info for ptrack, "b" records if hit has been used in ptrack
       v2hits[ipl]=[xclean,b,d,e]
-      if config.debug:
+      if global_variables.debug:
 	print('      Plane,z, projected hits:', ipl , zlayerv2[ipl], v2hits[ipl])
       
       for item in range(len(v2hits[ipl][0])): 
@@ -1097,12 +1097,12 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     else:
        nrtrcandv2,trcandv2=ptrack(zlayerv2,v2hits,6,15.)
     if len(trcandv2)>1: 
-      if config.debug:
+      if global_variables.debug:
 	print("   len(trcandv2) in stereo", len(trcandv2))
     
     nstereotracks=0
     if nrtrcandv2==0 : 
-      if config.debug:
+      if global_variables.debug:
 	print("   0 tracks found in stereo view, for Y-view track nr", t)
     
 
@@ -1110,7 +1110,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
     #else: totalstereo34==reconstructiblestereoidsfound34
     
     for t1 in trcandv2:
-      if config.debug:
+      if global_variables.debug:
 	print('   Track belonging to Y-view view track', t, 'found in stereo view:', t1, trcandv2[t1])      
       
       stereofitt,stereofitc=fitline(trcandv2[t1],v2hits,zlayerv2,resolution)
@@ -1150,7 +1150,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
         indx= trcandv2[t1][ipl]
         if indx>-1: 
 	  stereotrackids.append(StrawRawLink[v2hits[ipl][2][indx]][0].GetTrackID())     
-	  if config.debug:
+	  if global_variables.debug:
 	    print(
 		"      plane nr, zpos, x of hit, hitid, trackid",
 		ipl, zlayerv2[ipl], v2hits[ipl][0][indx], v2hits[ipl][2][indx],
@@ -1190,14 +1190,14 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if firsttwo==True: h['fracsame12-stereo'].Fill(fracMCsame(stereotrackids)[0])
       else: h['fracsame34-stereo'].Fill(fracMCsame(stereotrackids)[0])
       
-      if config.debug: 
+      if global_variables.debug: 
          print("      Largest fraction of hits in stereo view:",fracMCsame(stereotrackids)[0],"on MC track with id",fracMCsame(stereotrackids)[1])    
          #check if this trackid is the same as the track from the Y-view it belongs to
          if monitor==True: print("      fracMCsame(stereotrackids)[1]", fracMCsame(stereotrackids)[1],"foundhorizontaltrackids[",t-1,"]",foundhorizontaltrackids[t-1])
       
       if monitor==True: 
          if fracMCsame(stereotrackids)[1] != horizontaltrackids[t-1] :
-            if config.debug:
+            if global_variables.debug:
 	      print(
 		  "      Stereo track with trackid",
 		  fracMCsame(stereotrackids)[1],
@@ -1211,7 +1211,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
             if fracMCsame(stereotrackids)[1] not in foundstereotrackids: 
 	       foundstereotrackids.append(fracMCsame(stereotrackids)[1])
          else:
-            if config.debug:
+            if global_variables.debug:
 	      print(
 		  "      Stereo track with trackid",
 		  fracMCsame(stereotrackids)[1], 
@@ -1226,7 +1226,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       alltrackids=y11trackids+stereo11trackids+stereo12trackids+y12trackids+y21trackids+stereo21trackids+stereo22trackids+y22trackids 
       if firsttwo==True: h['fracsame12'].Fill(fracMCsame(alltrackids)[0])
       else: h['fracsame34'].Fill(fracMCsame(alltrackids)[0])      
-      if config.debug:
+      if global_variables.debug:
 	print(
 	    "      Largest fraction of hits in horizontal and stereo view:", fracMCsame(alltrackids)[0],
 	    "on MC track with id", fracMCsame(alltrackids)[1]
@@ -1263,7 +1263,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
                stereotan[trackkey*1000+nstereotracks]=stereotanMCv
                stereocst[trackkey*1000+nstereotracks]=stereocstMCv 
          else:
-            if config.debug:
+            if global_variables.debug:
 	      print("Track with trackid", fracMCsame(alltrackids)[1], "is not reconstructible. Removing it.")
 	    continue
       else:
@@ -1300,7 +1300,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if firsttwo==True: reconstructiblestereoidsfound12+=1
       else: reconstructiblestereoidsfound34+=1    
     else:     
-      if config.debug:
+      if global_variables.debug:
          debugevent(iEvent,True,v2y2,v2y3,v2ymin2,v2yother,v2z2,v2z3,v2zmin2,v2zother,foundstereotrackids)
          print("Nbr of reconstructible tracks after stereo",len(foundstereotrackids)," but ",len(ReconstructibleMCTracks)," reconstructible tracks in this event. Quitting.")
       return 0,[],[],[],[],[],[],{},{},{},{},{}
@@ -1309,7 +1309,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
       if firsttwo==True: reconstructibleidsfound12+=1
       else: reconstructibleidsfound34+=1  
     else: 
-      if config.debug: 
+      if global_variables.debug: 
          debugevent(iEvent,True,v2y2,v2y3,v2ymin2,v2yother,v2z2,v2z3,v2zmin2,v2zother,foundstereotrackids)
          print("Nbr of reconstructed tracks ",len(foundtrackids)," but",len(ReconstructibleMCTracks)," reconstructible tracks in this event. Quitting.")
       return 0,[],[],[],[],[],[],{},{},{},{},{}
@@ -1324,7 +1324,7 @@ def PatRec(firsttwo,zlayer,zlayerv2,StrawRaw,StrawRawLink,ReconstructibleMCTrack
 
 def TrackFit(hitPosList,theTrack,charge,pinv): 
    global theTracks
-   if config.debug:
+   if global_variables.debug:
      fitter.setDebugLvl(1)
    resolution = ShipGeo.strawtubes.sigma_spatial    
    hitCov = ROOT.TMatrixDSym(7)
@@ -1338,7 +1338,7 @@ def TrackFit(hitPosList,theTrack,charge,pinv):
      tp.addRawMeasurement(measurement) # package measurement in the TrackPoint                                          
      theTrack.insertPoint(tp)  # add point to Track
    theTracks.append(theTrack)
-   if not config.debug:
+   if not global_variables.debug:
      return # leave track fitting to shipDigiReco
 #check
    if not theTrack.checkConsistency():
@@ -1690,7 +1690,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
  reconstructibles34=0
  theTracks=[]
  
- if config.debug:
+ if global_variables.debug:
    print("************* PatRect START **************")  
     
  nShits=sTree.strawtubesPoint.GetEntriesFast() 
@@ -1710,14 +1710,14 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	        reconstructibles12+=1
 		tracksfound.append(item)
 		
-       if config.debug:
+       if global_variables.debug:
 	 print(
 	     "tracksfound", tracksfound,
 	     "reconstructibles12", reconstructibles12,
 	     "ReconstructibleMCTracks", ReconstructibleMCTracks
 	     )	
        if len(tracksfound)==0 and len(ReconstructibleMCTracks)>0: 
-         if config.debug:
+         if global_variables.debug:
 	   print("No tracks found in event after stations 1&2. Rejecting event.")
          return
     
@@ -1731,13 +1731,13 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	        reconstructibles34+=1 
 		tracksfound.append(item)
       if len(tracksfound)==0 and len(ReconstructibleMCTracks)>0: 
-        if config.debug:
+        if global_variables.debug:
 	  print("No tracks found in event after stations 3&4. Rejecting event.")
         return
       MatchedReconstructibleMCTracks=len(ReconstructibleMCTracks)*[0]  
 
 
-     if config.debug:
+     if global_variables.debug:
       if (nr12tracks>0) : 
        print(nr12tracks,"tracks12  ",tracks12)
        print("hitids12  ",hitids12)
@@ -1808,7 +1808,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
          p2y=py34[item1]
          p2z=pz34[item1]
          p2true=1./math.sqrt(p2x**2+p2y**2+p2z**2)
-         if config.debug:
+         if global_variables.debug:
 	   print(
 	       "Matching 1&2 track", item,
 	       "with 3&4 track", item1,
@@ -1837,7 +1837,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	      if (falsepositivethistrack==0 & falsenegativethistrack==0):
 	        totalaftermatching+=1
 	      else: 
-	        if config.debug:
+	        if global_variables.debug:
 		  print("Charge from track deflection doesn't match MC truth. Rejecting it.")
 	        break
 	    else:
@@ -1845,16 +1845,16 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	        matches==1
 	        totalaftermatching+=1
 
-	    if config.debug: 
+	    if global_variables.debug: 
 	       print("******* MATCH FOUND stations 12 track id",trackid12[item],"(fraction",fraction12[item]*100,"%) and stations 34 track id",trackid34[item1],"(fraction",fraction34[item1]*100,"%)")
 	       print("******* Reconstructible tracks ids",ReconstructibleMCTracks)
 	    
 	    rc=h['matchedtrackefficiency'].Fill(fraction12[item],fraction34[item1])
 	    for k,v in enumerate(ReconstructibleMCTracks):
-	      if config.debug:
+	      if global_variables.debug:
 		print("MatchedReconstructibleMCTracks", MatchedReconstructibleMCTracks, "k", k, "v", v)
 	      if v not in MatchedReconstructibleMCTracks:
-	        if config.debug:
+	        if global_variables.debug:
 		  print("ReconstructibleMCTracks", ReconstructibleMCTracks, "trackid34[item1]", trackid34[item1])
 	        if v==trackid34[item1]: MatchedReconstructibleMCTracks[k]=v
 	    p2true=p2true*int(charge)
@@ -1880,7 +1880,7 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	            hitPosList.append(m)
                nM = len(hitPosList)
                if nM<25:
-                 if config.debug:
+                 if global_variables.debug:
 		   print("Only", nM, "hits on this track. Insufficient for fitting.")
                  return
 	       #all particles are assumed to be muons
@@ -1909,14 +1909,14 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
 	       TrackFit(hitPosList,theTrack,charge,pinv)
                fittedtrackids.append(trackid34[item1])
          else :
-	    if config.debug:
+	    if global_variables.debug:
 	      print(
 		  "******* MATCH NOT FOUND stations 12 track id", trackid12[item],
 		  "(fraction", fraction12[item]*100, "%) and stations 34 track id", trackid34[item1],
 		  "(fraction", fraction34[item1]*100, "%)"
 		  )
             if trackid12[item]==trackid34[item1] : 
-	       if config.debug:
+	       if global_variables.debug:
 		 print("trackids the same, but not matched.")
        
  else: 
@@ -1931,5 +1931,5 @@ def execute(SmearedHits,sTree,ReconstructibleMCTracks):
  
  
 def finalize(): 
-   if config.debug:
+   if global_variables.debug:
      ut.writeHists(h,"recohists_patrec.root")

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -15,7 +15,7 @@ from rootpyPickler import Unpickler
 
 # For modules
 import shipDet_conf
-import globals
+import config
 
 # For track pattern recognition
 
@@ -71,7 +71,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
         ShipGeo = upkl.load('ShipGeo')
     
     # Globals
-    globals.ShipGeo = ShipGeo
+    config.ShipGeo = ShipGeo
 
     ############################################# Load SHiP modules ####################################################
 

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -15,7 +15,7 @@ from rootpyPickler import Unpickler
 
 # For modules
 import shipDet_conf
-import config
+import global_variables
 
 # For track pattern recognition
 
@@ -71,7 +71,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
         ShipGeo = upkl.load('ShipGeo')
     
     # Globals
-    config.ShipGeo = ShipGeo
+    global_variables.ShipGeo = ShipGeo
 
     ############################################# Load SHiP modules ####################################################
 

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -15,8 +15,7 @@ from rootpyPickler import Unpickler
 
 # For modules
 import shipDet_conf
-import __builtin__ as builtin
-# import TrackExtrapolateTool
+import globals
 
 # For track pattern recognition
 
@@ -72,7 +71,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
         ShipGeo = upkl.load('ShipGeo')
     
     # Globals
-    builtin.ShipGeo = ShipGeo
+    globals.ShipGeo = ShipGeo
 
     ############################################# Load SHiP modules ####################################################
 

--- a/python/shipStrawTracking_prev.py
+++ b/python/shipStrawTracking_prev.py
@@ -4,7 +4,7 @@
 #17-04-2015 comments to EvH
 
 from __future__ import print_function
-import config
+import global_variables
 import shipPatRec_prev 
 import ROOT,os,sys,getopt
 import shipDet_conf
@@ -27,7 +27,7 @@ parser.add_option("-t","--threeprong", dest="tp", help="threeprong=1 mumunu deca
 (options,args)=parser.parse_args()
 
 shipPatRec_prev.cheated=bool(options.chtd)
-config.debug = (int(options.dbg) == 1)
+global_variables.debug = (int(options.dbg) == 1)
 inputFile = options.input
 shipPatRec_prev.geoFile = options.geometry
 shipPatRec_prev.monitor=bool(options.mntr)
@@ -125,7 +125,7 @@ SHbranch       = sTree.Branch("SmearedHits",SmearedHits,32000,-1)
 fitTracks_PR      = sTree.Branch("FitTracks_PR",  fGenFitArray_PR,32000,-1) 
 mcLink_PR      = sTree.Branch("fitTrack2MC_PR",fitTrack2MC_PR,32000,-1)
  
-if config.debug:
+if global_variables.debug:
   print("Straw tracker geometry parameters (cm)")
   print("--------------------------------------")
   print("Strawlength            :",2*shipPatRec_prev.ship_geo.strawtubes.StrawLength)
@@ -156,7 +156,7 @@ def EventLoop(SmearedHits):
   if shipPatRec_prev.monitor==True: 
      shipPatRec_prev.ReconstructibleMCTracks=shipPatRec_prev.getReconstructibleTracks(n,sTree,sGeo)
      if len(shipPatRec_prev.ReconstructibleMCTracks)!=shipPatRec_prev.reconstructiblerequired : 
-        if config.debug:
+        if global_variables.debug:
           print(
               "Number of reconstructible tracks =", len(shipPatRec_prev.ReconstructibleMCTracks),
               "but number of reconstructible required=", shipPatRec_prev.reconstructiblerequired,
@@ -164,7 +164,7 @@ def EventLoop(SmearedHits):
               )
         continue
 
-     if config.debug:
+     if global_variables.debug:
        print("Reconstructible track ids", shipPatRec_prev.ReconstructibleMCTracks)
      
      
@@ -187,7 +187,7 @@ def EventLoop(SmearedHits):
   SHbranch.Fill()  
     
     
- if config.debug: 
+ if global_variables.debug: 
    print(shipPatRec_prev.falsenegative,"matched tracks with wrong negative charge from deflection.")
    print(shipPatRec_prev.falsepositive,"matched tracks with wrong positive charge from deflection.")
    print(shipPatRec_prev.morethan500,"events with more than 500 hits.")  
@@ -195,7 +195,7 @@ def EventLoop(SmearedHits):
   
  return   
             
-if config.debug:
+if global_variables.debug:
   if shipPatRec_prev.threeprong==1:
     debugrootfile = ROOT.TFile(str(shipPatRec_prev.reconstructiblerequired)+"track-debug-mumunu-"+str(nEvents)+".root","RECREATE")   
   else:  

--- a/python/shipStrawTracking_prev.py
+++ b/python/shipStrawTracking_prev.py
@@ -4,6 +4,7 @@
 #17-04-2015 comments to EvH
 
 from __future__ import print_function
+import config
 import shipPatRec_prev 
 import ROOT,os,sys,getopt
 import shipDet_conf
@@ -26,7 +27,7 @@ parser.add_option("-t","--threeprong", dest="tp", help="threeprong=1 mumunu deca
 (options,args)=parser.parse_args()
 
 shipPatRec_prev.cheated=bool(options.chtd)
-shipPatRec_prev.debug = int(options.dbg)
+config.debug = (int(options.dbg) == 1)
 inputFile = options.input
 shipPatRec_prev.geoFile = options.geometry
 shipPatRec_prev.monitor=bool(options.mntr)
@@ -124,7 +125,7 @@ SHbranch       = sTree.Branch("SmearedHits",SmearedHits,32000,-1)
 fitTracks_PR      = sTree.Branch("FitTracks_PR",  fGenFitArray_PR,32000,-1) 
 mcLink_PR      = sTree.Branch("fitTrack2MC_PR",fitTrack2MC_PR,32000,-1)
  
-if shipPatRec_prev.debug==1:
+if config.debug:
   print("Straw tracker geometry parameters (cm)")
   print("--------------------------------------")
   print("Strawlength            :",2*shipPatRec_prev.ship_geo.strawtubes.StrawLength)
@@ -155,10 +156,16 @@ def EventLoop(SmearedHits):
   if shipPatRec_prev.monitor==True: 
      shipPatRec_prev.ReconstructibleMCTracks=shipPatRec_prev.getReconstructibleTracks(n,sTree,sGeo)
      if len(shipPatRec_prev.ReconstructibleMCTracks)!=shipPatRec_prev.reconstructiblerequired : 
-        if shipPatRec_prev.debug==1: print("Number of reconstructible tracks =",len(shipPatRec_prev.ReconstructibleMCTracks),"but number of reconstructible required=",shipPatRec_prev.reconstructiblerequired,". Rejecting event.")
+        if config.debug:
+          print(
+              "Number of reconstructible tracks =", len(shipPatRec_prev.ReconstructibleMCTracks),
+              "but number of reconstructible required=", shipPatRec_prev.reconstructiblerequired,
+              ". Rejecting event."
+              )
         continue
 
-     if shipPatRec_prev.debug==1: print("Reconstructible track ids",shipPatRec_prev.ReconstructibleMCTracks)
+     if config.debug:
+       print("Reconstructible track ids", shipPatRec_prev.ReconstructibleMCTracks)
      
      
   #n = current event number, False=wire endpoints, True=MC truth
@@ -180,7 +187,7 @@ def EventLoop(SmearedHits):
   SHbranch.Fill()  
     
     
- if shipPatRec_prev.debug==1: 
+ if config.debug: 
    print(shipPatRec_prev.falsenegative,"matched tracks with wrong negative charge from deflection.")
    print(shipPatRec_prev.falsepositive,"matched tracks with wrong positive charge from deflection.")
    print(shipPatRec_prev.morethan500,"events with more than 500 hits.")  
@@ -188,7 +195,7 @@ def EventLoop(SmearedHits):
   
  return   
             
-if shipPatRec_prev.debug==1:
+if config.debug:
   if shipPatRec_prev.threeprong==1:
     debugrootfile = ROOT.TFile(str(shipPatRec_prev.reconstructiblerequired)+"track-debug-mumunu-"+str(nEvents)+".root","RECREATE")   
   else:  

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import division
 # simple vertex reconstruction with errors
 import ROOT,sys,os
+from config import debug
 import shipunit as u
 import rootUtils as ut
 import numpy as np

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import division
 # simple vertex reconstruction with errors
 import ROOT,sys,os
-import config
+import global_variables
 import shipunit as u
 import rootUtils as ut
 import numpy as np
@@ -90,7 +90,7 @@ class Task:
    fitStatus = fittedTracks[tr].getFitStatus()
    xx  = fittedTracks[tr].getFittedState()
    pid   = xx.getPDG()
-   if not config.pidProton and abs(pid) == 2212:
+   if not global_variables.pidProton and abs(pid) == 2212:
      pid = int(math.copysign(211,pid))
    rep   = ROOT.genfit.RKTrackRep(xx.getPDG())  
    state = ROOT.genfit.StateOnPlane(rep)
@@ -131,7 +131,7 @@ class Task:
       step+=1
       if step > 10:  
          ut.reportError("shipVertex::abort iteration, too many steps")
-         if config.debug:
+         if global_variables.debug:
           print('abort iteration, too many steps, pos=',newPos[0],newPos[1],newPos[2],' doca=',doca,'z before and dz',zBefore,dz)
          rc = False
          break 

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import division
 # simple vertex reconstruction with errors
 import ROOT,sys,os
-from config import debug
+import config
 import shipunit as u
 import rootUtils as ut
 import numpy as np
@@ -90,7 +90,7 @@ class Task:
    fitStatus = fittedTracks[tr].getFitStatus()
    xx  = fittedTracks[tr].getFittedState()
    pid   = xx.getPDG()
-   if not pidProton and abs(pid) == 2212:
+   if not config.pidProton and abs(pid) == 2212:
      pid = int(math.copysign(211,pid))
    rep   = ROOT.genfit.RKTrackRep(xx.getPDG())  
    state = ROOT.genfit.StateOnPlane(rep)
@@ -131,7 +131,7 @@ class Task:
       step+=1
       if step > 10:  
          ut.reportError("shipVertex::abort iteration, too many steps")
-         if debug: 
+         if config.debug:
           print('abort iteration, too many steps, pos=',newPos[0],newPos[1],newPos[2],' doca=',doca,'z before and dz',zBefore,dz)
          rc = False
          break 


### PR DESCRIPTION
As discussed in #294, I replace the use of `__builtins__` to create global variables with a dedicated dummy module.

While this should be quite a trivial change, **please test!**

While making the replacement, I noticed that while several script initialise global variables, I did not see them used anywhere. In that case, it might make sense to remove them if they are really unused, or use them, if this is by accident.

