### PR TITLE
Replacing dangerous TGeoVolumeAssembly instances with air TGeoVolumes

### DIFF
--- a/nutaudet/EmulsionMagnet.cxx
+++ b/nutaudet/EmulsionMagnet.cxx
@@ -174,7 +174,6 @@ void EmulsionMagnet::ConstructGeometry()
   InitMedium("steel");
   TGeoMedium *Steel = gGeoManager->GetMedium("steel");
 
-
   gGeoManager->SetVisLevel(10);
 
   TGeoVolume *tTauNuDet = gGeoManager->GetVolume("tTauNuDet");  
@@ -589,7 +588,6 @@ void EmulsionMagnet::ConstructGeometry()
       //magnetized region
 
       TGeoVolume *volMagRegion = new TGeoVolume("volMagRegion",IncoilBox, air);
-      //TGeoVolumeAssembly *volMagRegion = new TGeoVolumeAssembly("volMagRegion");
       MagnetVol->AddNode(volMagRegion, 1, new TGeoTranslation(0,0,0));
 
       //pillars for the magnet

--- a/nutaudet/NuTauMudet.cxx
+++ b/nutaudet/NuTauMudet.cxx
@@ -272,6 +272,9 @@ void NuTauMudet::ConstructGeometry()
     
   InitMedium("Concrete");
   TGeoMedium *Conc =gGeoManager->GetMedium("Concrete");
+
+  InitMedium("air");
+  TGeoMedium *air =gGeoManager->GetMedium("air");
     
   TGeoUniformMagField *retFieldU    = new TGeoUniformMagField(0.,0.,-fField); //magnetic field up return yoke
   TGeoUniformMagField *retFieldL   = new TGeoUniformMagField(0.,0.,fField); //magnetic field low return yoke
@@ -283,7 +286,8 @@ void NuTauMudet::ConstructGeometry()
       TGeoVolumeAssembly *volMudetBox = new TGeoVolumeAssembly("volNuTauMudet");
       tTauNuDet->AddNode(volMudetBox, 1, new TGeoTranslation(0,10*cm,fZcenter));
   
-      TGeoVolumeAssembly *volUpYoke = new TGeoVolumeAssembly("volUpYoke");
+      TGeoBBox *UpYokeBox = new TGeoBBox("UpYokeBox", fXRyoke/2, fYRyoke/2, fZRyoke/2);
+      TGeoVolume *volUpYoke = new TGeoVolume("volUpYoke",UpYokeBox,air);
       volMudetBox->AddNode(volUpYoke,1,new TGeoTranslation(0,fYtot/2 - fYRyoke/2,0));
       volUpYoke->SetField(retFieldU);
     
@@ -296,7 +300,8 @@ void NuTauMudet::ConstructGeometry()
       TGeoVolume *volFeYoke1 = new TGeoVolume("volFeYoke1",FeYoke1,Iron);
       volFeYoke1->SetLineColor(kGray+1);
     
-      TGeoVolumeAssembly *volCoilContainer = new TGeoVolumeAssembly("volCoilContainer");
+      TGeoBBox *CoilContainer = new TGeoBBox("CoilContainer",fXtot/2, fCoilH/2, 40*cm);
+      TGeoVolume *volCoilContainer = new TGeoVolume("volCoilContainer",CoilContainer,air);
     
       TGeoBBox *Coil = new TGeoBBox("Coil",fXtot/2, fCoilH/2, fCoilW/2);
       TGeoVolume *volCoil = new TGeoVolume("volCoil",Coil,Cu);
@@ -327,7 +332,8 @@ void NuTauMudet::ConstructGeometry()
       volUpYoke->AddNode(volCoilContainer,1,new TGeoTranslation(0,fYRyoke/2 - fCoilH/2,0)); //up
       volUpYoke->AddNode(volCoilContainer,2,new TGeoTranslation(0,-fYRyoke/2 + fCoilH/2,0)); //low
     
-      TGeoVolumeAssembly *volLowYoke = new TGeoVolumeAssembly("volLowYoke");
+      TGeoBBox *LowYokeBox = new TGeoBBox("LowYokeBox", fXRyoke/2, fYRyoke/2, fZRyoke/2);
+      TGeoVolume *volLowYoke = new TGeoVolume("volLowYoke",LowYokeBox,air);
       volMudetBox->AddNode(volLowYoke,1,new TGeoTranslation(0,-fYtot/2 + fYRyoke/2,0));
       volLowYoke->SetField(retFieldL);
    
@@ -348,7 +354,8 @@ void NuTauMudet::ConstructGeometry()
       volLowYoke->AddNode(volCoilContainer,4,new TGeoTranslation(0,-fYRyoke/2 + fCoilH/2,0)); //low
 
       Int_t ArmNumber = 1;
-      TGeoVolumeAssembly *volArm1 = new TGeoVolumeAssembly("volArm1Mudet");
+      TGeoBBox *Arm1Box = new TGeoBBox("Arm1MudetBox", fXFe/2, fYFe/2, fZArm/2);
+      TGeoVolume *volArm1 = new TGeoVolume("volArm1Mudet", Arm1Box,air);
       TGeoUniformMagField *magField1 = new TGeoUniformMagField(0.,-fField,0.); //magnetic field arm1
       volArm1->SetField(magField1);
       volMudetBox ->AddNode(volArm1,ArmNumber,new TGeoTranslation(0,0,-(fGapMiddle+fZArm)/2));
@@ -363,8 +370,10 @@ void NuTauMudet::ConstructGeometry()
 	{
 	  volArm1->AddNode(volIron,nr + 100 + i, new TGeoTranslation(0, 0, -fZArm/2+i*(fZFe +fZRpc) +fZFe/2));
 	}
-    
-      TGeoVolumeAssembly *volRpcContainer = new TGeoVolumeAssembly("volRpcContainer");
+
+   
+      TGeoBBox *RpcContainer = new TGeoBBox("RpcContainer", fXRpc/2, fYRpc/2, fZRpc/2);
+      TGeoVolume *volRpcContainer = new TGeoVolume("volRpcContainer",RpcContainer,air); 
   
       TGeoBBox *Strip = new TGeoBBox("Strip",fXStrip/2, fYStrip/2, fZStrip/2);
       TGeoVolume *volStrip = new TGeoVolume("volStrip",Strip,Cu);
@@ -396,15 +405,16 @@ void NuTauMudet::ConstructGeometry()
       ArmNumber = 2;
       nr =  ArmNumber*1E4;
 
-      TGeoVolumeAssembly *volArm2 = new TGeoVolumeAssembly("volArm2Mudet");
+      TGeoBBox *Arm2Box = new TGeoBBox("Arm2MudetBox",fXFe/2, fYFe/2, fZArm/2);
+      TGeoVolume *volArm2 = new TGeoVolume("volArm2Mudet", Arm2Box,air);
       TGeoUniformMagField *magField2 = new TGeoUniformMagField(0.,fField,0.); //magnetic field arm2
       volArm2->SetField(magField2);
       volMudetBox ->AddNode(volArm2,1,new TGeoTranslation(0,0,(fGapMiddle+fZArm)/2));
       TGeoVolume *volIron2 = new TGeoVolume("volIron2",IronLayer,Iron);
 
      //different volumes for second arm
-      
-      TGeoVolumeAssembly *volRpcContainer2 = new TGeoVolumeAssembly("volRpcContainer2");
+
+      TGeoVolume *volRpcContainer2 = new TGeoVolume("volRpcContainer2",RpcContainer,air);      
       TGeoVolume *volStrip2 = new TGeoVolume("volStrip2",Strip,Cu);
       
       volStrip2->SetLineColor(kRed);
@@ -538,7 +548,7 @@ void NuTauMudet::ConstructGeometry()
       laterallowright->RegisterYourself();
       //building composite shapes, writing compositions as TString first to improve readibility
       TString *supportaddition = new TString("MUDETTRIANGCUT+MUDETUPSUPPORT:MuDetupright+MUDETUPSUPPORT:MuDetupleft+MUDETLOWSUPPORT:MuDetlowright+MUDETLOWSUPPORT:MuDetlowleft+MUDETLATERALSUPPORT:MuDetlateralupleft+MUDETLATERALSUPPORT:MuDetlateralupright+MUDETLATERALSUPPORT:MuDetlaterallowleft+MUDETLATERALSUPPORT:MuDetlaterallowright");
-      TString *supportaddition1 = new TString("MUDETTRIANGCUT1+MUDETUPSUPPORT1:MuDetupright+MUDETUPSUPPORT1:MuDetupleft+MUDETLOWSUPPORT1:MuDetlowright+MUDETLOWSUPPORT1:MuDetlowleft+MUDETLOWSUPPORT:MuDetlowleft+MUDETLATERALSUPPORT1:MuDetlateralupleft+MUDETLATERALSUPPORT1:MuDetlateralupright+MUDETLATERALSUPPORT1:MuDetlaterallowleft+MUDETLATERALSUPPORT1:MuDetlaterallowright");
+      TString *supportaddition1 = new TString("MUDETTRIANGCUT1+MUDETUPSUPPORT1:MuDetupright+MUDETUPSUPPORT1:MuDetupleft+MUDETLOWSUPPORT1:MuDetlowright+MUDETLOWSUPPORT1:MuDetlowleft+MUDETLOWSUPPORT1:MuDetlowleft+MUDETLATERALSUPPORT1:MuDetlateralupleft+MUDETLATERALSUPPORT1:MuDetlateralupright+MUDETLATERALSUPPORT1:MuDetlaterallowleft+MUDETLATERALSUPPORT1:MuDetlaterallowright");
       TGeoCompositeShape * SupportedIronLayer = new TGeoCompositeShape("SupportedIronLayer",supportaddition->Data());
       TGeoCompositeShape * SupportedIronLayer1 = new TGeoCompositeShape("SupportedIronLayer1",supportaddition1->Data());
 
@@ -558,7 +568,8 @@ void NuTauMudet::ConstructGeometry()
           volMudetBox->AddNode(MudetIronLayer1,nr + 100 + fNFe + i, new TGeoTranslation(0, 0,dz));
 	}
       //*****************************RPC LAYERS****************************************
-      TGeoVolumeAssembly *volRpcContainer = new TGeoVolumeAssembly("volRpcContainer");
+      TGeoBBox *RpcContainer = new TGeoBBox("RpcContainer", fXRpc/2, fYRpc/2, fZRpc/2);
+      TGeoVolume *volRpcContainer = new TGeoVolume("volRpcContainer",RpcContainer,air);
   
       TGeoBBox *Strip = new TGeoBBox("Strip",fXStrip/2, fYStrip/2, fZStrip/2);
       TGeoVolume *volStrip = new TGeoVolume("volStrip",Strip,Cu);
@@ -579,8 +590,9 @@ void NuTauMudet::ConstructGeometry()
       TGeoVolume *volRpc = new TGeoVolume("volRpc",RpcGas,RPCmat);
       volRpc->SetLineColor(kCyan);
       volRpcContainer->AddNode(volRpc,1,new TGeoTranslation(0,0,0));
-       
-      TGeoVolumeAssembly *volRpcContainer1 = new TGeoVolumeAssembly("volRpcContainer1");
+
+      TGeoBBox *RpcContainer1 = new TGeoBBox("RpcContainer1", fXRpc/2+fdeltax/2, fYRpc/2+fdeltay/2, fZRpc/2);
+      TGeoVolume *volRpcContainer1 = new TGeoVolume("volRpcContainer1",RpcContainer1,air);      
   
       TGeoBBox *Strip1  = new TGeoBBox("Strip1",fXStrip/2+fdeltax/2, fYStrip/2+fdeltay/2, fZStrip/2);
       TGeoVolume *volStrip1  = new TGeoVolume("volStrip1",Strip1,Cu);

--- a/nutaudet/Target.cxx
+++ b/nutaudet/Target.cxx
@@ -360,8 +360,7 @@ void Target::ConstructGeometry()
 	MagnetVol->AddNode(volTarget,1,new TGeoTranslation(0,-fMagnetY/2+fColumnY+YDimension/2,0));
       if(fDesign==3){        
         TGeoVolume *volMagRegion=gGeoManager->GetVolume("volMagRegion");     
-        Double_t ZDimMagnetizedRegion = ((TGeoBBox*) volMagRegion->GetShape())->GetDZ() * 2.; //n.d.r. DZ is the semidimension 
-        cout<<"Test crash assembly "<<ZDimMagnetizedRegion<<endl;
+        Double_t ZDimMagnetizedRegion = ((TGeoBBox*) volMagRegion->GetShape())->GetDZ() * 2.; //n.d.r. DZ is the semidimension         
         for (int i = 0; i < fNTarget; i++){
          volMagRegion->AddNode(volTarget,i+1,new TGeoTranslation(0,0, -ZDimMagnetizedRegion/2 + ZDimension/2. + i*(ZDimension + 3 * fHpTDZ + 2* fHpTDistance)));
         }

--- a/nutaudet/Target.cxx
+++ b/nutaudet/Target.cxx
@@ -319,7 +319,6 @@ void Target::ConstructGeometry()
   InitMedium("steel");
   TGeoMedium *Steel =gGeoManager->GetMedium("steel");
 
-
   Int_t NPlates = number_of_plates; //Number of doublets emulsion + Pb
   Int_t NRohacellGap = 2;
 
@@ -450,7 +449,7 @@ void Target::ConstructGeometry()
       volCES->SetVisibility(kTRUE);
     
       TGeoBBox *RohGap = new TGeoBBox("RohGap", EmulsionX/2, EmulsionY/2, RohacellGap/2);
-      TGeoVolume *volRohGap = new TGeoVolume("RohacellGap",RohGap,rohacell);
+      TGeoVolume *volRohGap = new TGeoVolume("RohacellGap",RohGap,air); //using AIR for CES, not rohacell
       volRohGap->SetTransparency(1);
       volRohGap->SetLineColor(kYellow);
     
@@ -502,8 +501,9 @@ void Target::ConstructGeometry()
     
       volCell->AddNode(volBrick,1,new TGeoTranslation(0,0,-CellWidth/2 + BrickZ/2));
       volCell->AddNode(volCES,1,new TGeoTranslation(0,0,-CellWidth/2 + BrickZ + CESWidth/2));
-    
-      TGeoVolumeAssembly *volRow = new TGeoVolumeAssembly("Row");
+
+      TGeoBBox *Row = new TGeoBBox("row",XDimension/2, BrickY/2, CellWidth/2);
+      TGeoVolume *volRow = new TGeoVolume("Row",Row,air);
       volRow->SetLineColor(20);
     
       Double_t d_cl_x = -WallXDim/2;
@@ -513,7 +513,8 @@ void Target::ConstructGeometry()
 	  d_cl_x += BrickX;
 	}
 
-      TGeoVolumeAssembly *volWall = new TGeoVolumeAssembly("Wall");
+      TGeoBBox *Wall = new TGeoBBox("wall",XDimension/2, YDimension/2, CellWidth/2);
+      TGeoVolume *volWall = new TGeoVolume("Wall",Wall,air);
     
       Double_t d_cl_y = -WallYDim/2;
       for(int k= 0; k< fNRow; k++)
@@ -550,8 +551,8 @@ void Target::ConstructGeometry()
     
       tTauNuDet->AddNode(volTarget,1,new TGeoTranslation(0,0,fCenterZ));
 	
-   
-      TGeoVolumeAssembly *volRow = new TGeoVolumeAssembly("Row");
+      TGeoBBox *Row = new TGeoBBox("row",XDimension/2, BrickY/2, CellWidth/2);
+      TGeoVolume *volRow = new TGeoVolume("Row",Row,air);
       volRow->SetLineColor(20);
     
       Double_t d_cl_x = -WallXDim/2;
@@ -560,7 +561,8 @@ void Target::ConstructGeometry()
 	  volRow->AddNode(volBrick,j,new TGeoTranslation(d_cl_x+BrickX/2, 0, 0));
 	  d_cl_x += BrickX;
 	}
-      TGeoVolumeAssembly *volWall = new TGeoVolumeAssembly("Wall");
+      TGeoBBox *Wall = new TGeoBBox("wall",XDimension/2, YDimension/2, BrickZ/2);
+      TGeoVolume *volWall = new TGeoVolume("Wall",Wall,air);
     
       Double_t d_cl_y = -WallYDim/2;
       for(int k= 0; k< fNRow; k++)


### PR DESCRIPTION
Dear all,

I have recently replaced too many volumes with TGeoVolumeAssemblies. This can cause issues since, even if a volume is not the final daughter, it may be involved in the determination of the DetectorID (see for example what happens in the ProcessHits of NuTauMudet.cxx). I have noticed that if the called volumes is not a real volume, but rather an assembly one, the computation of the DetectorID is spoiled.

Therefore, to avoid further issues, I have replaced most of them with TGeoVolumes, using 'air' as medium. I have kept as TGeoVolumeAssembly only the mother box of each detector.

I am available for any question or suggestion.

Best regards,
Antonio Iuliano