### PR TITLE
Fixing typo in variable phiRandom from Argument Parser

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -428,7 +428,7 @@ if simEngine == "MuonBack":
  primGen.AddGenerator(MuonBackgen)
  options.nEvents = min(options.nEvents,MuonBackgen.GetNevents())
  MCTracksWithHitsOnly = True # otherwise, output file becomes too big
- print('Process ',options.nEvents,' from input file, with Phi random=',phiRandom, ' with MCTracksWithHitsOnly',MCTracksWithHitsOnly)
+ print('Process ',options.nEvents,' from input file, with Phi random=',options.phiRandom, ' with MCTracksWithHitsOnly',MCTracksWithHitsOnly)
  if options.followMuon :  
     options.fastMuon = True
     modules['Veto'].SetFollowMuon()


### PR DESCRIPTION
Dear all,

today I noticed that I could not launch the muonBackground simulation (#301), because run_simScript.py ask for not defined variable phiRandom in a printout. 

The corresponding variable, extracted from Argument Parser and used in the MuonBackground generator initialization, is options.phiRandom.

So I have fixed the print message.

Best Regards,
Antonio Iuliano