### PR TITLE
FairLogger python interface (version 1)

### DIFF
--- a/python/logger.py
+++ b/python/logger.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import os
+import ROOT
+# TODO: add header to CMake
+ROOT.gROOT.ProcessLine('#include "' + os.path.join(os.path.expandvars('$FAIRSHIP'), 'utils', 'logger.hxx') + '"')
+
+for func in ('fatal', 'error', 'warn', 'info', 'debug'):
+    # The double lambda is used in order to capture 'func' by value, not by reference
+    # (which would always point to the last value taken in the loop)
+    globals()[func] = (lambda f:
+        lambda *args: ROOT.ship.__dict__[f](*map(type, args))(*args)
+    )(func)
+    globals()[func].__doc__ = \
+        'Python wrapper around the C++ function template ship::{}(Types... args).'.format(func)

--- a/utils/logger.hxx
+++ b/utils/logger.hxx
@@ -1,0 +1,53 @@
+#include "fairlogger/Logger.h"
+
+namespace ship {
+
+template <fair::Severity severity, class T>
+void log(T arg)
+{
+   for (bool fairLOggerunLikelyvariable = false; fair::Logger::Logging(severity) && !fairLOggerunLikelyvariable;
+        fairLOggerunLikelyvariable = true)
+      fair::Logger(severity, __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__).Log() << arg;
+}
+
+template <fair::Severity severity, class T, class... Types>
+void log(T arg, Types... args)
+{
+   log<severity>(arg);
+   log<severity>(args...);
+}
+
+template <class T>
+void log(T arg)
+{
+   constexpr fair::Severity severity = fair::Severity::INFO;
+   for (bool fairLOggerunLikelyvariable = false; fair::Logger::Logging(severity) && !fairLOggerunLikelyvariable;
+        fairLOggerunLikelyvariable = true)
+      fair::Logger(severity, __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__).Log() << arg;
+}
+
+template <class... Types>
+void warn(Types &&... args)
+{
+   log<fair::Severity::warning>(std::forward<Types>(args)...);
+}
+
+template <class... Types>
+void debug(Types &&... args)
+{
+   log<fair::Severity::debug>(std::forward<Types>(args)...);
+}
+
+template <class... Types>
+void fatal(Types &&... args)
+{
+   log<fair::Severity::fatal>(std::forward<Types>(args)...);
+}
+
+template <class... Types>
+void log(Types &&... args)
+{
+   log<fair::Severity::info>(std::forward<Types>(args)...);
+}
+
+} // namespace ship

--- a/utils/logger.hxx
+++ b/utils/logger.hxx
@@ -1,53 +1,51 @@
-#include "fairlogger/Logger.h"
+#include "FairLogger.h"
+#pragma once
 
 namespace ship {
 
 template <fair::Severity severity, class T>
 void log(T arg)
 {
-   for (bool fairLOggerunLikelyvariable = false; fair::Logger::Logging(severity) && !fairLOggerunLikelyvariable;
-        fairLOggerunLikelyvariable = true)
-      fair::Logger(severity, __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__).Log() << arg;
+    if (fair::Logger::Logging(severity)) {
+        fair::Logger(severity, __FILE__, to_string(__LINE__), __FUNCTION__).Log() << arg;
+    }
 }
 
 template <fair::Severity severity, class T, class... Types>
 void log(T arg, Types... args)
 {
-   log<severity>(arg);
-   log<severity>(args...);
-}
-
-template <class T>
-void log(T arg)
-{
-   constexpr fair::Severity severity = fair::Severity::INFO;
-   for (bool fairLOggerunLikelyvariable = false; fair::Logger::Logging(severity) && !fairLOggerunLikelyvariable;
-        fairLOggerunLikelyvariable = true)
-      fair::Logger(severity, __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__).Log() << arg;
+    log<severity>(arg);
+    log<severity>(args...);
 }
 
 template <class... Types>
-void warn(Types &&... args)
+void fatal(Types... args)
 {
-   log<fair::Severity::warning>(std::forward<Types>(args)...);
+    log<fair::Severity::fatal>(args...);
 }
 
 template <class... Types>
-void debug(Types &&... args)
+void error(Types... args)
 {
-   log<fair::Severity::debug>(std::forward<Types>(args)...);
+    log<fair::Severity::error>(args...);
 }
 
 template <class... Types>
-void fatal(Types &&... args)
+void warn(Types... args)
 {
-   log<fair::Severity::fatal>(std::forward<Types>(args)...);
+    log<fair::Severity::warning>(args...);
 }
 
 template <class... Types>
-void log(Types &&... args)
+void info(Types... args)
 {
-   log<fair::Severity::info>(std::forward<Types>(args)...);
+    log<fair::Severity::info>(args...);
+}
+
+template <class... Types>
+void debug(Types... args)
+{
+    log<fair::Severity::debug>(args...);
 }
 
 } // namespace ship


### PR DESCRIPTION
Up to now it was not possible to use FairLogger for logging in python, resulting in us using `print` statements for logging in python and FairLogger in C++.

This pull request adds an interface to FairLogger for python (2 or 3), which can be used as follows:
```python
from logger import info, warn, error, debug
warn("test") # > [WARN] test
error(5) # > [ERROR] 5
info("test") # > [INFO] test
debug(42) # is not printed by default
```
The name of the module could be easily changed to something else (e.g. `shiplog`).

Current limitations of this first version (to be fixed in future):
* Currently if several arguments are passed, they are printed on separate lines.
* Types not understood by PyROOT or not printable in C++ might not work (in that case, we recommend logging a pre-formatted string.
* There are some opportunities for optimisation and clean-up in python and the C++ code.
* The C++ header is not integrated with CMake yet.
* When experimental PyROOT becomes stable, this should become much simpler and more powerful!

For most use-cases the interface should however be already sufficient.

This pull request is one of the results of the Starter Kit hackathon (hopefully the first of many to come!), and is mainly the work of @JLTastet .

We will probably port e.g. `run_simScript.py` to use this interface as an example, including to show how the log-level can be modified.