### PR TITLE
FairLogger python interface (version 2)

### DIFF
--- a/python/logger.py
+++ b/python/logger.py
@@ -5,11 +5,25 @@ import ROOT
 # TODO: add header to CMake
 ROOT.gROOT.ProcessLine('#include "' + os.path.join(os.path.expandvars('$FAIRSHIP'), 'utils', 'logger.hxx') + '"')
 
-for func in ('fatal', 'error', 'warn', 'info', 'debug'):
-    # The double lambda is used in order to capture 'func' by value, not by reference
-    # (which would always point to the last value taken in the loop)
-    globals()[func] = (lambda f:
-        lambda *args: ROOT.ship.__dict__[f](*map(type, args))(*args)
-    )(func)
-    globals()[func].__doc__ = \
-        'Python wrapper around the C++ function template ship::{}(Types... args).'.format(func)
+def _make_wrapper(funcname):
+    def function(*args, **kwargs):
+        delim = kwargs.get('delim', ' ')
+        # Interleaves arguments with delimiters. No delimiter at the end.
+        args_with_delim = [val for pair in zip(args, len(args)*[delim]) for val in pair][:-1]
+        return ROOT.ship.__dict__[funcname](*map(type, args_with_delim))(*args_with_delim)
+    docstring = '''\
+    Python wrapper around the C++ function template ship::{}(Types... args).
+
+    Keyword arguments:
+    delim -- delimiter to be inserted between each argument (default \' \')
+    '''.format(funcname)
+    return function, docstring
+
+def _add_wrappers():
+    # This function is used to avoid polluting the global namespace
+    for funcname in ('fatal', 'error', 'warn', 'info', 'debug'):
+        function, docstring = _make_wrapper(funcname)
+        globals()[funcname] = function
+        globals()[funcname].__doc__ = docstring
+
+_add_wrappers()

--- a/utils/logger.hxx
+++ b/utils/logger.hxx
@@ -3,19 +3,30 @@
 
 namespace ship {
 
+namespace details {
+
 template <fair::Severity severity, class T>
-void log(T arg)
+void log(fair::Logger& logger, T arg)
 {
     if (fair::Logger::Logging(severity)) {
-        fair::Logger(severity, __FILE__, to_string(__LINE__), __FUNCTION__).Log() << arg;
+        logger << arg;
     }
 }
 
 template <fair::Severity severity, class T, class... Types>
-void log(T arg, Types... args)
+void log(fair::Logger& logger, T arg, Types... args)
 {
-    log<severity>(arg);
-    log<severity>(args...);
+    log<severity>(logger, arg);
+    log<severity>(logger, args...);
+}
+
+}
+
+template <fair::Severity severity, class... Types>
+void log(Types... args)
+{
+    fair::Logger logger(severity, __FILE__, to_string(__LINE__), __FUNCTION__);
+    details::log<severity>(logger.Log(), args...);
 }
 
 template <class... Types>

--- a/utils/logger.hxx
+++ b/utils/logger.hxx
@@ -1,5 +1,5 @@
-#include "FairLogger.h"
 #pragma once
+#include "FairLogger.h"
 
 namespace ship {
 


### PR DESCRIPTION
Quote @JLTastet:

I have added a `delim` keyword argument to the Python wrappers. It did not require modifying the C++ code at all, and its behaviour now matches that of the `print()` function.

**Typical usage:**
```python
>>> from logger import *
>>> error(1, 2, "Test", 3.14159)
# [ERROR] 1 2 Test 3.14159
>>> error(1, 2, "Test", 3.14159, delim='')
# [ERROR] 12Test3.14159
>>> error(1, 2, "Test", 3.14159, delim=' | ')
# [ERROR] 1 | 2 | Test | 3.14159
```
```
>>> help(error)
Help on function function in module logger:

function(*args, **kwargs)
    Python wrapper around the C++ function template ship::error(Types... args).
    
    Keyword arguments:
    delim -- delimiter to be inserted between each argument (default ' ')
```

_Originally posted by @JLTastet in https://github.com/ShipSoft/FairShip/pull/303#issuecomment-546626450_