### PR TITLE
Fix ROOT hijacking our --help

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -5,6 +5,9 @@ import os
 import sys
 import getopt
 import ROOT
+# Fix https://root-forum.cern.ch/t/pyroot-hijacks-help/15207 :
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
 import shipunit as u
 import shipRoot_conf
 import rootUtils as ut


### PR DESCRIPTION
Currently when running `run_simScript.py --help` the following is shown:
```
usage: root [-b B] [-x X] [-e E] [-n N] [-t T] [-q Q] [-l L] [-config CONFIG]
            [-memstat MEMSTAT] [-h HELP] [--version VERSION]
            [--notebook NOTEBOOK] [--web WEB] [--web=<browser> WEB=<BROWSER>]
            [dir] [file:data.root] [file1.C...fileN.C]

OPTIONS:
  -b                             Run in batch mode without graphics
  -x                             Exit on exceptions
  -e                             Execute the command passed between single quotes
  -n                             Do not execute logon and logoff macros as specified in .rootrc
  -t                             Enable thread-safety and implicit multi-threading (IMT)
  -q                             Exit after processing command line macro files
  -l                             Do not show splash screen
  -config                        print ./configure options
  -memstat                       run with memory usage monitoring
  -h, -?, --help                 Show summary of options
  --version                      Show the ROOT version
  --notebook                     Execute ROOT notebook
  --web                          Display graphics in a default web browser
  --web=<browser>                Display graphics in specified web browser
  [dir]                          if dir is a valid directory cd to it before executing
  [file:data.root]               Open the ROOT file data.root
  [file1.C...fileN.C]            Execute the the ROOT macro file1.C ... fileN.C
```

This PR fixes this such that `run_simScript.py --help` displays the following:
```
usage: run_simScript.py [-h] [--Pythia6] [--Pythia8] [--PG] [--pID PID]
                        [--Estart ESTART] [--Eend EEND] [-A A] [--Genie]
                        [--NuRadio] [--Ntuple] [--MuonBack] [--FollowMuon]
                        [--FastMuon] [--Nuage] [--phiRandom]
                        [--Cosmics COSMICS] [--MuDIS] [--RpvSusy]
                        [--DarkPhoton] [--SusyBench RPVSUSYBENCH] [-m THEMASS]
                        [-c THECOUPLINGS] [-cp THEPRODCOUPLINGS]
                        [-cd THEDECCOUPLINGS] [-e THEDPEPSILON] [-n NEVENTS]
                        [-i FIRSTEVENT] [-s THESEED] [-S SAMESEED]
                        [-f INPUTFILE] [-g GEOFILE] [-o OUTPUTDIR] [-Y DY]
                        [--tankDesign DV] [--muShieldDesign DS]
                        [--nuTauTargetDesign NUD] [--caloDesign CALODESIGN]
                        [--strawDesign STRAWDESIGN] [--Muflux] [--charm CHARM]
                        [--CharmdetSetup CHARMDETSETUP]
                        [--CharmTarget CHARMTARGET] [-F] [-t] [--dry-run] [-D]

optional arguments:
  -h, --help            show this help message and exit
  --Pythia6             Use Pythia6
  --Pythia8             Use Pythia8
  --PG                  Use Particle Gun
  --pID PID             id of particle used by the gun (default=22)
  --Estart ESTART       start of energy range of particle gun for muflux
                        detector (default=10 GeV)
  --Eend EEND           end of energy range of particle gun for muflux
                        detector (default=10 GeV)
  -A A                  b: signal from b, c: from c (default), bc: from Bc, or
                        inclusive
  --Genie               Genie for reading and processing neutrino interactions
  --NuRadio             misuse GenieGenerator for neutrino radiography and
                        geometry timing test
  --Ntuple              Use ntuple as input
  --MuonBack            Generate events from muon background file, --Cosmics=0
                        for cosmic generator data
  --FollowMuon          Make muonshield active to follow muons
  --FastMuon            Only transport muons for a fast muon only background
                        estimate
  --Nuage               Use Nuage, neutrino generator of OPERA
  --phiRandom           only relevant for muon background generator, random
                        phi
  --Cosmics COSMICS     Use cosmic generator, argument switch for cosmic
                        generator 0 or 1
  --MuDIS               Use muon deep inelastic scattering generator
  --RpvSusy             Generate events based on RPV neutralino
  --DarkPhoton          Generate dark photons
  --SusyBench RPVSUSYBENCH
                        Generate HP Susy
  -m THEMASS, --mass THEMASS
                        Mass of hidden particle, default 1.0GeV for HNL,
                        0.2GeV for DP
  -c THECOUPLINGS, --couplings THECOUPLINGS, --coupling THECOUPLINGS
                        couplings 'U2e,U2mu,U2tau' or -c 'U2e,U2mu,U2tau' to
                        set list of HNL couplings. TP default for HNL,
                        ctau=53.3km
  -cp THEPRODCOUPLINGS, --production-couplings THEPRODCOUPLINGS
                        production couplings 'U2e,U2mu,U2tau' to set the
                        couplings for HNL production only
  -cd THEDECCOUPLINGS, --decay-couplings THEDECCOUPLINGS
                        decay couplings 'U2e,U2mu,U2tau' to set the couplings
                        for HNL decay only
  -e THEDPEPSILON, --epsilon THEDPEPSILON
                        to set mixing parameter epsilon
  -n NEVENTS, --nEvents NEVENTS
                        Number of events to generate
  -i FIRSTEVENT, --firstEvent FIRSTEVENT
                        First event of input file to use
  -s THESEED, --seed THESEED
                        Seed for random number. Only for experts, see
                        TRrandom::SetSeed documentation
  -S SAMESEED, --sameSeed SAMESEED
                        can be set to an integer for the muonBackground
                        simulation with specific seed for each muon, only for
                        experts!
  -f INPUTFILE          Input file if not default file
  -g GEOFILE            geofile for muon shield geometry, for experts only
  -o OUTPUTDIR, --output OUTPUTDIR
                        Output directory
  -Y DY                 max height of vacuum tank
  --tankDesign DV       4=TP elliptical tank design, 5 = optimized conical
                        rectangular design, 6=5 without segment-1
  --muShieldDesign DS   5=TP muon shield, 6=magnetized hadron, 7=short magnet
                        design, 9=optimised with T4 as constraint, 8=requires
                        config file ,10=with field map for hadron absorber
  --nuTauTargetDesign NUD
                        0=TP, 1=new magnet option for short muon shield, 2= no
                        magnet surrounding neutrino detector
  --caloDesign CALODESIGN
                        0=ECAL/HCAL TP 1=ECAL/HCAL TP + preshower 2=splitCal
                        3=ECAL/ passive HCAL
  --strawDesign STRAWDESIGN
                        simplistic tracker design, 4=sophisticated straw tube
                        design, horizontal wires (default), 10=2cm straw
  --Muflux              Muflux fixed target setup
  --charm CHARM         !=0 create charm detector instead of SHiP
  --CharmdetSetup CHARMDETSETUP
                        1 charm cross section setup, 0 muon flux setup
  --CharmTarget CHARMTARGET
                        six different configurations used in July 2018
                        exposure for charm
  -F                    default = False: copy only stable particles to stack,
                        except for HNL events
  -t, --test            quick test
  --dry-run             stop after initialize
  -D, --display         store trajectories
```


This is a "feature" of PyROOT, which defaults to this behaviour. Luckily it can be disables by changing a ROOT config variable. In future it will change the default behaviour to not hijack our `--help`.

Until then, we'll unfortunately need to add the magic config line to each of our files using `argparse`.