### PR TITLE
Import unpack.py into FairShip to unpack muflux and charm data

### DIFF
--- a/macro/testbeam_unpack.py
+++ b/macro/testbeam_unpack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import argparse
 import ROOT
 

--- a/macro/unpack.py
+++ b/macro/unpack.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python2
+import argparse
+import ROOT
+
+# Fix https://root-forum.cern.ch/t/pyroot-hijacks-help/15207 :
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+
+def main():
+    source = ROOT.ShipTdcSource(args.input)
+
+    source.AddUnpacker(0xc00, ROOT.DriftTubeUnpack(args.charm))
+    source.AddUnpacker(0xb00, ROOT.RPCUnpack())
+    source.AddUnpacker(0x8100, ROOT.ScalerUnpack())
+
+    if args.charm:
+        pixelUnpack = ROOT.PixelUnpack(0x800)
+        source.AddUnpacker(0x800, pixelUnpack)
+        source.AddUnpacker(0x801, pixelUnpack)
+        source.AddUnpacker(0x802, pixelUnpack)
+        source.AddUnpacker(0x900, ROOT.SciFiUnpack(0x900))
+
+    run = ROOT.FairRunOnline(source)
+    run.SetOutputFile(args.output)
+    run.SetAutoFinish(True)
+    run.SetRunId(args.run)
+
+    run.Init()
+
+    run.Run(-1, 0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-f", "--input", required=True, help="Input file (can be on EOS)"
+    )
+    parser.add_argument("-o", "--output", required=True, help="Output file")
+    parser.add_argument("-n", "--run", default=0, type=int, help="Run number")
+    parser.add_argument(
+        "--charm", action="store_true", help="Unpack charm data (default: muon flux)"
+    )
+    args = parser.parse_args()
+    ROOT.gROOT.SetBatch(True)
+    main()


### PR DESCRIPTION
Now that it is stable and rarely changes, it's probably worth including this script in FairShip proper (previously it was in a separate repository), so that FairShip can unpack the data out of the box.

Once this is merged the script will be removed from the `muon_flux_online` repository.

FYI: @antonioiuliano2 @owtscharenko 