### PR TITLE
WIP: Adding instructions for local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ However, this won't work if you are using HTCondor. In such case you can do:
 eval alienv load FairShip/latest
 ```
 
+## Local build, without access to CVMFS
+Commands are similar to the previous case, but without access to CVMFS you need to build the required packages.
+1. Download the FairShip software
+    ```bash
+    git clone https://github.com/ShipSoft/FairShip.git
+    ```
+2. Build the software using aliBuild
+    ```bash
+    FairShip/aliBuild.sh
+    ```
+3. Load the environment
+    ```bash
+    alibuild/alienv enter FairShip/latest
+    ```
+    
 ## Docker Instructions
 1. Build an docker image from a Dockerfile:
     ```bash

--- a/system/install_on_ubuntu.sh
+++ b/system/install_on_ubuntu.sh
@@ -1,15 +1,15 @@
-# installation on blank Ubuntu 17.10: 
-# FROM ubuntu:17.10
+# installation on blank Ubuntu 18.04 LTS:
+# FROM ubuntu:18.04
 sudo apt-get update 
-sudo apt-get install python-dev python-pip make patch sed git-all gedit environment-modules \
+sudo apt-get install python3-dev python3-pip make patch sed git-all gedit environment-modules \
    libx11-dev libxpm-dev libxext-dev ncurses-dev libxml2-dev libxft-dev \
    libxmu-dev  ncurses-dev  curl bzip2  libbz2-dev gzip unzip tar gfortran libkrb5-dev \
     wget automake autoconf libtool bison  flex byacc libgif-dev libjpeg-dev libtiff5-dev\
    libexpat1-dev libcurl4-openssl-dev libssl-dev libbz2-dev libbz2-dev libglu1-mesa libglu1-mesa-dev\
    autopoint texinfo gettext libtool libtool-bin pkg-config python-tk cmake linuxbrew-wrapper 
 
-sudo pip install --upgrade pip
-sudo pip install matplotlib numpy scipy certifi ipython ipywidgets ipykernel notebook metakernel pyyaml
+sudo pip3 install --upgrade pip
+sudo pip3 install matplotlib numpy scipy certifi ipython ipywidgets ipykernel notebook metakernel pyyaml sklearn
 
 # sudo apt-get krb5-user
 # for kinit: cp from lxplus /etc/krb5.conf


### PR DESCRIPTION
Dear all,

I have noticed that the current version of README does not contains information about how to build locally the FairShip software.

I have added the essential commands, but I would require your assistance on two points:

1) It is usually recommended to use only 1 core for installation, because compiling ROOT often leads to crash for lack of memory. Shall we modify aliBuild.sh accordingly, or leave it to the user?

2) To help with the first phase, shall we insert a list of pre-requisites? I know that aliDoctor tells the user which packages he needs to install, but it might be helpful to have an initial list of packages to install before launching aliBuild, similarly as it is done by the ALICE group:

https://alice-doc.github.io/alice-analysis-tutorial/building/prereq-ubuntu.html

Best regards,
Antonio