### PR TITLE
Catching a genfit::Exception in track extrapolation

### DIFF
--- a/charmdet/MufluxReco.cxx
+++ b/charmdet/MufluxReco.cxx
@@ -491,6 +491,7 @@ Double_t MufluxReco::extrapolateToPlane(genfit::Track* fT, Float_t z, TVector3& 
 						mClose = m;
 					}
 				} catch (const genfit::Exception& e) {
+					//TODO maybe instead of aborting extrapolate from any other point?
 					std::cerr
 							<< "MufluxReco::extrapolateToPlane failed to find closest hit to z = "
 							<< z << ". Aborting extrapolation." << std::endl;
@@ -506,12 +507,13 @@ Double_t MufluxReco::extrapolateToPlane(genfit::Track* fT, Float_t z, TVector3& 
 				genfit::RKTrackRep* rep = new genfit::RKTrackRep(pdgcode);
 				genfit::StateOnPlane* state = new genfit::StateOnPlane(rep);
 				rep->setPosMom(*state, Pos, Mom);
-				rc = rep->extrapolateToPlane(*state, m_new_position,
-						m_parallelToZ);
+				rc = rep->extrapolateToPlane(*state, m_new_position, m_parallelToZ);
 				pos = state->getPos();
 				mom = state->getMom();
 				delete rep;
 				delete state;
+				//TODO check: isn't the extrapolation already done now? If so:
+				//return rc
 			} catch (const genfit::Exception& e) {
 				std::cerr
 						<< "MufluxReco::extrapolateToPlane failed to extrapolate to hit #"

--- a/charmdet/MufluxReco.cxx
+++ b/charmdet/MufluxReco.cxx
@@ -507,6 +507,7 @@ Double_t MufluxReco::extrapolateToPlane(genfit::Track* fT, Float_t z, TVector3& 
 				genfit::RKTrackRep* rep = new genfit::RKTrackRep(pdgcode);
 				genfit::StateOnPlane* state = new genfit::StateOnPlane(rep);
 				rep->setPosMom(*state, Pos, Mom);
+				m_new_position.SetXYZ(0., 0., z);
 				rc = rep->extrapolateToPlane(*state, m_new_position, m_parallelToZ);
 				pos = state->getPos();
 				mom = state->getMom();

--- a/charmdet/MufluxReco.h
+++ b/charmdet/MufluxReco.h
@@ -56,7 +56,11 @@ public:
    TVector3 findMCMomentum(int mctr);
 
 private:
-  protected:
+   //two vectors often needed, only helpers so that they don't need to be recreated everytime they are needed
+   TVector3 m_new_position;
+   const TVector3 m_parallelToZ;
+
+protected:
     Bool_t MCdata;
     TTreeReader* xSHiP;
     std::vector<int> noisyChannels;


### PR DESCRIPTION
# Related issue
This PR is related to issue #316.

# Applied changes
In this PR three tings are changed: 

1. In all cases where an unhandled genfit::Exception can be thrown it is now handled. This could in general happen in four cases. The first three are very unlikely (in fact should only happen if the fit didn't converge which should be realized before extrapolating a passed track) and should not happen. The last case is only handled differently where the cardinal track representation is extrapolated in case of an exception.
2. Two variables (both TVector3) were declared as global heap veriables which might be a security risk and might lead to unforeseeable behavior of the program. Made them private member variables of the class MufluxReco. This way, they don't need to be re-allocated everytime the method ```extrapolateToPlane(Double_t MufluxReco::extrapolateToPlane(genfit::Track* fT, Float_t z, TVector3& pos, TVector3& mom)``` is called and they are now encapsulated in the ```MufluxReco namespace```.
3. Probably most important change: Removed an ```if``` check that was labelled to be there because it is more stable against crashes. Removing this leads to residuals changing in the sub micron range but has a performance increase (for my tests between 5% and 20%). Need to discuss if we want to keep this. For more info see the comment in the issue: https://github.com/ShipSoft/FairShip/issues/316#issuecomment-554358758