### PR TITLE
Removing dummy surrounding planes from nutaudet

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -742,8 +742,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.tauHPT.ConcreteX = c.tauHPT.DX
         c.tauHPT.ConcreteY = c.tauMudet.Ytot/2 - c.tauHPT.DY/2
         c.tauHPT.ConcreteZ = c.tauHPT.DZ
-    if nuTauTargetDesign==3:
-        c.tauHPT.SRDY = 10 * u.cm  #additional detectors for improving acceptance
+    if nuTauTargetDesign==3:        
         c.tauHPT.DX = c.tauHPT.TX
         c.tauHPT.DY = c.tauHPT.TY
         c.tauHPT.DZ = c.tauHPT.TZ

--- a/nutaudet/HPT.cxx
+++ b/nutaudet/HPT.cxx
@@ -383,12 +383,6 @@ void Hpt::Register()
 // -----   returns hpt, arm, rpc numbers -----------------------------------
 void Hpt::DecodeVolumeID(Int_t detID,int &nHPT, int &nplane, Bool_t &ishor)
 {
-  if (detID < 1000){ //temporary surrounding stations
-    ishor = 0;
-    nHPT = 0;
-    nplane = detID/100;
-  }
-  else{ //DT stations
    nHPT = detID/1000;
    int idir = (detID - nHPT*1000)/100;
 
@@ -396,7 +390,7 @@ void Hpt::DecodeVolumeID(Int_t detID,int &nHPT, int &nplane, Bool_t &ishor)
    else if (idir == 0) ishor = kTRUE;
 
    nplane = (detID - nHPT*1000 - idir*100);
-  }
+  
 
 }
 

--- a/nutaudet/HPT.cxx
+++ b/nutaudet/HPT.cxx
@@ -124,6 +124,10 @@ void Hpt::SetDesign(Int_t Design)
   fDesign = Design;
 }
 
+void Hpt::SetSurroundingDetHeight(Double_t height)
+{ 
+ fSRHeight = height;
+}
 
 void Hpt::GetMagnetGeometry(Double_t EmuzC, Double_t EmuY)
 {

--- a/nutaudet/HPT.cxx
+++ b/nutaudet/HPT.cxx
@@ -124,10 +124,6 @@ void Hpt::SetDesign(Int_t Design)
   fDesign = Design;
 }
 
-void Hpt::SetSurroundingDetHeight(Double_t height)
-{ 
- fSRHeight = height;
-}
 
 void Hpt::GetMagnetGeometry(Double_t EmuzC, Double_t EmuY)
 {
@@ -245,23 +241,7 @@ void Hpt::ConstructGeometry()
         TGeoBBox *DT = new TGeoBBox("DT", DimX/2, DimY/2, DimZ/2);
         TGeoVolume *volDT = new TGeoVolume("volDT",DT,HPTmat); 
         volDT->SetLineColor(kBlue-5);
-
-        //The internal size is smaller, so the surrounding detector is divided into two parts  
-        TGeoBBox *SurroundingdetOuter = new TGeoBBox("SurroundingdetOuter",DXMagnetizedRegion/2., fSRHeight/2, DZMagnetizedRegion/2.);
-        TGeoVolume *volSurroundingdetOuter = new TGeoVolume("volSurroundingdetOuter",SurroundingdetOuter, HPTmat);
-        AddSensitiveVolume(volSurroundingdetOuter);
-        volSurroundingdetOuter->SetLineColor(kBlue);
-        tTauNuDet->AddNode(volSurroundingdetOuter,100, new TGeoTranslation(0,+fmagnety/2+fSRHeight/2, fmagnetcenter));
-        tTauNuDet->AddNode(volSurroundingdetOuter,400, new TGeoTranslation(0,-fmagnety/2-fSRHeight/2, fmagnetcenter));
-
-        Double_t SRInnerHeight = DYMagnetizedRegion / 2 - HPTrackerY / 2;
-        TGeoBBox *SurroundingdetInner = new TGeoBBox("SurroundingdetInner",DXMagnetizedRegion/2., SRInnerHeight/2, DZMagnetizedRegion/2.);
-        TGeoVolume *volSurroundingdetInner = new TGeoVolume("volSurroundingdetInner",SurroundingdetInner, HPTmat);
-        AddSensitiveVolume(volSurroundingdetInner);
-        volSurroundingdetInner->SetLineColor(kBlue);
-        volMagRegion->AddNode(volSurroundingdetInner, 200, new TGeoTranslation(0.,+DYMagnetizedRegion/2-SRInnerHeight/2,0.));
-        volMagRegion->AddNode(volSurroundingdetInner, 300, new TGeoTranslation(0.,-DYMagnetizedRegion/2+SRInnerHeight/2,0.));
-
+        
         // Creating of SciFi modules in HPT   
         InitMedium("CarbonComposite");
         TGeoMedium *CarbonComposite = gGeoManager->GetMedium("CarbonComposite");

--- a/nutaudet/HPT.h
+++ b/nutaudet/HPT.h
@@ -35,6 +35,7 @@ class Hpt:public FairDetector
     //methods for design 3 
     void SetDistanceHPTs(Double_t dd);       
     void SetHPTNumber(Int_t nHPT);
+    void SetSurroundingDetHeight(Double_t height);
     void GetMagnetGeometry(Double_t EmuzC, Double_t EmuY);
     void GetNumberofTargets(Int_t ntarget);
     //
@@ -111,6 +112,7 @@ protected:
     Double_t fConcreteY;
     Double_t fConcreteZ;
 
+    Double_t fSRHeight;
     Double_t fDesign;
     Double_t fDistance;
     Int_t fnHPT;
@@ -135,7 +137,7 @@ protected:
 
     Hpt(const Hpt&);
     Hpt& operator=(const Hpt&);
-    ClassDef(Hpt,6)
+    ClassDef(Hpt,5)
 
 };
 #endif 

--- a/nutaudet/HPT.h
+++ b/nutaudet/HPT.h
@@ -35,7 +35,6 @@ class Hpt:public FairDetector
     //methods for design 3 
     void SetDistanceHPTs(Double_t dd);       
     void SetHPTNumber(Int_t nHPT);
-    void SetSurroundingDetHeight(Double_t height);
     void GetMagnetGeometry(Double_t EmuzC, Double_t EmuY);
     void GetNumberofTargets(Int_t ntarget);
     //
@@ -112,7 +111,6 @@ protected:
     Double_t fConcreteY;
     Double_t fConcreteZ;
 
-    Double_t fSRHeight;
     Double_t fDesign;
     Double_t fDistance;
     Int_t fnHPT;
@@ -137,7 +135,7 @@ protected:
 
     Hpt(const Hpt&);
     Hpt& operator=(const Hpt&);
-    ClassDef(Hpt,5)
+    ClassDef(Hpt,6)
 
 };
 #endif 

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -310,7 +310,8 @@ def configure(run,ship_geo):
    if ship_geo.nuTauTargetDesign==3:
     tauHpt.SetHPTNumber(ship_geo.tauHPT.nHPT)
     tauHpt.SetDistanceHPTs(ship_geo.tauHPT.distHPT)
-    tauHpt.SetSurroundingDetHeight(ship_geo.tauHPT.SRDY)
+    if hasattr(ship_geo.tauHPT, "SRDY"):
+     tauHpt.SetSurroundingDetHeight(ship_geo.tauHPT.SRDY)
     tauHpt.GetMagnetGeometry(ship_geo.EmuMagnet.zC, ship_geo.EmuMagnet.Y)
     tauHpt.GetNumberofTargets(ship_geo.NuTauTarget.target)
    detectorList.append(tauHpt)


### PR DESCRIPTION
Dear all,

this commit removes the additional surrounding sensitive volumes which were used to test the detector's acceptance, and do not correspond to any physical detector.

The methods which set their dimensions are kept as usual, to preserve backward compatibility.

Please let me know if you have any comment.

Best regards,
Antonio Iuliano