### PR TITLE
Fix pixel positions

### DIFF
--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -124,42 +124,25 @@ void PixelModules::SetSiliconStationAngles(Int_t nstation, Double_t anglex, Doub
  zangle[nstation] = anglez;
 }
 
-void PixelModules::SetSiliconSlicesNumber(Int_t nSl){
-	nSlices=nSl;
-        if(nSlices==1){
-		nSi=nSi1;
-	}
-	else if(nSlices=10){
-	nSi=nSi10;
-	}
+void PixelModules::SetSiliconSlicesNumber(Int_t nSl)
+{
+   nSlices = nSl;
+   nSi = nSlices * 12;
 }
 
-Double_t *PixelModules::GetPosSize1(){
-	return new Double_t[nSi1];
+Double_t *PixelModules::GetPosSize(Int_t n)
+{
+   return new Double_t[n];
 }
 
-Double_t *PixelModules::GetPosSize10(){
-	return new Double_t[nSi10];
-}
-
-void PixelModules::SetPositionSize(){
-	if(nSlices==1){
-		xs=GetPosSize1();
-		ys=GetPosSize1();
-		zs=GetPosSize1();
-		xangle=GetPosSize1();
-		yangle=GetPosSize1();
-		zangle=GetPosSize1();
-	}
-	else if(nSlices==10){
-		xs=GetPosSize10();
-		ys=GetPosSize10();
-		zs=GetPosSize10();
-		xangle=GetPosSize10();
-		yangle=GetPosSize10();
-		zangle=GetPosSize10();
-		
-	}
+void PixelModules::SetPositionSize()
+{
+   xs = GetPosSize(nSi);
+   ys = GetPosSize(nSi);
+   zs = GetPosSize(nSi);
+   xangle = GetPosSize(nSi);
+   yangle = GetPosSize(nSi);
+   zangle = GetPosSize(nSi);
 }
 
 
@@ -181,109 +164,23 @@ void PixelModules::SetBoxParam(Double_t SX, Double_t SY, Double_t SZ, Double_t z
    z_offset = first_plane_offset; // distance between first module and box outside
    SetSiliconDZ(SiliconDZthin, SiliconDZthick);
    ComputeDimZSlice();
-   SetVertical();
-   SetIDs();
+   PixelIDlist = SetIDs();
    SetPositionSize();
 }
 
-Bool_t *PixelModules::GetVertical1(){
-	return new Bool_t[nSi1];
+
+Int_t *PixelModules::GetIDlist(Int_t n)
+{
+   return new Int_t[n];
 }
 
-Bool_t *PixelModules::GetVertical10(){
-	return new Bool_t[nSi10];
-}
-
-void PixelModules::SetVertical(){
-	if(nSlices==10){
-		vertical=GetVertical10();
-    		for(int i=0;i<nSi10;i++){
-    		    vertical[i]=kFALSE;
-    		    }
-    		for(int i=0;i<3;i++){
-    			for(int j =0;j<20;j++){
-    		    vertical[i*40+j]=kTRUE;
-    		    }
-    		}
-		}
-	else{
-		vertical=GetVertical1();
-		vertical[0]=kTRUE;
-		vertical[1]=kTRUE;
-		vertical[2]=kFALSE;
-		vertical[3]=kFALSE;
-		vertical[4]=kTRUE;
-		vertical[5]=kTRUE;
-		vertical[6]=kFALSE;
-		vertical[7]=kFALSE;
-		vertical[8]=kTRUE;
-		vertical[9]=kTRUE;
-		vertical[10]=kFALSE;
-		vertical[11]=kFALSE;
-	}
-}
-
-Int_t *PixelModules::GetIDlist1(){
-return new Int_t[12];
-}
-
-Int_t *PixelModules::GetIDlist10(){
-return new Int_t[120];
-}
-
-Int_t* PixelModules::SetIDs(){
-	switch(nSlices){
-		
-		case 1 : {
-			PixelIDlist=GetIDlist1();
-			PixelIDlist[0]=111;
-			PixelIDlist[1]=112;
-			PixelIDlist[2]=121;
-			PixelIDlist[3]=122;
-			PixelIDlist[4]=131;
-			PixelIDlist[5]=132;
-			PixelIDlist[6]=141;
-			PixelIDlist[7]=142;
-			PixelIDlist[8]=151;
-			PixelIDlist[9]=152;
-			PixelIDlist[10]=161;
-			PixelIDlist[11]=162;
-			}
-		case 10: {
-			PixelIDlist=GetIDlist10();	
-    			//id convention: 1{a}{b}{c}, a = number of pair (from 1 to 6), b = element of the pair (1 or 2), c=slice (0 to 9)
-    			int chi=0;
-    			for(int i=1110;i<1130;i++){
-    				PixelIDlist[chi]=i;
-    				chi++;
-    			}
-    			
-    			for(int i=1210;i<1230;i++){
-    				PixelIDlist[chi]=i;
-	    			chi++;
-    			}
-
-    			for(int i=1310;i<1330;i++){
-    				PixelIDlist[chi]=i;
-    				chi++;
-    			}
-    			for(int i=1410;i<1430;i++){
-    				PixelIDlist[chi]=i;
-	    			chi++;
-    			}
-    			for(int i=1510;i<1530;i++){
-    				PixelIDlist[chi]=i;
-    				chi++;
-    			}
-    			for(int i=1610;i<1630;i++){
-	    			PixelIDlist[chi]=i;
-    				chi++;
-    			}
-    			//Alternated pixel stations optimized for y and x measurements
-}
-
-}
-return PixelIDlist;
+Int_t *PixelModules::SetIDs()
+{
+   PixelIDlist = GetIDlist(nSi);
+   for (Int_t i = 0; i < nSi; i++) {
+      PixelIDlist[i] = i;
+   }
+   return PixelIDlist;
 }
 
 void PixelModules::ConstructGeometry()
@@ -424,6 +321,7 @@ void PixelModules::ConstructGeometry()
 		}
 	
 }
+
 
 }
 

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -192,134 +192,161 @@ void PixelModules::ConstructGeometry()
     InitMedium("silicon");
     TGeoMedium *Silicon = gGeoManager->GetMedium("silicon");
 
-    InitMedium("aluminium");
-    TGeoMedium *Aluminium = gGeoManager->GetMedium("aluminium");
+   InitMedium("aluminium");
+   TGeoMedium *Aluminium = gGeoManager->GetMedium("aluminium");
 
-    InitMedium("copper");
-    TGeoMedium *Copper = gGeoManager->GetMedium("copper");
+   InitMedium("copper");
+   TGeoMedium *Copper = gGeoManager->GetMedium("copper");
 
-    InitMedium("kapton");
-    TGeoMedium *Kapton = gGeoManager->GetMedium("kapton");
+   InitMedium("kapton");
+   TGeoMedium *Kapton = gGeoManager->GetMedium("kapton");
 
-    InitMedium("CoilCopper");
-    TGeoMedium *Cu  = gGeoManager->GetMedium("CoilCopper");
+   InitMedium("CoilCopper");
+   TGeoMedium *Cu = gGeoManager->GetMedium("CoilCopper");
 
-    InitMedium("CoilAluminium");
-    TGeoMedium *Al  = gGeoManager->GetMedium("CoilAluminium");
+   InitMedium("CoilAluminium");
+   TGeoMedium *Al = gGeoManager->GetMedium("CoilAluminium");
 
-    InitMedium("TTmedium");
-    TGeoMedium *TT  = gGeoManager->GetMedium("TTmedium");
+   InitMedium("TTmedium");
+   TGeoMedium *TT = gGeoManager->GetMedium("TTmedium");
 
-    InitMedium("STTmix8020_2bar");
-    TGeoMedium *sttmix8020_2bar   = gGeoManager->GetMedium("STTmix8020_2bar");
+   InitMedium("STTmix8020_2bar");
+   TGeoMedium *sttmix8020_2bar = gGeoManager->GetMedium("STTmix8020_2bar");
 
-    TGeoVolume *top = gGeoManager->GetTopVolume();
+   TGeoVolume *top = gGeoManager->GetTopVolume();
 
-    
-    //computing the largest offsets in order to set PixelBox dimensions correctly
-    Double_t offsetxmax = 0., offsetymax = 0.;
-   for (int istation = 0; istation < nSi; istation++){
-     if (TMath::Abs(xs[istation]) > offsetxmax) offsetxmax = TMath::Abs(xs[istation]);
-     if (TMath::Abs(ys[istation]) > offsetymax) offsetymax = TMath::Abs(ys[istation]);
-    }
-    TGeoVolumeAssembly *volPixelBox = new TGeoVolumeAssembly("volPixelBox");
-    Double_t inimodZoffset(zs[0]-DimZSithick) ;//initial Z offset of Pixel Module 0 so as to avoid volume extrusion
-    top->AddNode(volPixelBox, 1, new TGeoTranslation(0,0,zBoxPosition+ inimodZoffset)); //volume moved in
+   TGeoVolumeAssembly *volPixelBox = new TGeoVolumeAssembly("volPixelBox");
+   top->AddNode(volPixelBox, 1, new TGeoTranslation(0, 0, zBoxPosition ));
 
+   TGeoBBox *Pixelythin = new TGeoBBox("Pixelythin", Dim1Short / 2, Dim1Long / 2, DimZThinSlice / 2); // long along y
+   TGeoVolume *volPixelythin = new TGeoVolume("volPixelythin", Pixelythin, Silicon);
+   volPixelythin->SetLineColor(kBlue - 5);
+   AddSensitiveVolume(volPixelythin);
 
-    TGeoBBox *Pixelythin = new TGeoBBox("Pixelythin", Dim1Short/2, Dim1Long/2, DimZThinSlice/2); //long along y
-    TGeoVolume *volPixelythin = new TGeoVolume("volPixelythin",Pixelythin,Silicon); 
-    volPixelythin->SetLineColor(kBlue-5);
-    AddSensitiveVolume(volPixelythin);
+   TGeoBBox *Pixelxthin = new TGeoBBox("Pixelxthin", (Dim1Long) / 2, (Dim1Short) / 2, DimZThinSlice / 2); // long along
+                                                                                                          // x
+   TGeoVolume *volPixelxthin = new TGeoVolume("volPixelxthin", Pixelxthin, Silicon);
+   volPixelxthin->SetLineColor(kBlue - 5);
+   AddSensitiveVolume(volPixelxthin);
 
-    TGeoBBox *Pixelxthin = new TGeoBBox("Pixelxthin", (Dim1Long)/2, (Dim1Short)/2, DimZThinSlice/2); //long along x
-    TGeoVolume *volPixelxthin = new TGeoVolume("volPixelxthin",Pixelxthin,Silicon); 
-    volPixelxthin->SetLineColor(kBlue-5);
-    AddSensitiveVolume(volPixelxthin);
+   TGeoBBox *Pixelythick = new TGeoBBox("Pixelythick", Dim1Short / 2, Dim1Long / 2, DimZThickSlice / 2); // long along y
+   TGeoVolume *volPixelythick = new TGeoVolume("volPixelythick", Pixelythick, Silicon);
+   volPixelythick->SetLineColor(kBlue - 5);
+   AddSensitiveVolume(volPixelythick);
 
-    TGeoBBox *Pixelythick = new TGeoBBox("Pixelythick", Dim1Short/2, Dim1Long/2, DimZThickSlice/2); //long along y
-    TGeoVolume *volPixelythick = new TGeoVolume("volPixelythick",Pixelythick,Silicon); 
-    volPixelythick->SetLineColor(kBlue-5);
-    AddSensitiveVolume(volPixelythick);
+   TGeoBBox *Pixelxthick =
+      new TGeoBBox("Pixelxthick", (Dim1Long) / 2, (Dim1Short) / 2, DimZThickSlice / 2); // long along x
+   TGeoVolume *volPixelxthick = new TGeoVolume("volPixelxthick", Pixelxthick, Silicon);
+   volPixelxthick->SetLineColor(kBlue - 5);
+   AddSensitiveVolume(volPixelxthick);
 
-    TGeoBBox *Pixelxthick = new TGeoBBox("Pixelxthick", (Dim1Long)/2, (Dim1Short)/2, DimZThickSlice/2); //long along x
-    TGeoVolume *volPixelxthick = new TGeoVolume("volPixelxthick",Pixelxthick,Silicon); 
-    volPixelxthick->SetLineColor(kBlue-5);
-    AddSensitiveVolume(volPixelxthick);
-  
-  ///////////////////////////////////////////////////////Passive material///////////////////////////////////////////////////////
+   ///////////////////////////////////////////////////////Passive
+   /// material///////////////////////////////////////////////////////
 
-    TGeoBBox *WindowBox = new TGeoBBox("WindowBox",Windowx/2, Windowy/2,DimZWindow/2);
-    TGeoVolume *volWindow = new TGeoVolume("volWindow",WindowBox,Kapton);
-    volWindow->SetLineColor(kRed);
+   TGeoBBox *WindowBox = new TGeoBBox("WindowBox", Windowx / 2, Windowy / 2, DimZWindow / 2);
+   TGeoVolume *volWindow = new TGeoVolume("volWindow", WindowBox, Kapton);
+   volWindow->SetLineColor(kRed);
 
-    TGeoBBox *FrontEndx = new TGeoBBox("FrontEndx",Dim1Long/2, Dim1Short/2 ,FrontEndthick/2);
-    TGeoVolume *volFrontEndx = new TGeoVolume("volFrontEndx",FrontEndx,Silicon);
-    volFrontEndx->SetLineColor(kRed);
+   TGeoBBox *FrontEndx = new TGeoBBox("FrontEndx", Dim1Long / 2, Dim1Short / 2, FrontEndthick / 2);
+   TGeoVolume *volFrontEndx = new TGeoVolume("volFrontEndx", FrontEndx, Silicon);
+   volFrontEndx->SetLineColor(kRed);
 
-    TGeoBBox *FrontEndy = new TGeoBBox("FrontEndy",Dim1Short/2, Dim1Long/2 ,FrontEndthick/2);
-    TGeoVolume *volFrontEndy = new TGeoVolume("volFrontEndy",FrontEndy,Silicon);
-    volFrontEndy->SetLineColor(kRed);
+   TGeoBBox *FrontEndy = new TGeoBBox("FrontEndy", Dim1Short / 2, Dim1Long / 2, FrontEndthick / 2);
+   TGeoVolume *volFrontEndy = new TGeoVolume("volFrontEndy", FrontEndy, Silicon);
+   volFrontEndy->SetLineColor(kRed);
 
-    TGeoBBox *FlexCux = new TGeoBBox("FlexCux",Dim1Long/2, Dim1Short/2 ,FlexCuthick/2);
-    TGeoVolume *volFlexCux = new TGeoVolume("volFlexCux",FlexCux,Copper);
-    volFlexCux->SetLineColor(kRed);
+   TGeoBBox *FlexCux = new TGeoBBox("FlexCux", Dim1Long / 2, Dim1Short / 2, FlexCuthick / 2);
+   TGeoVolume *volFlexCux = new TGeoVolume("volFlexCux", FlexCux, Copper);
+   volFlexCux->SetLineColor(kRed);
 
-    TGeoBBox *FlexCuy = new TGeoBBox("FlexCuy",Dim1Short/2, Dim1Long/2 ,FlexCuthick/2);
-    TGeoVolume *volFlexCuy = new TGeoVolume("volFlexCuy",FlexCuy,Copper);
-    volFlexCuy->SetLineColor(kRed);
+   TGeoBBox *FlexCuy = new TGeoBBox("FlexCuy", Dim1Short / 2, Dim1Long / 2, FlexCuthick / 2);
+   TGeoVolume *volFlexCuy = new TGeoVolume("volFlexCuy", FlexCuy, Copper);
+   volFlexCuy->SetLineColor(kRed);
 
-    TGeoBBox *FlexKapx = new TGeoBBox("FlexKapx",Dim1Long/2, Dim1Short/2 ,FlexKapthick/2);
-    TGeoVolume *volFlexKapx = new TGeoVolume("volFlexKapx",FlexKapx,Kapton);
-    volFlexKapx->SetLineColor(kRed);
+   TGeoBBox *FlexKapx = new TGeoBBox("FlexKapx", Dim1Long / 2, Dim1Short / 2, FlexKapthick / 2);
+   TGeoVolume *volFlexKapx = new TGeoVolume("volFlexKapx", FlexKapx, Kapton);
+   volFlexKapx->SetLineColor(kRed);
 
-    TGeoBBox *FlexKapy = new TGeoBBox("FlexKapy",Dim1Short/2, Dim1Long/2 ,FlexKapthick/2);
-    TGeoVolume *volFlexKapy = new TGeoVolume("volFlexKapy",FlexKapy,Kapton);
-    volFlexKapy->SetLineColor(kRed);
+   TGeoBBox *FlexKapy = new TGeoBBox("FlexKapy", Dim1Short / 2, Dim1Long / 2, FlexKapthick / 2);
+   TGeoVolume *volFlexKapy = new TGeoVolume("volFlexKapy", FlexKapy, Kapton);
+   volFlexKapy->SetLineColor(kRed);
 
-////////////////////////////////////////////////////////End passive material////////////////////////////////////////////////////////////////
+   ////////////////////////////////////////////////////////End passive
+   /// material////////////////////////////////////////////////////////////////
 
-  volWindow->AddNode(0,0,new TGeoTranslation(0,0,-DimZPixelBox/2.-inimodZoffset-DimZWindow));
+   volPixelBox->AddNode(volWindow, 0, new TGeoTranslation(0, 0, -DimZPixelBox / 2. + DimZWindow));
+   volPixelBox->AddNode(volWindow, 1, new TGeoTranslation(0, 0, DimZPixelBox / 2. - DimZWindow));
+   
+   // loop to create and align the active volumes ( == Sensors). Only the active material is sliced.
 
-    for (Int_t ipixel = 0; ipixel < nSi; ipixel++){
-      if (vertical[ipixel]){
-		if(PixelIDlist[ipixel]) {
-			if(PixelIDlist[ipixel]<1130 || (PixelIDlist[ipixel]>1219 && PixelIDlist[ipixel]<1620)){
-				volPixelBox->AddNode(volPixelythick, PixelIDlist[ipixel], new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset)); //compensation for the Node offset
-					}
-			else {volPixelBox->AddNode(volPixelythin, PixelIDlist[ipixel], new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset)); 
-//compensation for the Node offset}
-			}
-					}
-		else volPixelBox->AddNode(volPixelythick, 9000, new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset)); 
-//this else is used for debugging, if the number of slices isn't 10
+   for (Int_t ipixel = 0; ipixel < nSi; ipixel++) {
+       // modules with large pixel pitch in y
+      if ((ipixel / nSlices) % 4 == 0 || (ipixel / nSlices) % 4 == 1) {
+         volPixelBox->AddNode(volPixelythick, PixelIDlist[ipixel],
+            new TGeoTranslation(xs[ipixel], ys[ipixel], (-DimZPixelBox / 2.) + zs[ipixel] + z_offset));
+      } else { // modules with large pixel pitch in x
+         // check for the two thinner modules
+         if (((PixelIDlist[ipixel] / nSlices) == 2) || ((PixelIDlist[ipixel] / nSlices) == 11)) { 
+            volPixelBox->AddNode(volPixelxthin, PixelIDlist[ipixel],
+               new TGeoTranslation(xs[ipixel], ys[ipixel], (-DimZPixelBox / 2.) + zs[ipixel] + z_offset));
+         } else {
+            volPixelBox->AddNode(volPixelxthick, PixelIDlist[ipixel],
+               new TGeoTranslation(xs[ipixel], ys[ipixel], (-DimZPixelBox / 2.) + zs[ipixel] + z_offset));
+         }
+      }
+   }
 
-		if((ipixel+nSlices)%9==1){
-					volFrontEndy->AddNode(volFrontEndy, 0,new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset+DimZThickSlice+FrontEndthick));
-					volFlexCuy->AddNode(volFlexCuy, 0,new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset+DimZThickSlice+FlexCuthick));
-					volFlexKapy->AddNode(volFlexKapy, 0,new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset+DimZThickSlice+FlexKapthick));	
-			}
-		}
-      else{ 
-		if(PixelIDlist[ipixel]) 
-			if(PixelIDlist[ipixel]<1130 || (PixelIDlist[ipixel]>1219 && PixelIDlist[ipixel]<1620)){
-				volPixelBox->AddNode(volPixelxthick, PixelIDlist[ipixel], new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset));
-														}
-			else{
-				volPixelBox->AddNode(volPixelxthin, PixelIDlist[ipixel], new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset));
-				}
-		
-		else {
-			volPixelBox->AddNode(volPixelxthick, 9000, new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset)); //debugging else for if nSlice!=10
-			}
-
-		if((ipixel+nSlices)%9==1){
-					volFrontEndx->AddNode(volFrontEndx, 0,new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset+DimZThickSlice+FrontEndthick));
-					volFlexCux->AddNode(volFlexCux, 0,new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset+DimZThickSlice+FlexCuthick));
-					volFlexKapx->AddNode(volFlexKapx, 0,new TGeoTranslation(xs[ipixel],ys[ipixel],-DimZPixelBox/2.+ zs[ipixel]-inimodZoffset+DimZThickSlice+FlexKapthick));	
-					}
-		}
-	
+   // put passive materials in place (flex and FE)
+   Double_t z_tmp_cu = 0. ;
+   Double_t z_tmp_fe = 0. ;
+   Double_t z_tmp_kap = 0. ;
+   for (Int_t module = 0; module < nSi; module += nSlices) {
+      if ((module) % 4 == 0 || (module) % 4 == 1) {
+         // modules with large pixel pitch in y
+         if ((module) % 4 == 0) {
+            // flex is upstream, FE is downstream of sensor
+            z_tmp_cu = (-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThickSlice / 2.) - FlexKapthick - (FlexCuthick/ 2.) ;
+            z_tmp_kap =(-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThickSlice / 2.) - FlexKapthick / 2. ;
+            z_tmp_fe = (-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThickSlice / 2.) + (FrontEndthick/ 2.) ;
+         } else {
+            // FE is upstream, flex is downstream of sensor
+            z_tmp_fe = (-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThickSlice / 2.) - (FrontEndthick/ 2.) ;
+            z_tmp_kap =(-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThickSlice / 2.) + FlexKapthick / 2. ;
+            z_tmp_cu = (-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThickSlice / 2.) + FlexKapthick / 2. + (FlexCuthick/ 2.)  ;
+         }
+         volPixelBox->AddNode(volFrontEndy, module, new TGeoTranslation(xs[module], ys[module], z_tmp_fe));
+         volPixelBox->AddNode(volFlexCuy, module, new TGeoTranslation(xs[module], ys[module], z_tmp_cu));
+         volPixelBox->AddNode(volFlexKapy, module, new TGeoTranslation(xs[module], ys[module], z_tmp_kap));
+      } else {
+         // modules with large pixel pitch in x
+         // check for thinner modules
+         if (module == 2 ){
+            z_tmp_cu = (-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThinSlice / 2.) - FlexKapthick - (FlexCuthick/ 2.) ;
+            z_tmp_kap =(-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThinSlice / 2.) - FlexKapthick / 2. ;
+            z_tmp_fe = (-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThinSlice / 2.) + (FrontEndthick/ 2.) ;
+         }
+         else if (module == 11){
+            z_tmp_fe = (-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThinSlice / 2.) - (FrontEndthick/ 2.) ;
+            z_tmp_kap =(-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThinSlice / 2.) + FlexKapthick / 2. ;
+            z_tmp_cu = (-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThinSlice / 2.) + FlexKapthick / 2. + (FlexCuthick/ 2.)  ;
+         }
+         else if ((module) % 4 == 2) {
+            // flex is upstream, FE is downstream of sensor
+            z_tmp_cu = (-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThickSlice / 2.) - FlexKapthick - (FlexCuthick/ 2.) ;
+            z_tmp_kap =(-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThickSlice / 2.) - FlexKapthick / 2. ;
+            z_tmp_fe = (-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThickSlice / 2.) + (FrontEndthick/ 2.) ;
+         } else if (module % 4 == 3){
+            // FE is upstream, flex is downstream of sensor
+            z_tmp_fe = (-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThickSlice / 2.) - (FrontEndthick/ 2.) ;
+            z_tmp_kap =(-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThickSlice / 2.) + FlexKapthick / 2. ;
+            z_tmp_cu = (-DimZPixelBox / 2.) + zs[module + nSlices - 1] + z_offset + (DimZThickSlice / 2.) + FlexKapthick / 2. + (FlexCuthick/ 2.)  ;
+         }
+         volPixelBox->AddNode(volFrontEndx, module, new TGeoTranslation(xs[module], ys[module], z_tmp_fe));
+         volPixelBox->AddNode(volFlexCux, module, new TGeoTranslation(xs[module], ys[module], z_tmp_cu));
+         volPixelBox->AddNode(volFlexKapx, module, new TGeoTranslation(xs[module], ys[module], z_tmp_kap));
+      }
+      
+   }
 }
 
 

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -218,10 +218,10 @@ void PixelModules::ConstructGeometry()
    TGeoVolumeAssembly *volPixelBox = new TGeoVolumeAssembly("volPixelBox");
    top->AddNode(volPixelBox, 1, new TGeoTranslation(0, 0, zBoxPosition ));
 
-   TGeoBBox *Pixelythin = new TGeoBBox("Pixelythin", Dim1Short / 2, Dim1Long / 2, DimZThinSlice / 2); // long along y
-   TGeoVolume *volPixelythin = new TGeoVolume("volPixelythin", Pixelythin, Silicon);
-   volPixelythin->SetLineColor(kBlue - 5);
-   AddSensitiveVolume(volPixelythin);
+   // TGeoBBox *Pixelythin = new TGeoBBox("Pixelythin", Dim1Short / 2, Dim1Long / 2, DimZThinSlice / 2); // long along y
+   // TGeoVolume *volPixelythin = new TGeoVolume("volPixelythin", Pixelythin, Silicon);
+   // volPixelythin->SetLineColor(kBlue - 5);
+   // AddSensitiveVolume(volPixelythin);
 
    TGeoBBox *Pixelxthin = new TGeoBBox("Pixelxthin", (Dim1Long) / 2, (Dim1Short) / 2, DimZThinSlice / 2); // long along
                                                                                                           // x
@@ -229,13 +229,13 @@ void PixelModules::ConstructGeometry()
    volPixelxthin->SetLineColor(kBlue - 5);
    AddSensitiveVolume(volPixelxthin);
 
-   TGeoBBox *Pixelythick = new TGeoBBox("Pixelythick", Dim1Short / 2, Dim1Long / 2, DimZThickSlice / 2); // long along y
+   TGeoBBox *Pixelythick = new TGeoBBox("Pixelythick", Dim1Short / 2, Dim1Long / 2, DimZThickSlice / 2.); // long along y
    TGeoVolume *volPixelythick = new TGeoVolume("volPixelythick", Pixelythick, Silicon);
    volPixelythick->SetLineColor(kBlue - 5);
    AddSensitiveVolume(volPixelythick);
 
    TGeoBBox *Pixelxthick =
-      new TGeoBBox("Pixelxthick", (Dim1Long) / 2, (Dim1Short) / 2, DimZThickSlice / 2); // long along x
+      new TGeoBBox("Pixelxthick", (Dim1Long) / 2, (Dim1Short) / 2, DimZThickSlice / 2.); // long along x
    TGeoVolume *volPixelxthick = new TGeoVolume("volPixelxthick", Pixelxthick, Silicon);
    volPixelxthick->SetLineColor(kBlue - 5);
    AddSensitiveVolume(volPixelxthick);

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -67,7 +67,6 @@ PixelModules::PixelModules(const char *name, const Double_t DX, const Double_t D
    FlexCuthick = 0.0100 * cm;
    FlexKapthick = 0.0050 * cm;
    SetSiliconSlicesNumber(nSl);
-
 }
 
 PixelModules::~PixelModules()
@@ -111,7 +110,6 @@ void PixelModules::SetSiliconDZ(Double_t SiliconDZthin,Double_t SiliconDZthick)
   DimZSithin = SiliconDZthin;
   DimZSithick= SiliconDZthick;
 }
-
 
 void PixelModules::SetSiliconSlicesNumber(Int_t nSl)
 {
@@ -230,8 +228,7 @@ void PixelModules::ConstructGeometry()
    volPixelxthick->SetLineColor(kBlue - 5);
    AddSensitiveVolume(volPixelxthick);
 
-   ///////////////////////////////////////////////////////Passive
-   /// material///////////////////////////////////////////////////////
+   //////////////////////Passive material//////////////////////
 
    TGeoBBox *WindowBox = new TGeoBBox("WindowBox", Windowx / 2, Windowy / 2, DimZWindow / 2);
    TGeoVolume *volWindow = new TGeoVolume("volWindow", WindowBox, Kapton);
@@ -261,21 +258,20 @@ void PixelModules::ConstructGeometry()
    TGeoVolume *volFlexKapy = new TGeoVolume("volFlexKapy", FlexKapy, Kapton);
    volFlexKapy->SetLineColor(kRed);
 
-   ////////////////////////////////////////////////////////End passive
-   /// material////////////////////////////////////////////////////////////////
+   //////////////////////End Passive material//////////////////////
 
+   // place foil which covered the entry window of the pixelbox.
    volPixelBox->AddNode(volWindow, 0, new TGeoTranslation(0, 0, -DimZPixelBox / 2. + DimZWindow));
    volPixelBox->AddNode(volWindow, 1, new TGeoTranslation(0, 0, DimZPixelBox / 2. - DimZWindow));
    
    // loop to create and align the active volumes ( == Sensors). Only the active material is sliced.
-
    for (Int_t ipixel = 0; ipixel < nSi; ipixel++) {
        // modules with large pixel pitch in y
       if ((ipixel / nSlices) % 4 == 0 || (ipixel / nSlices) % 4 == 1) {
          volPixelBox->AddNode(volPixelythick, PixelIDlist[ipixel],
             new TGeoTranslation(xs[ipixel], ys[ipixel], (-DimZPixelBox / 2.) + zs[ipixel] + z_offset));
       } else { // modules with large pixel pitch in x
-         // check for the two thinner modules
+         // consider the two thinner modules
          if (((PixelIDlist[ipixel] / nSlices) == 2) || ((PixelIDlist[ipixel] / nSlices) == 11)) { 
             volPixelBox->AddNode(volPixelxthin, PixelIDlist[ipixel],
                new TGeoTranslation(xs[ipixel], ys[ipixel], (-DimZPixelBox / 2.) + zs[ipixel] + z_offset));
@@ -309,7 +305,7 @@ void PixelModules::ConstructGeometry()
          volPixelBox->AddNode(volFlexKapy, module, new TGeoTranslation(xs[module], ys[module], z_tmp_kap));
       } else {
          // modules with large pixel pitch in x
-         // check for thinner modules
+         // consider thinner modules
          if (module == 2 ){
             z_tmp_cu = (-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThinSlice / 2.) - FlexKapthick - (FlexCuthick/ 2.) ;
             z_tmp_kap =(-DimZPixelBox / 2.) + zs[module] + z_offset - (DimZThinSlice / 2.) - FlexKapthick / 2. ;
@@ -335,7 +331,6 @@ void PixelModules::ConstructGeometry()
          volPixelBox->AddNode(volFlexCux, module, new TGeoTranslation(xs[module], ys[module], z_tmp_cu));
          volPixelBox->AddNode(volFlexKapx, module, new TGeoTranslation(xs[module], ys[module], z_tmp_kap));
       }
-      
    }
 }
 

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -67,6 +67,7 @@ PixelModules::PixelModules(const char *name, const Double_t DX, const Double_t D
    FlexCuthick = 0.0100 * cm;
    FlexKapthick = 0.0050 * cm;
    SetSiliconSlicesNumber(nSl);
+
 }
 
 PixelModules::~PixelModules()
@@ -112,10 +113,28 @@ void PixelModules::SetSiliconDZ(Double_t SiliconDZthin,Double_t SiliconDZthick)
 }
 
 
-void PixelModules::SetSiliconStationPositions(Int_t nstation, Double_t posx, Double_t posy, Double_t posz){
- xs[nstation] = posx;
- ys[nstation] = posy;
- zs[nstation] = posz;
+void PixelModules::SetSiliconSlicesNumber(Int_t nSl)
+{
+   nSlices = nSl;
+   nSi = nSlices * 12;
+}
+
+void PixelModules::SetPositionSize()
+{
+   xs = std::vector<Double_t> (nSi);
+   ys = std::vector<Double_t> (nSi);
+   zs = std::vector<Double_t> (nSi);
+
+   xangle = std::vector<Double_t> (nSi);
+   yangle = std::vector<Double_t> (nSi);
+   zangle = std::vector<Double_t> (nSi);
+}
+
+void PixelModules::SetSiliconStationPositions(Int_t nstation, Double_t posx, Double_t posy, Double_t posz)
+{
+   xs[nstation] = posx;
+   ys[nstation] = posy;
+   zs[nstation] = posz;
 }
 
 void PixelModules::SetSiliconStationAngles(Int_t nstation, Double_t anglex, Double_t angley, Double_t anglez){
@@ -124,31 +143,10 @@ void PixelModules::SetSiliconStationAngles(Int_t nstation, Double_t anglex, Doub
  zangle[nstation] = anglez;
 }
 
-void PixelModules::SetSiliconSlicesNumber(Int_t nSl)
+void PixelModules::ComputeDimZSlice()
 {
-   nSlices = nSl;
-   nSi = nSlices * 12;
-}
-
-Double_t *PixelModules::GetPosSize(Int_t n)
-{
-   return new Double_t[n];
-}
-
-void PixelModules::SetPositionSize()
-{
-   xs = GetPosSize(nSi);
-   ys = GetPosSize(nSi);
-   zs = GetPosSize(nSi);
-   xangle = GetPosSize(nSi);
-   yangle = GetPosSize(nSi);
-   zangle = GetPosSize(nSi);
-}
-
-
-void PixelModules::ComputeDimZSlice(){
-DimZThinSlice=DimZSithin/nSlices;
-DimZThickSlice=DimZSithick/nSlices;
+   DimZThinSlice = DimZSithin / nSlices;
+   DimZThickSlice = DimZSithick / nSlices;
 }
 
 void PixelModules::SetBoxParam(Double_t SX, Double_t SY, Double_t SZ, Double_t zBox, Double_t SZPixel, Double_t D1short,
@@ -164,23 +162,15 @@ void PixelModules::SetBoxParam(Double_t SX, Double_t SY, Double_t SZ, Double_t z
    z_offset = first_plane_offset; // distance between first module and box outside
    SetSiliconDZ(SiliconDZthin, SiliconDZthick);
    ComputeDimZSlice();
-   PixelIDlist = SetIDs();
+   SetIDs();
    SetPositionSize();
 }
 
-
-Int_t *PixelModules::GetIDlist(Int_t n)
+void PixelModules::SetIDs()
 {
-   return new Int_t[n];
-}
-
-Int_t *PixelModules::SetIDs()
-{
-   PixelIDlist = GetIDlist(nSi);
    for (Int_t i = 0; i < nSi; i++) {
-      PixelIDlist[i] = i;
+      PixelIDlist.push_back(i);
    }
-   return PixelIDlist;
 }
 
 void PixelModules::ConstructGeometry()

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -354,31 +354,31 @@ void PixelModules::ConstructGeometry()
 
     TGeoBBox *WindowBox = new TGeoBBox("WindowBox",Windowx/2, Windowy/2,DimZWindow/2);
     TGeoVolume *volWindow = new TGeoVolume("volWindow",WindowBox,Kapton);
-    volWindow->SetLineColor(kGray);
+    volWindow->SetLineColor(kRed);
 
     TGeoBBox *FrontEndx = new TGeoBBox("FrontEndx",Dim1Long/2, Dim1Short/2 ,FrontEndthick/2);
     TGeoVolume *volFrontEndx = new TGeoVolume("volFrontEndx",FrontEndx,Silicon);
-    volFrontEndx->SetLineColor(kGray);
+    volFrontEndx->SetLineColor(kRed);
 
     TGeoBBox *FrontEndy = new TGeoBBox("FrontEndy",Dim1Short/2, Dim1Long/2 ,FrontEndthick/2);
     TGeoVolume *volFrontEndy = new TGeoVolume("volFrontEndy",FrontEndy,Silicon);
-    volFrontEndy->SetLineColor(kGray);
+    volFrontEndy->SetLineColor(kRed);
 
     TGeoBBox *FlexCux = new TGeoBBox("FlexCux",Dim1Long/2, Dim1Short/2 ,FlexCuthick/2);
     TGeoVolume *volFlexCux = new TGeoVolume("volFlexCux",FlexCux,Copper);
-    volFlexCux->SetLineColor(kGray);
+    volFlexCux->SetLineColor(kRed);
 
     TGeoBBox *FlexCuy = new TGeoBBox("FlexCuy",Dim1Short/2, Dim1Long/2 ,FlexCuthick/2);
     TGeoVolume *volFlexCuy = new TGeoVolume("volFlexCuy",FlexCuy,Copper);
-    volFlexCuy->SetLineColor(kGray);
+    volFlexCuy->SetLineColor(kRed);
 
     TGeoBBox *FlexKapx = new TGeoBBox("FlexKapx",Dim1Long/2, Dim1Short/2 ,FlexKapthick/2);
     TGeoVolume *volFlexKapx = new TGeoVolume("volFlexKapx",FlexKapx,Kapton);
-    volFlexKapx->SetLineColor(kGray);
+    volFlexKapx->SetLineColor(kRed);
 
     TGeoBBox *FlexKapy = new TGeoBBox("FlexKapy",Dim1Short/2, Dim1Long/2 ,FlexKapthick/2);
     TGeoVolume *volFlexKapy = new TGeoVolume("volFlexKapy",FlexKapy,Kapton);
-    volFlexKapy->SetLineColor(kGray);
+    volFlexKapy->SetLineColor(kRed);
 
 ////////////////////////////////////////////////////////End passive material////////////////////////////////////////////////////////////////
 

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -168,22 +168,22 @@ DimZThinSlice=DimZSithin/nSlices;
 DimZThickSlice=DimZSithick/nSlices;
 }
 
-
-
-void PixelModules::SetBoxParam(Double_t SX, Double_t SY, Double_t SZ, Double_t zBox, Double_t SZPixel, Double_t D1short, Double_t D1long,Double_t SiliconDZthin,Double_t SiliconDZthick)
+void PixelModules::SetBoxParam(Double_t SX, Double_t SY, Double_t SZ, Double_t zBox, Double_t SZPixel, Double_t D1short,
+                               Double_t D1long, Double_t SiliconDZthin, Double_t SiliconDZthick, Double_t first_plane_offset)
 {
-  SBoxX = SX;
-  SBoxY = SY;
-  SBoxZ = SZ;
-  zBoxPosition = zBox;
-  DimZPixelBox = SZPixel;
-  Dim1Short = D1short;
-  Dim1Long = D1long;
-  SetSiliconDZ(SiliconDZthin, SiliconDZthick);
-  ComputeDimZSlice();
-  SetVertical();
-  SetIDs();
-  SetPositionSize();
+   SBoxX = SX;
+   SBoxY = SY;
+   SBoxZ = SZ;
+   zBoxPosition = zBox;
+   DimZPixelBox = SZPixel;
+   Dim1Short = D1short;
+   Dim1Long = D1long;
+   z_offset = first_plane_offset; // distance between first module and box outside
+   SetSiliconDZ(SiliconDZthin, SiliconDZthick);
+   ComputeDimZSlice();
+   SetVertical();
+   SetIDs();
+   SetPositionSize();
 }
 
 Bool_t *PixelModules::GetVertical1(){

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -47,34 +47,26 @@ using std::endl;
 using namespace ShipUnit;
 
 PixelModules::PixelModules()
-  : FairDetector("HighPrecisionTrackers",kTRUE, kPixelModules),
-    fTrackID(-1),
-    fPdgCode(),
-    fVolumeID(-1),
-    fPos(),
-    fMom(),
-    fTime(-1.),
-    fLength(-1.),
-    fELoss(-1),
-    fPixelModulesPointCollection(new TClonesArray("PixelModulesPoint"))
-{}
+   : FairDetector("HighPrecisionTrackers", kTRUE, kPixelModules), fTrackID(-1), fPdgCode(), fVolumeID(-1), fPos(),
+     fMom(), fTime(-1.), fLength(-1.), fELoss(-1), fPixelModulesPointCollection(new TClonesArray("PixelModulesPoint"))
+{
+}
 
-PixelModules::PixelModules(const char* name, const Double_t DX, const Double_t DY, const Double_t DZ, Bool_t Active,Int_t nSl,const char* Title)
-  : FairDetector(name, Active, kPixelModules),
-    fTrackID(-1),
-    fPdgCode(),
-    fVolumeID(-1),
-    fPos(),
-    fMom(),
-    fTime(-1.),
-    fLength(-1.),
-    fELoss(-1),
-    fPixelModulesPointCollection(new TClonesArray("PixelModulesPoint"))
-{	
-  DimX = DX;
-  DimY = DY;
-  DimZ = DZ;
-  SetSiliconSlicesNumber(nSl);
+PixelModules::PixelModules(const char *name, const Double_t DX, const Double_t DY, const Double_t DZ, Bool_t Active,
+                           Int_t nSl, const char *Title)
+   : FairDetector(name, Active, kPixelModules), fTrackID(-1), fPdgCode(), fVolumeID(-1), fPos(), fMom(), fTime(-1.),
+     fLength(-1.), fELoss(-1), fPixelModulesPointCollection(new TClonesArray("PixelModulesPoint"))
+{
+   DimX = DX;
+   DimY = DY;
+   DimZ = DZ;
+   DimZWindow = 0.0110 * cm;
+   Windowx = 5 * cm;
+   Windowy = 5 * cm;
+   FrontEndthick = 0.0150 * cm;
+   FlexCuthick = 0.0100 * cm;
+   FlexKapthick = 0.0050 * cm;
+   SetSiliconSlicesNumber(nSl);
 }
 
 PixelModules::~PixelModules()

--- a/charmdet/PixelModules.cxx
+++ b/charmdet/PixelModules.cxx
@@ -334,10 +334,6 @@ void PixelModules::ConstructGeometry()
    }
 }
 
-
-}
-
-
 Bool_t  PixelModules::ProcessHits(FairVolume* vol){
     /** This method is called from the MC stepping */
     //Set parameters at entrance of volume. Reset ELoss.

--- a/charmdet/PixelModules.h
+++ b/charmdet/PixelModules.h
@@ -93,13 +93,10 @@ private:
    TClonesArray *fPixelModulesPointCollection;
 
    Int_t InitMedium(const char *name);
-   Int_t *GetIDlist(Int_t n);
 
 protected:
-   Double_t *GetPosSize(Int_t n);
    void SetPositionSize();
-   Double_t Dim1Short, Dim1Long;
-   Int_t *SetIDs();
+   void SetIDs();
 
    Double_t SBoxX = 0;
    Double_t SBoxY = 0;
@@ -114,22 +111,24 @@ protected:
    Double_t DimX = 0;
    Double_t DimY = 0;
    Double_t DimZ = 0;
+   Double_t DimZPixelBox;
    Double_t DimZWindow = 0.0110;
    Double_t Windowx = 5;
    Double_t Windowy = 5;
+
    Double_t FrontEndthick = 0.0150;
    Double_t FlexCuthick = 0.0100;
    Double_t FlexKapthick = 0.0050;
-   Double_t DimZPixelBox;
-   Int_t *PixelIDlist;
+   
+   Double_t Dim1Short, Dim1Long;
+   std::vector<Int_t> PixelIDlist ;
 
    Int_t nSi;
    Double_t DimZSithin = 0.02;
    Double_t DimZSithick = 0.0245;
    Double_t DimZThinSlice;
    Double_t DimZThickSlice;
-   Double_t *xs, *ys, *zs;
-   Double_t *xangle, *yangle, *zangle;
+   std::vector<Double_t> xs, ys, zs, xangle, yangle, zangle;
 
    PixelModules(const PixelModules &);
    PixelModules &operator=(const PixelModules &);

--- a/charmdet/PixelModules.h
+++ b/charmdet/PixelModules.h
@@ -74,75 +74,68 @@ public:
    void DecodeVolumeID(Int_t detID, int &nHPT);
 
 private:
+   /** Track information to be stored until the track leaves the
+    active volume.
+    */
+   Int_t fTrackID;      //!  track index
+   Int_t fPdgCode;      //!  pdg code
+   Int_t fVolumeID;     //!  volume id
+   TLorentzVector fPos; //!  position at entrance
+   TLorentzVector fMom; //!  momentum at entrance
+   Double32_t fTime;    //!  time
+   Double32_t fLength;  //!  length
+   Double32_t fELoss;   //!  energy loss
+   /*Number of Silicon pixel segments, 10 is the recommended amount for digitized runs, 1 for simple runs, is set in
+    * charm geometry file*/
+   Int_t nSlices = 1;
 
-    /** Track information to be stored until the track leaves the
-     active volume.
-     */
-    Int_t          fTrackID;           //!  track index
-    Int_t          fPdgCode;           //!  pdg code
-    Int_t          fVolumeID;          //!  volume id
-    TLorentzVector fPos;               //!  position at entrance
-    TLorentzVector fMom;               //!  momentum at entrance
-    Double32_t     fTime;              //!  time
-    Double32_t     fLength;            //!  length
-    Double32_t     fELoss;             //!  energy loss
-    /*Number of Silicon pixel segments, 10 is the recommended amount for digitized runs, 1 for simple runs, is set in charm geometry file*/
-    Int_t nSlices=10; 
-    
-    /** container for data points */
-    TClonesArray*  fPixelModulesPointCollection;
+   /** container for data points */
+   TClonesArray *fPixelModulesPointCollection;
 
-    Int_t InitMedium(const char* name);
-    Int_t *GetIDlist1(); 
-    Int_t *GetIDlist10();
-    Bool_t *vertical; 
+   Int_t InitMedium(const char *name);
+   Int_t *GetIDlist(Int_t n);
 
 protected:
+   Double_t *GetPosSize(Int_t n);
+   void SetPositionSize();
+   Double_t Dim1Short, Dim1Long;
+   Int_t *SetIDs();
 
-    Double_t *GetPosSize1();
-    Double_t *GetPosSize10();
-    void SetPositionSize();
-    Double_t Dim1Short, Dim1Long;
-    Int_t *SetIDs();   
-    void SetVertical(); 
-    Bool_t *GetVertical1();
-    Bool_t *GetVertical10();
- 
-    Double_t SBoxX = 0;
-    Double_t SBoxY = 0;
-    Double_t SBoxZ = 0;
+   Double_t SBoxX = 0;
+   Double_t SBoxY = 0;
+   Double_t SBoxZ = 0;
+   Double_t z_offset = 0;
 
-    Double_t BoxX = 0;
-    Double_t BoxY = 0;
-    Double_t BoxZ = 0;
-    Double_t zBoxPosition = 0;
+   Double_t BoxX = 0;
+   Double_t BoxY = 0;
+   Double_t BoxZ = 0;
+   Double_t zBoxPosition = 0;
 
-    Double_t DimX =0;
-    Double_t DimY =0;
-    Double_t DimZ = 0;
-    Double_t DimZWindow=0.0110;
-    Double_t Windowx=5;
-    Double_t Windowy=5;
-    Double_t FrontEndthick=0.0150;
-    Double_t FlexCuthick=0.0100;
-    Double_t FlexKapthick=0.0050;
-    Double_t overlap=0;
-    Double_t DimZPixelBox;
-    Int_t *PixelIDlist;
+   Double_t DimX = 0;
+   Double_t DimY = 0;
+   Double_t DimZ = 0;
+   Double_t DimZWindow = 0.0110;
+   Double_t Windowx = 5;
+   Double_t Windowy = 5;
+   Double_t FrontEndthick = 0.0150;
+   Double_t FlexCuthick = 0.0100;
+   Double_t FlexKapthick = 0.0050;
+   Double_t overlap = 0;
+   Double_t DimZPixelBox;
+   Int_t *PixelIDlist;
 
-    static const Int_t nSi1=12;
-    static const Int_t nSi10=120;
-    Int_t nSi;
-    Double_t DimZSithin=0.02;
-    Double_t DimZSithick=0.0245;
-    Double_t DimZThinSlice;
-    Double_t DimZThickSlice;
-    Double_t *xs, *ys, *zs;
-    Double_t *xangle, *yangle, *zangle;
-    
-    PixelModules(const PixelModules&);
-    PixelModules& operator=(const PixelModules&);
-    ClassDef(PixelModules,1)
+   static const Int_t nSi1 = 12;
+   static const Int_t nSi10 = 120;
+   Int_t nSi;
+   Double_t DimZSithin = 0.02;
+   Double_t DimZSithick = 0.0245;
+   Double_t DimZThinSlice;
+   Double_t DimZThickSlice;
+   Double_t *xs, *ys, *zs;
+   Double_t *xangle, *yangle, *zangle;
 
+   PixelModules(const PixelModules &);
+   PixelModules &operator=(const PixelModules &);
+   ClassDef(PixelModules, 1)
 };
 #endif

--- a/charmdet/PixelModules.h
+++ b/charmdet/PixelModules.h
@@ -16,64 +16,62 @@ class PixelModulesPoint;
 class FairVolume;
 class TClonesArray;
 
-class PixelModules:public FairDetector
-{
-  public:
-    PixelModules();
-    PixelModules(const char* name, const Double_t DX, const Double_t DY, const Double_t DZ,Bool_t Active,Int_t nSl=1,const char* Title="PixelModules");
-    virtual ~PixelModules();
-    void ConstructGeometry();
-    void SetZsize(const Double_t MSsize);
-    void SetBoxParam(Double_t SX, Double_t SY, Double_t SZ, Double_t zBox, Double_t SZPixel, Double_t D1short, Double_t D1long,Double_t SiliconDZthin, Double_t SiliconDZthick);
-//    SetBoxParam(DX,DY,DZ, zBox, DimZpixelbox, D1short, D1long,DimZSithin, DimZSithick,nSlice)
-    
-    void SetSiliconDZ(Double_t SiliconDZthin, Double_t SiliconDZthick);  
-    void SetSiliconStationPositions(Int_t nstation, Double_t posx, Double_t posy, Double_t posz);
-    void SetSiliconStationAngles(Int_t nstation, Double_t anglex, Double_t angley, Double_t anglez);
-    void SetSiliconDetNumber(Int_t nSilicon);
-    void SetSiliconSlicesNumber(Int_t nSl=1);
-    void ComputeDimZSlice();
-    /**      Initialization of the detector is done here    */
-    virtual void Initialize();
+class PixelModules : public FairDetector {
+public:
+   PixelModules();
+   PixelModules(const char *name, const Double_t DX, const Double_t DY, const Double_t DZ, Bool_t Active, Int_t nSl = 1,
+                const char *Title = "PixelModules");
+   virtual ~PixelModules();
+   void ConstructGeometry();
+   void SetZsize(const Double_t MSsize);
+   void SetBoxParam(Double_t SX, Double_t SY, Double_t SZ, Double_t zBox, Double_t SZPixel, Double_t D1short,
+                    Double_t D1long, Double_t SiliconDZthin, Double_t SiliconDZthick, Double_t first_plane_offset);
+   //    SetBoxParam(DX,DY,DZ, zBox, DimZpixelbox, D1short, D1long,DimZSithin, DimZSithick,nSlice)
 
-    /**       this method is called for each step during simulation
-     *       (see FairMCApplication::Stepping())
-     */
-    virtual Bool_t ProcessHits( FairVolume* v=0);
+   void SetSiliconDZ(Double_t SiliconDZthin, Double_t SiliconDZthick);
+   void SetSiliconStationPositions(Int_t nstation, Double_t posx, Double_t posy, Double_t posz);
+   void SetSiliconStationAngles(Int_t nstation, Double_t anglex, Double_t angley, Double_t anglez);
+   void SetSiliconDetNumber(Int_t nSilicon);
+   void SetSiliconSlicesNumber(Int_t nSl = 1);
+   void ComputeDimZSlice();
+   /**      Initialization of the detector is done here    */
+   virtual void Initialize();
 
-    /**       Registers the produced collections in FAIRRootManager.     */
-    virtual void   Register();
+   /**       this method is called for each step during simulation
+    *       (see FairMCApplication::Stepping())
+    */
+   virtual Bool_t ProcessHits(FairVolume *v = 0);
 
-    /** Gets the produced collections */
-    virtual TClonesArray* GetCollection(Int_t iColl) const ;
+   /**       Registers the produced collections in FAIRRootManager.     */
+   virtual void Register();
 
-    /**      has to be called after each event to reset the containers      */
-    virtual void   Reset();
+   /** Gets the produced collections */
+   virtual TClonesArray *GetCollection(Int_t iColl) const;
 
-    /**      This method is an example of how to add your own point
-     *       of type muonPoint to the clones array
-     */
-    PixelModulesPoint* AddHit(Int_t trackID, Int_t detID,
-                         TVector3 pos, TVector3 mom,
-                         Double_t time, Double_t length,
-                         Double_t eLoss, Int_t pdgCode);
+   /**      has to be called after each event to reset the containers      */
+   virtual void Reset();
 
-    /** The following methods can be implemented if you need to make
-     *  any optional action in your detector during the transport.
-     */
+   /**      This method is an example of how to add your own point
+    *       of type muonPoint to the clones array
+    */
+   PixelModulesPoint *AddHit(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t time, Double_t length,
+                             Double_t eLoss, Int_t pdgCode);
 
-    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-                              Int_t offset) {;}
-    virtual void   SetSpecialPhysicsCuts() {;}
-    virtual void   EndOfEvent();
-    virtual void   FinishPrimary() {;}
-    virtual void   FinishRun() {;}
-    virtual void   BeginPrimary() {;}
-    virtual void   PostTrack() {;}
-    virtual void   PreTrack() {;}
-    virtual void   BeginEvent() {;}
+   /** The following methods can be implemented if you need to make
+    *  any optional action in your detector during the transport.
+    */
 
-    void DecodeVolumeID(Int_t detID,int &nHPT);
+   virtual void CopyClones(TClonesArray *cl1, TClonesArray *cl2, Int_t offset) { ; }
+   virtual void SetSpecialPhysicsCuts() { ; }
+   virtual void EndOfEvent();
+   virtual void FinishPrimary() { ; }
+   virtual void FinishRun() { ; }
+   virtual void BeginPrimary() { ; }
+   virtual void PostTrack() { ; }
+   virtual void PreTrack() { ; }
+   virtual void BeginEvent() { ; }
+
+   void DecodeVolumeID(Int_t detID, int &nHPT);
 
 private:
 

--- a/charmdet/PixelModules.h
+++ b/charmdet/PixelModules.h
@@ -120,12 +120,9 @@ protected:
    Double_t FrontEndthick = 0.0150;
    Double_t FlexCuthick = 0.0100;
    Double_t FlexKapthick = 0.0050;
-   Double_t overlap = 0;
    Double_t DimZPixelBox;
    Int_t *PixelIDlist;
 
-   static const Int_t nSi1 = 12;
-   static const Int_t nSi10 = 120;
    Int_t nSi;
    Double_t DimZSithin = 0.02;
    Double_t DimZSithick = 0.0245;

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -332,9 +332,9 @@ with ConfigRegistry.register_config("basic") as c:
 
     c.PixelModules.DimZSithin = 0.0200 * u.cm
     c.PixelModules.DimZSithick = 0.0245 * u.cm
-    c.PixelModules.nSlice= 1 #for digitization simulation, fix nSlice=10
-    c.PixelModules.D1short = 3.36 * u.cm / 2.
-    c.PixelModules.D1long = 4.09 * u.cm
+    c.PixelModules.nSlice = 5  # for digitization simulation recommended nSlice=10
+    c.PixelModules.D1short = 50. * u.um * 336 # = 1.68 u.cm
+    c.PixelModules.D1long = ((78 * 250.) + 450. + 500. )* u.um * 2 # = 4.09 * u.cm each module has 160 columns, the outer two and the centered two have different size
     c.PixelModules.numSi = 12*c.PixelModules.nSlice
     c.PixelModules.z_offset = 0.7 * u.cm
 

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -349,71 +349,71 @@ with ConfigRegistry.register_config("basic") as c:
     c.PixelModules.ySi = []
     c.PixelModules.zSi = []
 
-    	#Module 0
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(1.53912)
-    	c.PixelModules.ySi.append(-0.002332)
-    	c.PixelModules.zSi.append(-0.13+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 1
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(-0.229076)
-    	c.PixelModules.ySi.append(0.005328)
-    	c.PixelModules.zSi.append(0.52+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 2
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(0.704924)
-    	c.PixelModules.ySi.append(0.808437)
-    	c.PixelModules.zSi.append(2.412+i*c.PixelModules.DimZSithin/c.PixelModules.nSlice)
-    	#Module 3
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(0.705433)
-    	c.PixelModules.ySi.append(-0.879224)
-    	c.PixelModules.zSi.append(3.09+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 4 (Didn't take data)
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(1.54963)
-    	c.PixelModules.ySi.append(-0.003912)
-    	c.PixelModules.zSi.append(5.17+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 5
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(-0.221577)
-    	c.PixelModules.ySi.append(-0.023944)
-    	c.PixelModules.zSi.append(5.79+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 6
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(0.690749)
-    	c.PixelModules.ySi.append(0.769728)
-    	c.PixelModules.zSi.append(7.77+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 7
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(0.702302)
-    	c.PixelModules.ySi.append(-0.874356)
-    	c.PixelModules.zSi.append(8.46+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 8
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(1.58271)
-    	c.PixelModules.ySi.append(-0.0030432)
-    	c.PixelModules.zSi.append(10.462+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 9
-    for i in range(1-c.PixelModules.nSlice,1):
-	c.PixelModules.xSi.append(-0.209171)
-	c.PixelModules.ySi.append(0.002488)
-	c.PixelModules.zSi.append(11.17+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 10
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(0.694199)
-    	c.PixelModules.ySi.append(0.850237)
-    	c.PixelModules.zSi.append(13.162+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
-    	#Module 11
-    for i in range(1-c.PixelModules.nSlice,1):
-    	c.PixelModules.xSi.append(0.683245)
-    	c.PixelModules.ySi.append(-0.79636)
-    	c.PixelModules.zSi.append(13.85+i*c.PixelModules.DimZSithin/c.PixelModules.nSlice)
+    # Module 0
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(1.53912)
+        c.PixelModules.ySi.append(-0.002332)
+        c.PixelModules.zSi.append(-0.13 + i * c.PixelModules.DimZSithick / c.PixelModules.nSlice)
+        # Module 1
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(-0.229076)
+        c.PixelModules.ySi.append(0.005328)
+        c.PixelModules.zSi.append(0.52 + i * c.PixelModules.DimZSithick / c.PixelModules.nSlice)
+        # Module 2
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(0.704924)
+        c.PixelModules.ySi.append(0.808437)
+        c.PixelModules.zSi.append(2.412+i*c.PixelModules.DimZSithin/c.PixelModules.nSlice)
+        # Module 3
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(0.705433)
+        c.PixelModules.ySi.append(-0.879224)
+        c.PixelModules.zSi.append(3.09+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 4 (Didn't take data)
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(1.54963)
+        c.PixelModules.ySi.append(-0.003912)
+        c.PixelModules.zSi.append(5.17+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 5
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(-0.221577)
+        c.PixelModules.ySi.append(-0.023944)
+        c.PixelModules.zSi.append(5.79+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 6
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(0.690749)
+        c.PixelModules.ySi.append(0.769728)
+        c.PixelModules.zSi.append(7.77+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 7
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(0.702302)
+        c.PixelModules.ySi.append(-0.874356)
+        c.PixelModules.zSi.append(8.46+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 8
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(1.58271)
+        c.PixelModules.ySi.append(-0.0030432)
+        c.PixelModules.zSi.append(10.462+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 9
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(-0.209171)
+        c.PixelModules.ySi.append(0.002488)
+        c.PixelModules.zSi.append(11.17+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 10
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(0.694199)
+        c.PixelModules.ySi.append(0.850237)
+        c.PixelModules.zSi.append(13.162+i*c.PixelModules.DimZSithick/c.PixelModules.nSlice)
+        # Module 11
+    for i in range(1-c.PixelModules.nSlice, 1):
+        c.PixelModules.xSi.append(0.683245)
+        c.PixelModules.ySi.append(-0.79636)
+        c.PixelModules.zSi.append(13.85+i*c.PixelModules.DimZSithin/c.PixelModules.nSlice)
 
-    #SciFi Modules
-    c.SciFi = AttrDict(z = 0*u.cm)
-    #mother volume dimensions
-    c.SciFi.DX = 50*u.cm 
+    # SciFi Modules
+    c.SciFi = AttrDict(z=0*u.cm)
+    # mother volume dimensions
+    c.SciFi.DX = 50*u.cm
     c.SciFi.DY = 50*u.cm
     c.SciFi.DZ = 28.07 * u.cm #as difference between positions of SF_DHBR and x of SF_UHTL in the Survey document
 

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -477,7 +477,10 @@ with ConfigRegistry.register_config("basic") as c:
    
     c.PixelModules.DimZpixelbox = c.PixelModules.zSi[c.PixelModules.numSi-1] - c.PixelModules.zSi[c.PixelModules.nSlice-1] + c.PixelModules.DimZSithick   
 
-    PixeltoGoliath = 30.45 *u.cm #25.45 + 5cm different goliath dz
+    # old calculation for DimZpixelbox c.PixelModules.zSi[c.PixelModules.numSi-1] - c.PixelModules.zSi[c.PixelModules.nSlice-1] + c.PixelModules.DimZSithick
+    c.PixelModules.DimZpixelbox = 34. * u.cm # correct physical size of surrounding box
+    
+    PixeltoGoliath = 30.45 * u.cm  # 25.45 + 5cm different goliath dz
     c.Spectrometer.zBox = 350.75 - c.Spectrometer.TS/2 - PixeltoGoliath - c.PixelModules.DimZpixelbox/2.
     #position of mother volumes
     c.Box.zBox = c.Spectrometer.zBox - c.PixelModules.DimZpixelbox/2. - c.Box.GapPostTargetTh

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -333,8 +333,8 @@ with ConfigRegistry.register_config("basic") as c:
     c.PixelModules.DimZSithin = 0.0200 * u.cm
     c.PixelModules.DimZSithick = 0.0245 * u.cm
     c.PixelModules.nSlice = 5  # for digitization simulation recommended nSlice=10
-    c.PixelModules.D1short = 50. * u.um * 336 # = 1.68 u.cm
-    c.PixelModules.D1long = ((78 * 250.) + 450. + 500. )* u.um * 2 # = 4.09 * u.cm each module has 160 columns, the outer two and the centered two have different size
+    c.PixelModules.D1short = 50. * u.um * 336 # = 1.68 u.cm. Each module has 336 rows.
+    c.PixelModules.D1long = ((78 * 250.) + 450. + 500. )* u.um * 2 # = 4.09 * u.cm. Each module has 160 columns, the outer two and the centered two have different size.
     c.PixelModules.numSi = 12*c.PixelModules.nSlice
     c.PixelModules.z_offset = 0.7 * u.cm
 

--- a/geometry/charm-geometry_config.py
+++ b/geometry/charm-geometry_config.py
@@ -335,8 +335,11 @@ with ConfigRegistry.register_config("basic") as c:
     c.PixelModules.nSlice= 1 #for digitization simulation, fix nSlice=10
     c.PixelModules.D1short = 3.36 * u.cm / 2.
     c.PixelModules.D1long = 4.09 * u.cm
-    c.PixelModules.numSi=12*c.PixelModules.nSlice
-    
+    c.PixelModules.numSi = 12*c.PixelModules.nSlice
+    c.PixelModules.z_offset = 0.7 * u.cm
+
+    # position of module centres units are cm. Geometry is given with reference to the centre of all modules for the xy plane and the front of the pixel box for the z axis, precision is given to the micron range
+    # module position naming: "axis"Si"Module number"
 
     #position of module centres units are cm. Geometry is given with reference to the centre of all modules for the xy plane and the front of the pixel box for the z axis, precision is given to the micron range
     #module position naming: "axis"Si"Module number"

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -52,9 +52,9 @@ def configure(run,ship_geo,Gfield=''):
     for i, (x, y, z) in enumerate(zip(ship_geo.SciFi.xSi,ship_geo.SciFi.ySi,ship_geo.SciFi.zSi)):
       SciFi.SetStationPositions(i, x, y, z)
 # === Pixel modules
-        PixelModules = ROOT.PixelModules("PixelModules", ship_geo.PixelModules.DX, ship_geo.PixelModules.DY,
+    PixelModules = ROOT.PixelModules("PixelModules", ship_geo.PixelModules.DX, ship_geo.PixelModules.DY,
                                          ship_geo.PixelModules.DZ, ROOT.kTRUE, ship_geo.PixelModules.nSlice)
-        PixelModules.SetBoxParam(ship_geo.PixelModules.DX, ship_geo.PixelModules.DY, ship_geo.PixelModules.DZ, ship_geo.PixelModules.zBox, 
+    PixelModules.SetBoxParam(ship_geo.PixelModules.DX, ship_geo.PixelModules.DY, ship_geo.PixelModules.DZ, ship_geo.PixelModules.zBox, 
                                  ship_geo.PixelModules.DimZpixelbox, ship_geo.PixelModules.D1short, ship_geo.PixelModules.D1long, 
                                  ship_geo.PixelModules.DimZSithin, ship_geo.PixelModules.DimZSithick, ship_geo.PixelModules.z_offset)
 # === SciFi modules

--- a/python/charmDet_conf.py
+++ b/python/charmDet_conf.py
@@ -52,8 +52,11 @@ def configure(run,ship_geo,Gfield=''):
     for i, (x, y, z) in enumerate(zip(ship_geo.SciFi.xSi,ship_geo.SciFi.ySi,ship_geo.SciFi.zSi)):
       SciFi.SetStationPositions(i, x, y, z)
 # === Pixel modules
-    PixelModules = ROOT.PixelModules("PixelModules",ship_geo.PixelModules.DX, ship_geo.PixelModules.DY, ship_geo.PixelModules.DZ,ROOT.kTRUE,ship_geo.PixelModules.nSlice)
-    PixelModules.SetBoxParam(ship_geo.PixelModules.DX,ship_geo.PixelModules.DY,ship_geo.PixelModules.DZ, ship_geo.PixelModules.zBox, ship_geo.PixelModules.DimZpixelbox, ship_geo.PixelModules.D1short, ship_geo.PixelModules.D1long,ship_geo.PixelModules.DimZSithin, ship_geo.PixelModules.DimZSithick)
+        PixelModules = ROOT.PixelModules("PixelModules", ship_geo.PixelModules.DX, ship_geo.PixelModules.DY,
+                                         ship_geo.PixelModules.DZ, ROOT.kTRUE, ship_geo.PixelModules.nSlice)
+        PixelModules.SetBoxParam(ship_geo.PixelModules.DX, ship_geo.PixelModules.DY, ship_geo.PixelModules.DZ, ship_geo.PixelModules.zBox, 
+                                 ship_geo.PixelModules.DimZpixelbox, ship_geo.PixelModules.D1short, ship_geo.PixelModules.D1long, 
+                                 ship_geo.PixelModules.DimZSithin, ship_geo.PixelModules.DimZSithick, ship_geo.PixelModules.z_offset)
 # === SciFi modules
     detectorList.append(SciFi)
 # === Pixel modules

--- a/python/shipunit.py
+++ b/python/shipunit.py
@@ -47,6 +47,8 @@ nanobarn = 1.e-9 *barn
 picobarn = 1.e-12*barn
 
 # symbols
+um  = micrometer
+
 mm  = millimeter
 mm2 = millimeter2
 mm3 = millimeter3


### PR DESCRIPTION
This pull request corrects for wrongly placed pixel detector volumes in the charm simulation.
It also updates the slicing option to be able to choose an arbitrary number of slices per sensor volume. 
The simulation runs and the output files seem fine.

However the errors which triggered my investigation were not fixed. After simulation following output is created:

```
 --------  End PYTHIA Event Listing  -----------------------------------------------------------------------------------------------
Error in <TStreamerInfo::Build>: PixelModules, discarding: int* PixelIDlist, no [dimension]

Error in <TStreamerInfo::Build>: PixelModules, discarding: double* xs, no [dimension]

Error in <TStreamerInfo::Build>: PixelModules, discarding: double* ys, no [dimension]

Error in <TStreamerInfo::Build>: PixelModules, discarding: double* zs, no [dimension]

Error in <TStreamerInfo::Build>: PixelModules, discarding: double* xangle, no [dimension]

Error in <TStreamerInfo::Build>: PixelModules, discarding: double* yangle, no [dimension]

Error in <TStreamerInfo::Build>: PixelModules, discarding: double* zangle, no [dimension]

[INFO] ***  FairBaseParSet written to ROOT file   version: 1
[INFO] ***  FairGeoParSet written to ROOT file   version: 1
```

I believe this is thrown when Geant4 tries to store these variables, however they are only used for placement of the volumes, and seem not to be important afterwards ? If anyone has a clue how to prevent this I would be happy to learn.
