### PR TITLE
Update of the SND Muon Identification System geometry

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -631,7 +631,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.tauMudet.zMudetC = c.Chamber1.z -c.chambers.Tub1length - c.tauMudet.Ztot/2 -31*u.cm;
         #lateral cuts
         c.tauMudet.CutHeight = 78.548 * u.cm
-        c.tauMudet.CutLength = (c.tauMudet.CutHeight / 2) / (r.TMath.Tan(r.TMath.DegToRad(55)))
+        c.tauMudet.CutLength = (c.tauMudet.CutHeight / 2) / (r.TMath.Tan(r.TMath.DegToRad() * 55))
         #upper cover
         c.tauMudet.XCov = c.tauMudet.XFe
         c.tauMudet.YCov = 6*u.cm

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import shipunit as u
 import ROOT as r
+import math
 from ShipGeoConfig import AttrDict, ConfigRegistry
 # the following params should be passed through 'ConfigRegistry.loadpy' method
 # muShieldDesign = 5  # 1=passive 2=active 5=TP design 6=magnetized hadron absorber 9=optimised with T4 as constraint, 8=requires config file
@@ -606,22 +607,23 @@ with ConfigRegistry.register_config("basic") as c:
         c.tauMudet.NFethick = 4 #upstream slabs, more thick
         c.tauMudet.NFethin = 4 #downstream slabs, less thick
         c.tauMudet.NRpc= 8
-                
-        c.tauMudet.XFe = scaleMudet*1.900*u.m #layer dimensions, excluded supports
-        c.tauMudet.YFe = scaleMudet*3.600*u.m
+        
+        c.tauMudet.XFe = scaleMudet*1.950*u.m #layer dimensions, excluded supports
+        c.tauMudet.YFe = scaleMudet*3.850*u.m
+
         c.tauMudet.ZFethick = 15.*u.cm
         c.tauMudet.ZFethin = 10.* u.cm
 
         c.tauMudet.XRpc = c.tauMudet.XFe
         c.tauMudet.YRpc = c.tauMudet.YFe
-        c.tauMudet.ZRpc = 7.*u.cm
+        c.tauMudet.ZRpc = 8.*u.cm
         #support structure
-        c.tauMudet.UpperSupportX = 34 * u.cm
-        c.tauMudet.UpperSupportY = 34 * u.cm
-        c.tauMudet.LowerSupportX = 34 * u.cm
-        c.tauMudet.LowerSupportY = 34 * u.cm
-        c.tauMudet.LateralSupportX = 34 * u.cm
-        c.tauMudet.LateralSupportY = 34 * u.cm
+        c.tauMudet.UpperSupportX = 30 * u.cm
+        c.tauMudet.UpperSupportY = 32 * u.cm
+        c.tauMudet.LowerSupportX = 30 * u.cm
+        c.tauMudet.LowerSupportY = 40 * u.cm
+        c.tauMudet.LateralSupportX = 30.5 * u.cm
+        c.tauMudet.LateralSupportY = 32 * u.cm
 
         c.tauMudet.Xtot = c.tauMudet.XFe + 2 * c.tauMudet.LateralSupportX#now we need to include also supports.
         c.tauMudet.Ytot = c.tauMudet.YFe + c.tauMudet.UpperSupportY + c.tauMudet.LowerSupportY 
@@ -629,8 +631,34 @@ with ConfigRegistry.register_config("basic") as c:
         #c.tauMudet.zMudetC = -c.decayVolume.length/2. - c.tauMudet.Ztot/2
         c.tauMudet.zMudetC = c.Chamber1.z -c.chambers.Tub1length - c.tauMudet.Ztot/2 -31*u.cm;
         #lateral cuts
-        c.tauMudet.CutHeight = 100 * u.cm
-        c.tauMudet.CutLength = 25 * u.cm
+        c.tauMudet.CutHeight = 78.548 * u.cm
+        c.tauMudet.CutLength = (c.tauMudet.CutHeight/2)/(math.tan(math.radians(55)))
+        #upper cover
+        c.tauMudet.XCov = c.tauMudet.XFe
+        c.tauMudet.YCov = 6*u.cm
+        c.tauMudet.ZCov = c.tauMudet.NFethick*c.tauMudet.ZFethick+c.tauMudet.NRpc*c.tauMudet.ZRpc+c.tauMudet.NFethin*c.tauMudet.ZFethin
+        
+        c.tauMudet.YSpacing = 28.5*u.cm
+        #lateral cover
+        c.tauMudet.XLateral = 7*u.cm
+        c.tauMudet.YLateral = c.tauMudet.LateralSupportY
+        c.tauMudet.ZLateral = c.tauMudet.ZCov
+        #lateral cross
+        c.tauMudet.XCross = 2*u.cm
+        c.tauMudet.YCross = c.tauMudet.YFe-2*c.tauMudet.YLateral-2*c.tauMudet.YSpacing - 8*u.cm
+        c.tauMudet.ZCross = c.tauMudet.ZCov
+        c.tauMudet.WidthArm = 2* u.cm
+        #RPC frame
+        c.tauMudet.XRpc_outer = 284.5*u.cm
+        c.tauMudet.YRpc_outer = 428.2*u.cm
+        c.tauMudet.ZRpc_outer = 2.2*u.cm
+        c.tauMudet.XRpc_inner = 190*u.cm
+        c.tauMudet.YRpc_inner = 372*u.cm
+        c.tauMudet.ZRpc_inner = 1.7*u.cm
+        #RPC Gap
+        c.tauMudet.XRpcGap = c.tauMudet.XRpc_inner
+        c.tauMudet.YRpcGap = 120*u.cm
+        c.tauMudet.ZRpcGap = 0.2*u.cm
         
         c.tauMudet.PillarX = 40*u.cm
         c.tauMudet.PillarZ = 50*u.cm
@@ -640,7 +668,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.tauMudet.ZGas = 1*u.mm
     c.tauMudet.XStrip =  c.tauMudet.XRpc
     c.tauMudet.YStrip =  c.tauMudet.YRpc
-    c.tauMudet.ZStrip = 0.05*u.mm
+    c.tauMudet.ZStrip = 0.02*u.mm
     c.tauMudet.XPet =  c.tauMudet.XRpc
     c.tauMudet.YPet =  c.tauMudet.YRpc
     c.tauMudet.ZPet = 0.1*u.mm

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import shipunit as u
 import ROOT as r
-import math
 from ShipGeoConfig import AttrDict, ConfigRegistry
 # the following params should be passed through 'ConfigRegistry.loadpy' method
 # muShieldDesign = 5  # 1=passive 2=active 5=TP design 6=magnetized hadron absorber 9=optimised with T4 as constraint, 8=requires config file

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -631,7 +631,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.tauMudet.zMudetC = c.Chamber1.z -c.chambers.Tub1length - c.tauMudet.Ztot/2 -31*u.cm;
         #lateral cuts
         c.tauMudet.CutHeight = 78.548 * u.cm
-        c.tauMudet.CutLength = (c.tauMudet.CutHeight/2)/(math.tan(math.radians(55)))
+        c.tauMudet.CutLength = (c.tauMudet.CutHeight / 2) / (r.TMath.Tan(r.TMath.DegToRad(55)))
         #upper cover
         c.tauMudet.XCov = c.tauMudet.XFe
         c.tauMudet.YCov = 6*u.cm

--- a/nutaudet/NuTauMudet.cxx
+++ b/nutaudet/NuTauMudet.cxx
@@ -10,6 +10,7 @@
 #include "TClonesArray.h"
 #include "TVirtualMC.h"
 
+#include "TGeoPara.h"
 #include "TGeoBBox.h"
 #include "TGeoTrd1.h"
 #include "TGeoTrd2.h"
@@ -186,7 +187,7 @@ void NuTauMudet::SetNRpcInTagger(Int_t NmuRpc)
   fNmuRpc = NmuRpc;
 }
 
-void NuTauMudet::SetSupportTransverseDimensions(Double_t UpperSupportX, Double_t UpperSupportY, Double_t LowerSupportX, Double_t LowerSupportY, Double_t LateralSupportX, Double_t LateralSupportY)
+void NuTauMudet::SetSupportTransverseDimensions(Double_t UpperSupportX, Double_t UpperSupportY, Double_t LowerSupportX, Double_t LowerSupportY, Double_t LateralSupportX, Double_t LateralSupportY, Double_t YSpacing)
 {
   fUpSuppX = UpperSupportX;
   fUpSuppY = UpperSupportY;
@@ -194,6 +195,7 @@ void NuTauMudet::SetSupportTransverseDimensions(Double_t UpperSupportX, Double_t
   fLowSuppY = LowerSupportY;
   fLatSuppX = LateralSupportX;
   fLatSuppY = LateralSupportY;
+  fYSpacing = YSpacing;
 }
 
 void NuTauMudet::SetLateralCutSize(Double_t CutHeight , Double_t CutLength){
@@ -206,6 +208,48 @@ void NuTauMudet::SetPillarDimensions(Double_t X, Double_t Y, Double_t Z)
   fPillarX = X;
   fPillarY = Y;
   fPillarZ = Z;
+}
+
+void NuTauMudet::SetUpperCoverDimensions(Double_t X, Double_t Y, Double_t Z)
+{
+  fXCov = X;
+  fYCov = Y;
+  fZCov = Z;
+}
+void NuTauMudet::SetLateralCoverDimensions(Double_t X, Double_t Y, Double_t Z)
+{
+  fXLateral = X;
+  fYLateral = Y;
+  fZLateral = Z;
+}
+
+void NuTauMudet::SetCrossDimensions(Double_t X, Double_t Y, Double_t Z, Double_t WidthArm)
+{
+  fXCross = X;
+  fYCross = Y;
+  fZCross = Z;
+  fWidthArm = WidthArm;
+}
+
+void NuTauMudet::SetRpcOuterDimensions(Double_t X, Double_t Y, Double_t Z)
+{
+  fXRpc_outer = X;
+  fYRpc_outer = Y;
+  fZRpc_outer = Z;
+}
+
+void NuTauMudet::SetRpcInnerDimensions(Double_t X, Double_t Y, Double_t Z)
+{
+  fXRpc_inner = X;
+  fYRpc_inner = Y;
+  fZRpc_inner = Z;
+}
+
+void NuTauMudet::SetRpcGapDimensions(Double_t X, Double_t Y, Double_t Z)
+{
+  fXRpcGap = X;
+  fYRpcGap = Y;
+  fZRpcGap = Z;
 }
 
 
@@ -269,6 +313,9 @@ void NuTauMudet::ConstructGeometry()
 
   InitMedium("air");
   TGeoMedium *air =gGeoManager->GetMedium("air");
+
+  InitMedium("Aluminum"); //new
+  TGeoMedium *Al =gGeoManager->GetMedium("Aluminum"); //new
     
   TGeoUniformMagField *retFieldU    = new TGeoUniformMagField(0.,0.,-fField); //magnetic field up return yoke
   TGeoUniformMagField *retFieldL   = new TGeoUniformMagField(0.,0.,fField); //magnetic field low return yoke
@@ -471,6 +518,42 @@ void NuTauMudet::ConstructGeometry()
 
       TGeoBBox *IronLayer1 = new TGeoBBox("Iron",fXFe/2, fYFe/2, fZFethin/2);
       TGeoVolume *volIron1 = new TGeoVolume("volIron1",IronLayer1,Iron);
+      //***********************ADDING EXTERNAL DETAILS TO THE MUON FILTER
+
+      //********UPPER COVER***********
+
+      TGeoBBox *UpperCover = new TGeoBBox("UpperCover",fXCov/2, fYCov/2, fZCov/2);
+      TGeoVolume *volUpperCover = new TGeoVolume("volUpperCover",UpperCover, Al);
+      volUpperCover->SetLineColor(kYellow-7);
+      volMudetBox->AddNode(volUpperCover, 1, new TGeoTranslation(0, fYFe/2+fYCov/2+fUpSuppY, -fZtot/2 + fZCov/2 + (fNmuRpc*fZRpc/2)));
+      
+      //**********LATERAL COVER**********
+
+      TGeoBBox *LateralCover = new TGeoBBox("LateralCover",fXLateral/2, fYLateral/2, fZLateral/2);
+      TGeoVolume *volLateralCover = new TGeoVolume("volLateralCover",LateralCover, Al);
+      volLateralCover->SetLineColor(kYellow-7);
+      volMudetBox->AddNode(volLateralCover, 1, new TGeoTranslation(-fXFe/2.-fLatSuppX-fXLateral/2., -fYFe/2.+fYLateral/2.+fYSpacing+ 4.*cm, -fZtot/2 + fZLateral/2 + (fNmuRpc*fZRpc/2))); //low right
+      volMudetBox->AddNode(volLateralCover, 2, new TGeoTranslation(+fXFe/2.+fLatSuppX+fXLateral/2., -fYFe/2.+fYLateral/2.+fYSpacing+ 4.*cm, -fZtot/2 + fZLateral/2 + (fNmuRpc*fZRpc/2))); //low left
+      volMudetBox->AddNode(volLateralCover, 3, new TGeoTranslation(-fXFe/2.-fLatSuppX-fXLateral/2., +fYFe/2.-fYLateral/2.-fYSpacing- 4.*cm, -fZtot/2 + fZLateral/2 + (fNmuRpc*fZRpc/2))); //up right
+      volMudetBox->AddNode(volLateralCover, 4, new TGeoTranslation(+fXFe/2.+fLatSuppX+fXLateral/2., +fYFe/2.-fYLateral/2.-fYSpacing- 4.*cm, -fZtot/2 + fZLateral/2 + (fNmuRpc*fZRpc/2))); //up left
+
+      //*********** LATERAL CROSSES************
+
+      Double_t Inclination =TMath::Pi()/2 - TMath::ATan(fYCross/(fZCross - fWidthArm)); 
+      TGeoRotation *Crossrot1 = new TGeoRotation("Crossrot1", 0., 0.,0.); TGeoRotation *Crossrot2 = new TGeoRotation("Crossrot2", 0., 0.,0.);
+      Crossrot1->RotateY(-90); Crossrot2->RotateY(90);
+      Crossrot1->SetName("NegativeRot"); Crossrot2->SetName("PositiveRot");
+      Crossrot1->RegisterYourself(); Crossrot2->RegisterYourself();
+
+      TGeoPara *ArmCross1 = new TGeoPara ("ArmCross1", fWidthArm/2., fYCross/2, fXCross/2., TMath::RadToDeg()*Inclination, 0., 0.);//length and height are not x and y here, because it will be rotated!
+      ArmCross1->SetName("ARMCROSS1");
+      TGeoPara *ArmCross2 = new TGeoPara ("ArmCross2", fWidthArm/2., fYCross/2, fXCross/2., TMath::RadToDeg()*Inclination, 0., 0.);//length and height are not x and y here, because it will be rotated!
+      ArmCross2->SetName("ARMCROSS2");
+      TGeoCompositeShape *MuCross = new TGeoCompositeShape("MUFILTERCROSS", "ARMCROSS1:NegativeRot+ARMCROSS2:PositiveRot");
+      TGeoVolume *volMuDetCross = new TGeoVolume("volMuDetCross",MuCross, Al);
+      volMuDetCross->SetLineColor(kYellow-7);
+      volMudetBox->AddNode(volMuDetCross, 1, new TGeoTranslation(-fXFe/2.-fLatSuppX-fXLateral+fXCross/2., 0., -fZtot/2 + fZCross/2 + (fNmuRpc*fZRpc/2))); // right
+      volMudetBox->AddNode(volMuDetCross, 2, new TGeoTranslation(+fXFe/2.+fLatSuppX+fXLateral-fXCross/2., 0., -fZtot/2 + fZCross/2 + (fNmuRpc*fZRpc/2))); // left
 
       //***********************ADDING CUTS AT MID-LATERAL IN WALLS
       IronLayer->SetName("MUDETIRON");
@@ -514,12 +597,13 @@ void NuTauMudet::ConstructGeometry()
       TGeoBBox *LateralSupport1 = new TGeoBBox(fLatSuppX/2., fLatSuppY/2.,fZFethin/2.);
       LateralSupport1->SetName("MUDETLATERALSUPPORT1");
       //Translations (left is considered from the beam, positive x)
+
       TGeoTranslation * upright = new TGeoTranslation("MuDetupright",-fXFe/2.+fUpSuppX/2.,fYFe/2+fUpSuppY/2.,0);
       TGeoTranslation * upleft = new TGeoTranslation("MuDetupleft",+fXFe/2.-fUpSuppX/2.,fYFe/2+fUpSuppY/2.,0); 
-      TGeoTranslation * lateralupleft = new TGeoTranslation("MuDetlateralupleft",+fXFe/2.+fLowSuppX/2.,fYFe/2-fLowSuppY/2.,0); 
-      TGeoTranslation * lateralupright = new TGeoTranslation("MuDetlateralupright",-fXFe/2.-fLowSuppX/2.,fYFe/2-fLowSuppY/2.,0); 
-      TGeoTranslation * laterallowleft = new TGeoTranslation("MuDetlaterallowleft",+fXFe/2.+fLowSuppX/2.,-fYFe/2+fLowSuppY/2.,0); 
-      TGeoTranslation * laterallowright = new TGeoTranslation("MuDetlaterallowright",-fXFe/2.-fLowSuppX/2.,-fYFe/2+fLowSuppY/2.,0); 
+      TGeoTranslation * lateralupleft = new TGeoTranslation("MuDetlateralupleft",+fXFe/2.+fLowSuppX/2.,fYFe/2-fLowSuppY/2.-fYSpacing,0); 
+      TGeoTranslation * lateralupright = new TGeoTranslation("MuDetlateralupright",-fXFe/2.-fLowSuppX/2.,fYFe/2-fLowSuppY/2.-fYSpacing,0); 
+      TGeoTranslation * laterallowleft = new TGeoTranslation("MuDetlaterallowleft",+fXFe/2.+fLowSuppX/2.,-fYFe/2+fLowSuppY/2.+fYSpacing,0); 
+      TGeoTranslation * laterallowright = new TGeoTranslation("MuDetlaterallowright",-fXFe/2.-fLowSuppX/2.,-fYFe/2+fLowSuppY/2.+fYSpacing,0); 
       TGeoTranslation * lowright = new TGeoTranslation("MuDetlowright",-fXFe/2.+fLowSuppX/2.,-fYFe/2-fLowSuppY/2.,0); 
       TGeoTranslation * lowleft = new TGeoTranslation("MuDetlowleft",+fXFe/2.-fLowSuppX/2.,-fYFe/2-fLowSuppY/2.,0);
       //necessary to put SetName, otherwise it will not find them
@@ -547,9 +631,9 @@ void NuTauMudet::ConstructGeometry()
       TGeoCompositeShape * SupportedIronLayer1 = new TGeoCompositeShape("SupportedIronLayer1",supportaddition1->Data());
 
       TGeoVolume *MudetIronLayer = new TGeoVolume("MudetIronLayer", SupportedIronLayer, Iron);
-      MudetIronLayer->SetLineColor(kGray);
+      MudetIronLayer->SetLineColor(kRed+2);
       TGeoVolume *MudetIronLayer1 = new TGeoVolume("MudetIronLayer1", SupportedIronLayer1, Iron);
-      MudetIronLayer1->SetLineColor(kGray);
+      MudetIronLayer1->SetLineColor(kRed+2);
 
       for(Int_t i = 0; i < fNFe; i++)
 	{
@@ -562,9 +646,11 @@ void NuTauMudet::ConstructGeometry()
           volMudetBox->AddNode(MudetIronLayer1,nr + 100 + fNFe + i, new TGeoTranslation(0, 0,dz));
 	}
       //*****************************RPC LAYERS****************************************
-      TGeoBBox *RpcContainer = new TGeoBBox("RpcContainer", fXRpc/2, fYRpc/2, fZRpc/2);
-      TGeoVolume *volRpcContainer = new TGeoVolume("volRpcContainer",RpcContainer,air);
-  
+
+      TGeoBBox *RpcContainer_0 = new TGeoBBox("RpcContainer", fXRpc_outer/2, fYRpc_outer/2, fZRpc/2);
+      RpcContainer_0->SetName("RPCCOINTAINER_0");
+      
+      /*
       TGeoBBox *Strip = new TGeoBBox("Strip",fXStrip/2, fYStrip/2, fZStrip/2);
       TGeoVolume *volStrip = new TGeoVolume("volStrip",Strip,Cu);
       volStrip->SetLineColor(kGreen);
@@ -580,26 +666,95 @@ void NuTauMudet::ConstructGeometry()
       volElectrode->SetLineColor(kGreen);
       volRpcContainer->AddNode(volElectrode,1,new TGeoTranslation(0,0,-2*mm));
       volRpcContainer->AddNode(volElectrode,2,new TGeoTranslation(0,0, 2*mm));
-      TGeoBBox *RpcGas = new TGeoBBox("RpcGas", fXGas/2, fYGas/2, fZGas/2);
+      TGeoBBox *RpcGas = new TGeoBBox("RpcGas", fXRpcGap/2, fYRpc_inner/2, fZGas/2);
       TGeoVolume *volRpc = new TGeoVolume("volRpc",RpcGas,RPCmat);
       volRpc->SetLineColor(kCyan);
       volRpcContainer->AddNode(volRpc,1,new TGeoTranslation(0,0,0));
+      */
+      
+      TGeoBBox *RpcOuter =  new TGeoBBox("RpcOuter", fXRpc_outer/2, fYRpc_outer/2, fZRpc_outer/2);
+      RpcOuter->SetName("RPCOUTER");
+      TGeoTrd2 *Indentation = new TGeoTrd2("Indentation", (fYRpc_outer- 2*(31.2*cm+15.*cm))/2, (fYRpc_outer-2*31.2*cm)/2, (fZRpc_outer+0.1*cm)/2,(fZRpc_outer+0.1*cm)/2,(15.*cm+0.1*cm)/2); // (b, B, Z_up, Z_down, h)
+      Indentation->SetName("INDENTATION");
+      const TGeoTranslation leftindent("leftindent", (fXRpc_outer-15.*cm)/2, 0, 0);
+      TGeoCombiTrans* left_ind = new TGeoCombiTrans(leftindent, rot);
+      left_ind->SetName("LEFTINDENT");
+      left_ind->RegisterYourself();
+      const TGeoTranslation rightindent("rightindent", (-fXRpc_outer+15.*cm)/2, 0, 0);
+      TGeoCombiTrans* right_ind = new TGeoCombiTrans(rightindent, rot1);
+      right_ind->SetName("RIGHTINDENT");
+      right_ind->RegisterYourself();
+      TGeoBBox *RpcInner =  new TGeoBBox("RpcInner", fXRpc_inner/2, fYRpc_inner/2, fZRpc_inner/2);
+      RpcInner->SetName("RPCINNER");
+      TGeoTranslation *exclusion = new TGeoTranslation(0, 0, (-fZRpc_inner/2) -0.6*cm);
+      exclusion->SetName("EXCLUSION");
+      exclusion->RegisterYourself();
+      TGeoCompositeShape *RpcShell = new TGeoCompositeShape("RpcShell", "RPCOUTER-INDENTATION:RIGHTINDENT-INDENTATION:LEFTINDENT-RPCINNER:EXCLUSION");
+      TGeoVolume *volRpcShell = new TGeoVolume("volRpcShell", RpcShell, Al);
+      volRpcShell->SetLineColor(kGray);
+      
+      TGeoBBox *GasShape = new TGeoBBox("GasShape", fXRpcGap/2, fYRpc_inner/2, fZGas/2);
+      GasShape->SetName("RPCGAS");
+      TGeoBBox *GapSpacing = new TGeoBBox("GapSpacing", fXRpcGap/2, 6./2*cm, (fZGas+0.01*cm)/2 );
+      GapSpacing->SetName("GAPSPACE");
+      TGeoTranslation *mdown = new TGeoTranslation("mdown", 0., -(fYRpcGap+6*cm)/2, 0.); // 6 cm is the spacing between two gaps
+      mdown->SetName("MDOWN");
+      mdown->RegisterYourself();
+      TGeoTranslation *mup = new TGeoTranslation("mup",0., (fYRpcGap+6*cm)/2, 0.);
+      mup->SetName("MUP");
+      mup->RegisterYourself();
+      TGeoCompositeShape *RpcGas = new TGeoCompositeShape("RpcGas", "RPCGAS-GAPSPACE:MUP-GAPSPACE:MDOWN");
+      TGeoVolume *volRpc = new TGeoVolume("volRpc",RpcGas, RPCmat);
+      volRpc->SetLineColor(kCyan);
+      
+      //****RPC container framing*********
+      TGeoTrd2 *Indentation_0 = new TGeoTrd2("Indentation_0", (fYRpc_outer- 2*(31.2*cm+15.*cm))/2, (fYRpc_outer-2*31.2*cm)/2, (fZRpc)/2,(fZRpc)/2,(15.*cm+0.1*cm)/2);
+      Indentation_0->SetName("INDENTATION_0");
+      TGeoCompositeShape *RpcContainer = new TGeoCompositeShape("RpcContainer", "RPCCOINTAINER_0-INDENTATION_0:RIGHTINDENT-INDENTATION_0:LEFTINDENT"); 
+      TGeoVolume *volRpcContainer = new TGeoVolume("volRpcContainer",RpcContainer,air);
+      //***********************************
+      
+      TGeoBBox *GapShape = new TGeoBBox("GapShape", fXRpcGap/2, fYRpc_inner/2, fZRpcGap/2);
+      GapShape->SetName("RPCGAP");
+      TGeoBBox *GapSpacing1 = new TGeoBBox("GapSpacing1", fXRpcGap/2, 6./2*cm, (fZRpcGap+0.01*cm)/2);
+      GapSpacing1->SetName("GAPSPACE1");
+      TGeoCompositeShape *RpcGap = new TGeoCompositeShape("RpcGap", "RPCGAP-GAPSPACE1:MUP-GAPSPACE1:MDOWN");
+      TGeoVolume *volRpcGap = new TGeoVolume("volRpcGap",RpcGap, bakelite);
+      volRpcGap->SetLineColor(kOrange);
+      
+      TGeoBBox *Strip = new TGeoBBox("Strip", fXRpc_inner/2, fYRpc_inner/2, fZStrip/2);
+      TGeoVolume *volStrip= new TGeoVolume("volStrip", Strip, Cu);
+      volStrip->SetLineColor(kOrange+5);
+      TGeoRotation rot2("rot2", 0., 0.,0.);
+      rot2.RotateY(180);
+      const TGeoTranslation trans_rot(0., 0., fZGas/2+fZRpcGap+fZStrip+fZRpc_outer/2);
+      TGeoCombiTrans *comb_1 = new TGeoCombiTrans(trans_rot, rot2);
+      
+      volRpcContainer->AddNode(volRpcShell,1, new TGeoTranslation(0., 0., -fZGas/2-fZRpcGap-fZStrip-fZRpc_outer/2));
+      volRpcContainer->AddNode(volRpcShell,2, comb_1);
+      volRpcContainer->AddNode(volStrip, 1, new TGeoTranslation(0., 0., fZGas/2+fZRpcGap+fZStrip/2));
+      volRpcContainer->AddNode(volStrip, 2, new TGeoTranslation(0., 0., -fZGas/2-fZRpcGap-fZStrip/2));
+      volRpcContainer->AddNode(volRpcGap, 1, new TGeoTranslation(0., 0., (fZGas+fZRpcGap)/2));
+      volRpcContainer->AddNode(volRpcGap, 2, new TGeoTranslation(0., 0., -(fZGas+fZRpcGap)/2));
+      volRpcContainer->AddNode(volRpc, 1, new TGeoTranslation(0., 0., 0.));
 
       AddSensitiveVolume(volRpc);
       
       for(Int_t i = 0; i < fNRpc; i++)
 	{
+         double dy = 5.*cm;
          double dz = -fZtot/2 + (i+1)*fZFe + i*fZRpc + fZRpc/2+(fNmuRpc*fZRpc/2);
          if (i >= fNFe) dz = dz - (i + 1 - fNFe) * (fZFe - fZFethin);
-         volMudetBox->AddNode(volRpcContainer,nr + i,new TGeoTranslation(0, 0, dz));          
+         if(i%2)volMudetBox->AddNode(volRpcContainer,nr + i,new TGeoTranslation(0, -dy, dz)); //staggering
+         else{volMudetBox->AddNode(volRpcContainer,nr + i,new TGeoTranslation(0, dy, dz));}          
 	}
     
       TGeoBBox *Pillar1Box = new TGeoBBox(fPillarX/2,fPillarY/2, fPillarZ/2);
       TGeoVolume *Pillar1Vol = new TGeoVolume("Pillar1Vol",Pillar1Box,Steel);
       Pillar1Vol->SetLineColor(kGreen+3);
 
-      tTauNuDet->AddNode(Pillar1Vol,1, new TGeoTranslation(-fXtot/2+fPillarX/2,-fYtot/2-fPillarY/2,fZcenter-fZtot/2+fPillarZ/2));
-      tTauNuDet->AddNode(Pillar1Vol,2, new TGeoTranslation(fXtot/2-fPillarX/2,-fYtot/2-fPillarY/2,fZcenter-fZtot/2 +fPillarZ/2));
+      //tTauNuDet->AddNode(Pillar1Vol,1, new TGeoTranslation(-fXtot/2+fPillarX/2,-fYtot/2-fPillarY/2,fZcenter-fZtot/2+fPillarZ/2));
+      //tTauNuDet->AddNode(Pillar1Vol,2, new TGeoTranslation(fXtot/2-fPillarX/2,-fYtot/2-fPillarY/2,fZcenter-fZtot/2 +fPillarZ/2));
       //      tTauNuDet->AddNode(Pillar1Vol,3, new TGeoTranslation(-fXtot/2+fPillarX/2,-fYtot/2-fPillarY/2,fZcenter+fZtot/2-fPillarZ/2)); //eventually two pillars at the end. Now muon det is followed by veto, so its steel pillar supports both
       //tTauNuDet->AddNode(Pillar1Vol,4, new TGeoTranslation(fXtot/2-fPillarX/2,-fYtot/2-fPillarY/2,fZcenter+fZtot/2-fPillarZ/2));
 
@@ -634,8 +789,8 @@ Bool_t  NuTauMudet::ProcessHits(FairVolume* vol)
     Int_t pdgCode = p->GetPdgCode();
     Int_t detID=0;
     gMC->CurrentVolID(detID);
-
-    // cout<< "detID = " << detID << endl;
+    //cout<<"THIS HIT"<<endl;
+    //cout<< "detID = " << detID << endl;
     Int_t MaxLevel = gGeoManager->GetLevel();
     const Int_t MaxL = MaxLevel;
     //cout << "MaxLevel = " << MaxL << endl;
@@ -643,9 +798,13 @@ Bool_t  NuTauMudet::ProcessHits(FairVolume* vol)
     Int_t NRpc =0;
     const char *name;
     name = gMC->CurrentVolName();
-    //cout << name << endl;
-    Int_t motherID = gGeoManager->GetMother(0)->GetNumber();
-    const char *mumname = gMC->CurrentVolOffName(0);
+    //cout << name << " ";
+    Int_t motherID = 0;
+    if( strcmp(name, "volRpc")==0){motherID = gGeoManager->GetMother(1)->GetNumber();}
+    else{motherID = gGeoManager->GetMother(0)->GetNumber();}
+    /* This up here is made because of a strange behaviour of the script, volRpc gets different
+    Mother volume number even if it has the correct path */
+    const char *mumname = gMC->CurrentVolOffName(1);
     //cout<<mumname<<"   "<< motherID<<endl;
     detID = motherID;
     //cout<< "detID = " << detID << endl;

--- a/nutaudet/NuTauMudet.h
+++ b/nutaudet/NuTauMudet.h
@@ -40,9 +40,15 @@ class NuTauMudet:public FairDetector
     void SetReturnYokeDimensions(Double_t X, Double_t Y, Double_t Z);
     void SetSmallerYokeDimensions(Double_t X, Double_t Y, Double_t Z);
     void SetCoilParameters(Double_t CoilH, Double_t CoilW, Int_t N, Double_t CoilG);
-    void SetSupportTransverseDimensions(Double_t UpperSupportX, Double_t UpperSupportY, Double_t LowerSupportX, Double_t LowerSupportY, Double_t LateralSupportX, Double_t LateralSupportY);
+    void SetSupportTransverseDimensions(Double_t UpperSupportX, Double_t UpperSupportY, Double_t LowerSupportX, Double_t LowerSupportY, Double_t LateralSupportX, Double_t LateralSupportY, Double_t YSpacing);
     void SetLateralCutSize(Double_t CutHeight , Double_t CutLength); //lateral triangular cuts
     void SetPillarDimensions(Double_t X, Double_t Y, Double_t Z);
+    void SetUpperCoverDimensions(Double_t X, Double_t Y, Double_t Z);
+    void SetLateralCoverDimensions(Double_t X, Double_t Y, Double_t Z);
+    void SetCrossDimensions(Double_t X, Double_t Y, Double_t Z, Double_t WidthArm);
+    void SetRpcOuterDimensions(Double_t X, Double_t Y, Double_t Z);
+    void SetRpcInnerDimensions(Double_t X, Double_t Y, Double_t Z);
+    void SetRpcGapDimensions(Double_t X, Double_t Y, Double_t Z);
 
     void ConstructGeometry();
     
@@ -159,12 +165,39 @@ protected:
     Double_t fUpSuppX, fUpSuppY;//Dimensions of iron support structures
     Double_t fLowSuppX, fLowSuppY;
     Double_t fLatSuppX, fLatSuppY; //lateral supports
+    Double_t fYSpacing;
 
     Double_t fCutHeight, fCutLength; //Cut dimensions
     //Dimension of steel pillars
     Double_t fPillarX;
     Double_t fPillarY;
     Double_t fPillarZ;
+    //Dimension of upper cover on the RPC
+    Double_t fXCov;
+    Double_t fYCov;
+    Double_t fZCov;
+    //Dimension of lateral covers on RPC
+    Double_t fXLateral;
+    Double_t fYLateral;
+    Double_t fZLateral;
+    //Dimension of lateral crosses on RPC
+    Double_t fXCross;
+    Double_t fYCross;
+    Double_t fZCross;
+    Double_t fWidthArm;
+    //Dimension of outer frame of RPC
+    Double_t fXRpc_outer;
+    Double_t fYRpc_outer;
+    Double_t fZRpc_outer;
+    //Dimension of inner frame of RPC
+    Double_t fXRpc_inner;
+    Double_t fYRpc_inner;
+    Double_t fZRpc_inner;
+    //Dimension of gaps in RPC
+    Double_t fXRpcGap;
+    Double_t fYRpcGap;
+    Double_t fZRpcGap;
+
 
 
     NuTauMudet(const NuTauMudet&);

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -473,13 +473,9 @@ def configure(run,ship_geo):
   run.SetField(fMagField)
 #
  exclusionList = []
-<<<<<<< HEAD
  #exclusionList = ["Muon","Ecal","Hcal","Strawtubes","TargetTrackers","NuTauTarget","HighPrecisionTrackers",\
  #                 "Veto","Magnet","MuonShield","TargetStation","NuTauMudet","EmuMagnet", "TimeDet", "UpstreamTagger"]
-=======
-# exclusionList = ["Muon","Ecal","Hcal","Strawtubes",\
-#                  "Veto","Magnet","MuonShield","TargetStation", "TimeDet"]
->>>>>>> 0fa9a94... Added Rpc new geometry components
+
  for x in detectorList:
    if x.GetName() in exclusionList: continue
    run.AddModule(x)

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -207,7 +207,7 @@ def configure(run,ship_geo):
       taumuondetector.SetLateralCutSize(ship_geo.tauMudet.CutHeight, ship_geo.tauMudet.CutLength)
       taumuondetector.SetSupportTransverseDimensions(ship_geo.tauMudet.UpperSupportX,ship_geo.tauMudet.UpperSupportY, \
                                                      ship_geo.tauMudet.LowerSupportX, ship_geo.tauMudet.LowerSupportY, \
-                                                     ship_geo.tauMudet.LateralSupportX, ship_geo.tauMudet.LateralSupportY)
+                                                     ship_geo.tauMudet.LateralSupportX, ship_geo.tauMudet.LateralSupportY, ship_geo.tauMudet.YSpacing)
    else: #geometry used before new iron sampling
       taumuondetector.SetFeDimensions(ship_geo.tauMudet.XFe,ship_geo.tauMudet.YFe, ship_geo.tauMudet.ZFe)
       taumuondetector.SetNFeInArm(ship_geo.tauMudet.NFe)
@@ -217,6 +217,12 @@ def configure(run,ship_geo):
    taumuondetector.SetRpcElectrodeDimensions(ship_geo.tauMudet.XEle,ship_geo.tauMudet.YEle, ship_geo.tauMudet.ZEle)
    taumuondetector.SetRpcPETDimensions(ship_geo.tauMudet.XPet,ship_geo.tauMudet.YPet, ship_geo.tauMudet.ZPet)
    taumuondetector.SetNRpcInArm(ship_geo.tauMudet.NRpc)
+   taumuondetector.SetUpperCoverDimensions(ship_geo.tauMudet.XCov, ship_geo.tauMudet.YCov, ship_geo.tauMudet.ZCov)
+   taumuondetector.SetLateralCoverDimensions(ship_geo.tauMudet.XLateral, ship_geo.tauMudet.YLateral, ship_geo.tauMudet.ZLateral)
+   taumuondetector.SetCrossDimensions(ship_geo.tauMudet.XCross, ship_geo.tauMudet.YCross, ship_geo.tauMudet.ZCross, ship_geo.tauMudet.WidthArm)
+   taumuondetector.SetRpcOuterDimensions(ship_geo.tauMudet.XRpc_outer, ship_geo.tauMudet.YRpc_outer, ship_geo.tauMudet.ZRpc_outer)
+   taumuondetector.SetRpcInnerDimensions(ship_geo.tauMudet.XRpc_inner, ship_geo.tauMudet.YRpc_inner, ship_geo.tauMudet.ZRpc_inner)
+   taumuondetector.SetRpcGapDimensions(ship_geo.tauMudet.XRpcGap, ship_geo.tauMudet.YRpcGap, ship_geo.tauMudet.ZRpcGap)
    taumuondetector.SetPillarDimensions(ship_geo.tauMudet.PillarX,ship_geo.tauMudet.PillarY, ship_geo.tauMudet.PillarZ)
    detectorList.append(taumuondetector)
    if ship_geo.nuTauTargetDesign==3:
@@ -467,8 +473,13 @@ def configure(run,ship_geo):
   run.SetField(fMagField)
 #
  exclusionList = []
+<<<<<<< HEAD
  #exclusionList = ["Muon","Ecal","Hcal","Strawtubes","TargetTrackers","NuTauTarget","HighPrecisionTrackers",\
  #                 "Veto","Magnet","MuonShield","TargetStation","NuTauMudet","EmuMagnet", "TimeDet", "UpstreamTagger"]
+=======
+# exclusionList = ["Muon","Ecal","Hcal","Strawtubes",\
+#                  "Veto","Magnet","MuonShield","TargetStation", "TimeDet"]
+>>>>>>> 0fa9a94... Added Rpc new geometry components
  for x in detectorList:
    if x.GetName() in exclusionList: continue
    run.AddModule(x)


### PR DESCRIPTION
I improved the description of the Muon Identification System of the SND detector, I added the following components : 
- Upper Cover : an aluminum plate on the top of the detector;
- Lateral Cover : four aluminum covers attached to the lateral supports of the iron plates on both sides;
- Lateral Cross : two aluminum crosses on both sides standing between the Lateral Covers;
- Improved details of RPCs : aluminum frames, strips, gaps and gas.

Moreover, height and width of the iron plates and the lower/upper supports have been changed and the staggering of the RPC planes has been implemented.
The totality of these changes are made with respect to the following design by A. Crupano as shown by M. De Serio at the 19th SHiP collaboration meeting on 2nd of April 2020.
![Schermata 2020-04-02 alle 13 46 14](https://user-images.githubusercontent.com/53048804/78245806-63927a00-74e8-11ea-9868-0a2bcb70bd3b.png)
![ perspective_total](https://user-images.githubusercontent.com/53048804/78246255-267ab780-74e9-11ea-965a-9b07e480d805.png)