### PR TITLE
Rearrangement of positioning logic

### DIFF
--- a/UpstreamTagger/UpstreamTagger.cxx
+++ b/UpstreamTagger/UpstreamTagger.cxx
@@ -98,7 +98,7 @@ UpstreamTagger::UpstreamTagger()
 {
 }
 
-UpstreamTagger::UpstreamTagger(const char* name, Bool_t active)
+UpstreamTagger::UpstreamTagger(const char* name, Bool_t active, Double_t BX, Double_t BY, Double_t BZ)
   : FairDetector(name, active, kUpstreamTagger),
     fTrackID(-1),
     fVolumeID(-1),
@@ -108,7 +108,11 @@ UpstreamTagger::UpstreamTagger(const char* name, Bool_t active)
     fLength(-1.),
     fELoss(-1),
     //
-    det_zPos(0),     
+    det_zPos(0), 
+
+    xbox_fulldet(BX),
+    ybox_fulldet(BY),
+    zbox_fulldet(BZ),    
 
     det_xGlassPos(0),    
     det_yGlassPos(0),    

--- a/UpstreamTagger/UpstreamTagger.h
+++ b/UpstreamTagger/UpstreamTagger.h
@@ -19,7 +19,7 @@ class UpstreamTagger: public FairDetector
      *       Active: kTRUE for active detectors (ProcessHits() will be called)
      *               kFALSE for inactive detectors
     */
-    UpstreamTagger(const char* Name, Bool_t Active);
+    UpstreamTagger(const char* Name, Bool_t Active, Double_t BX, Double_t BY, Double_t BZ);
 
     /** default constructor */
     UpstreamTagger();
@@ -46,6 +46,10 @@ class UpstreamTagger: public FairDetector
 
     /** Sets detector position and sizes */
     void SetZposition(Double_t z) {det_zPos = z;}
+
+    void SetZSpace_Layers(Double_t spacelayers) {z_space_layers = spacelayers;}
+    void SetExtraY(Double_t extray) {extra_y = extray;}
+
     void SetSizeX_Glass(Double_t xg) {det_xGlassPos = xg;}
     void SetSizeY_Glass(Double_t yg) {det_yGlassPos = yg;}
     void SetSizeZ_Glass(Double_t zg) {det_zGlassPos = zg;}
@@ -164,11 +168,11 @@ class UpstreamTagger: public FairDetector
     Double_t     det_yStripPos;     //!  y-size of Strip for modules with 32 strips
     Double_t     det_zStripPos;     //!  z-size of Strip
     
-    Double_t xbox_fulldet = 233.4; //cm 
-    Double_t ybox_fulldet = 507; 
-    Double_t zbox_fulldet = 17.0024;
-    Double_t z_space_layers = 0.2;  
-    Double_t extra_y = 6.5; 
+    Double_t xbox_fulldet; //cm 
+    Double_t ybox_fulldet; 
+    Double_t zbox_fulldet;
+    Double_t z_space_layers;  
+    Double_t extra_y; 
     
     TGeoVolume* UpstreamTagger_fulldet; // Timing_detector_1 object
    

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -485,6 +485,56 @@ with ConfigRegistry.register_config("basic") as c:
        c.strawtubes.tr12ydim           = int(c.Yheight/2.)
        c.strawtubes.tr34ydim           = int(c.Yheight/2.)
 
+    #Upstream Tagger
+    c.UpstreamTagger = AttrDict(z=0)
+    
+    c.UpstreamTagger.BX = 233.4 * u.cm
+    c.UpstreamTagger.BY = 507 * u.cm
+    c.UpstreamTagger.BZ = 17.0024 * u.cm
+
+    c.UpstreamTagger.Z_Space_Layers = 0.2 * u.cm
+    c.UpstreamTagger.Extra_Y = 6.5 * u.cm
+
+    c.UpstreamTagger.Z_Glass = 0.2 * u.cm
+    c.UpstreamTagger.Y_Glass = 105 * u.cm   
+    c.UpstreamTagger.X_Glass = 223 * u.cm   
+    c.UpstreamTagger.Z_Glass_Border = 0.2 * u.cm
+    c.UpstreamTagger.Y_Glass_Border = 1.0 * u.cm
+    c.UpstreamTagger.X_Glass_Border = 1.0 * u.cm
+    c.UpstreamTagger.Z_PMMA = 0.8 * u.cm
+    c.UpstreamTagger.Y_PMMA = 108 * u.cm
+    c.UpstreamTagger.X_PMMA = 226 * u.cm
+    c.UpstreamTagger.DY_PMMA = 1.5 * u.cm
+    c.UpstreamTagger.DX_PMMA = 1.5 * u.cm
+    c.UpstreamTagger.DZ_PMMA = 0.1 * u.cm
+    c.UpstreamTagger.Z_FreonSF6 = 0.1 * u.cm
+    c.UpstreamTagger.Y_FreonSF6 = 107 * u.cm
+    c.UpstreamTagger.X_FreonSF6 = 225 * u.cm
+    c.UpstreamTagger.Z_FreonSF6_2 = 0.8 * u.cm
+    c.UpstreamTagger.Y_FreonSF6_2 = 0.5 * u.cm
+    c.UpstreamTagger.X_FreonSF6_2 = 0.5 * u.cm
+    c.UpstreamTagger.Z_FR4 = 0.15 * u.cm
+    c.UpstreamTagger.Y_FR4 = 111 * u.cm
+    c.UpstreamTagger.X_FR4 = 229 * u.cm
+    c.UpstreamTagger.Z_Aluminium = 1.1503 * u.cm
+    c.UpstreamTagger.Y_Aluminium = 111 * u.cm
+    c.UpstreamTagger.X_Aluminium = 233 * u.cm
+    c.UpstreamTagger.DZ_Aluminium = 0.1 * u.cm
+    c.UpstreamTagger.DY_Aluminium = 1 * u.cm
+    c.UpstreamTagger.DX_Aluminium = 0.2 * u.cm
+    c.UpstreamTagger.Z_Air = 1.1503 * u.cm
+    c.UpstreamTagger.Y_Air = 0 * u.cm
+    c.UpstreamTagger.X_Air = 2 * u.cm
+    c.UpstreamTagger.Z_Strip = 0.0003 * u.cm
+    c.UpstreamTagger.Y_Strip = 3.1 * u.cm
+    c.UpstreamTagger.X_Strip = 229 * u.cm
+    c.UpstreamTagger.X_Strip64 = 3.3 * u.cm
+    c.UpstreamTagger.Y_Strip64 = 111 * u.cm
+
+    c.UpstreamTagger.DistChamber1 = 7.4988 * u.cm
+
+    c.UpstreamTagger.Z_Position = c.Chamber1.z - c.chambers.Tub1length - c.Veto.innerSupport - c.UpstreamTagger.DistChamber1 - c.UpstreamTagger.BZ/2.
+
     #Parameters for tau neutrino target Magnet
     if nuTauTargetDesign!=2:
         c.EmuMagnet = AttrDict(z=0*u.cm)
@@ -628,7 +678,10 @@ with ConfigRegistry.register_config("basic") as c:
         c.tauMudet.Ytot = c.tauMudet.YFe + c.tauMudet.UpperSupportY + c.tauMudet.LowerSupportY 
         c.tauMudet.Ztot = c.tauMudet.NRpc*c.tauMudet.ZRpc+c.tauMudet.NFethick*c.tauMudet.ZFethick + c.tauMudet.NFethin*c.tauMudet.ZFethin
         #c.tauMudet.zMudetC = -c.decayVolume.length/2. - c.tauMudet.Ztot/2
-        c.tauMudet.zMudetC = c.Chamber1.z -c.chambers.Tub1length - c.tauMudet.Ztot/2 -31*u.cm;
+        c.tauMudet.DistTagger = 3.4988 * u.cm
+        #c.UpstreamTagger.Z_Position = c.tauMudet.zMudetC + (c.tauMudet.Ztot)/2 + c.UpstreamTagger.BZ/2 +c.UpstreamTagger.DistMuDet
+        #c.tauMudet.zMudetC = c.Chamber1.z -c.chambers.Tub1length - c.tauMudet.Ztot/2 -31*u.cm;
+        c.tauMudet.zMudetC = c.UpstreamTagger.Z_Position -c.UpstreamTagger.BZ/2. - c.tauMudet.DistTagger - c.tauMudet.Ztot/2.
         #lateral cuts
         c.tauMudet.CutHeight = 78.548 * u.cm
         c.tauMudet.CutLength = (c.tauMudet.CutHeight / 2) / (r.TMath.Tan(r.TMath.DegToRad() * 55))
@@ -808,42 +861,3 @@ with ConfigRegistry.register_config("basic") as c:
     c.NuTauTarget.PillarX = 0.5*u.m
     c.NuTauTarget.PillarZ = 0.5*u.m
     c.NuTauTarget.PillarY = 10*u.m - c.NuTauTarget.ydim/2 -c.NuTauTarget.BaseY- 0.1*u.mm - c.cave.floorHeightMuonShield
-
-    #Upstream Tagger
-    c.UpstreamTagger = AttrDict(z=0)
-    c.UpstreamTagger.Z_Glass = 0.2 * u.cm
-    c.UpstreamTagger.Y_Glass = 105 * u.cm   
-    c.UpstreamTagger.X_Glass = 223 * u.cm   
-    c.UpstreamTagger.Z_Glass_Border = 0.2 * u.cm
-    c.UpstreamTagger.Y_Glass_Border = 1.0 * u.cm
-    c.UpstreamTagger.X_Glass_Border = 1.0 * u.cm
-    c.UpstreamTagger.Z_PMMA = 0.8 * u.cm
-    c.UpstreamTagger.Y_PMMA = 108 * u.cm
-    c.UpstreamTagger.X_PMMA = 226 * u.cm
-    c.UpstreamTagger.DY_PMMA = 1.5 * u.cm
-    c.UpstreamTagger.DX_PMMA = 1.5 * u.cm
-    c.UpstreamTagger.DZ_PMMA = 0.1 * u.cm
-    c.UpstreamTagger.Z_FreonSF6 = 0.1 * u.cm
-    c.UpstreamTagger.Y_FreonSF6 = 107 * u.cm
-    c.UpstreamTagger.X_FreonSF6 = 225 * u.cm
-    c.UpstreamTagger.Z_FreonSF6_2 = 0.8 * u.cm
-    c.UpstreamTagger.Y_FreonSF6_2 = 0.5 * u.cm
-    c.UpstreamTagger.X_FreonSF6_2 = 0.5 * u.cm
-    c.UpstreamTagger.Z_FR4 = 0.15 * u.cm
-    c.UpstreamTagger.Y_FR4 = 111 * u.cm
-    c.UpstreamTagger.X_FR4 = 229 * u.cm
-    c.UpstreamTagger.Z_Aluminium = 1.1503 * u.cm
-    c.UpstreamTagger.Y_Aluminium = 111 * u.cm
-    c.UpstreamTagger.X_Aluminium = 233 * u.cm
-    c.UpstreamTagger.DZ_Aluminium = 0.1 * u.cm
-    c.UpstreamTagger.DY_Aluminium = 1 * u.cm
-    c.UpstreamTagger.DX_Aluminium = 0.2 * u.cm
-    c.UpstreamTagger.Z_Air = 1.1503 * u.cm
-    c.UpstreamTagger.Y_Air = 0 * u.cm
-    c.UpstreamTagger.X_Air = 2 * u.cm
-    c.UpstreamTagger.Z_Strip = 0.0003 * u.cm
-    c.UpstreamTagger.Y_Strip = 3.1 * u.cm
-    c.UpstreamTagger.X_Strip = 229 * u.cm
-    c.UpstreamTagger.X_Strip64 = 3.3 * u.cm
-    c.UpstreamTagger.Y_Strip64 = 111 * u.cm
-    c.UpstreamTagger.Z_Position = c.tauMudet.zMudetC + (c.tauMudet.Ztot)/2 + 12.0*u.cm

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -418,8 +418,10 @@ def configure(run,ship_geo):
  Muon.SetFilterThickness(ship_geo.Muon.FilterThickness)
  detectorList.append(Muon)
 
- upstreamTagger = ROOT.UpstreamTagger("UpstreamTagger", ROOT.kTRUE)
+ upstreamTagger = ROOT.UpstreamTagger("UpstreamTagger", ROOT.kTRUE,ship_geo.UpstreamTagger.BX,ship_geo.UpstreamTagger.BY,ship_geo.UpstreamTagger.BZ)
  upstreamTagger.SetZposition(ship_geo.UpstreamTagger.Z_Position)
+ upstreamTagger.SetZSpace_Layers(ship_geo.UpstreamTagger.Z_Space_Layers)
+ upstreamTagger.SetExtraY(ship_geo.UpstreamTagger.Extra_Y)
  upstreamTagger.SetSizeX_Glass(ship_geo.UpstreamTagger.X_Glass)
  upstreamTagger.SetSizeY_Glass(ship_geo.UpstreamTagger.Y_Glass)
  upstreamTagger.SetSizeZ_Glass(ship_geo.UpstreamTagger.Z_Glass)


### PR DESCRIPTION
Dear all FairShip users,

here the positioning logic of the SND detector is revisited as requested, following the work by @CelsoFCF  and @dcentanni . Now it follows the physical orders of detectors, from downstream to upstream:

* **UpstreamTagger**:  c.UpstreamTagger.Z_Position = c.Chamber1.z - c.chambers.Tub1length - c.Veto.innerSupport - c.UpstreamTagger.DistChamber1 - c.UpstreamTagger.BZ/2.
* **MuonFilter:** c.tauMudet.zMudetC = c.UpstreamTagger.Z_Position -c.UpstreamTagger.BZ/2. - c.tauMudet.DistTagger - c.tauMudet.Ztot/2.
* **Magnet**: c.EmuMagnet.zC = c.tauMudet.zMudetC - c.tauMudet.Ztot/2 - c.EmuMagnet.GapDown - c.EmuMagnet.Z/2 (kept as before, not changed)

The UpstreamTagger attributes definitions are therefore moved before the other ones. Also, the box dimensions have been moved from the class to the geometry_config.py.
Please let me know if you have any questions.