### PR TITLE
Disable triggered clang-tidy warnings, don't make them errors (yet)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,15 @@
-WarningsAsErrors: '*'
+---
+# WarningsAsErrors: '*'
+Checks: -clang-analyzer-core.UndefinedBinaryOperatorResult,
+    -clang-analyzer-core.CallAndMessage,
+    -clang-analyzer-deadcode.DeadStores,
+    -clang-analyzer-security.FloatLoopCounter,
+    -clang-diagnostic-deprecated-declarations,
+    -clang-analyzer-optin.cplusplus.VirtualCall,
+    -clang-analyzer-cplusplus.NewDeleteLeaks,
+    -clang-analyzer-core.DivideZero,
+    -clang-diagnostic-logical-op-parentheses,
+    -clang-diagnostic-literal-conversion,
+    -clang-diagnostic-shadow,
+    -clang-diagnostic-string-compare,
+    -clang-diagnostic-return-type,


### PR DESCRIPTION
Similar to #343, but this time for `clang-tidy`:

- Disable warnings triggered (to be fixed and re-enabled one-by-one)
- Don't make them errors (to not break the build)

Installation of `clang-tidy` should best be done using the system package manager if possible, because we definitely don't want to build the `clang` toolchain.

To test, add the following to the `cmake` invocation in `fairship.sh`:

```bash
      -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
```