### PR TITLE
Setting transverse size of SND emulsion target to values from CDS

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -703,8 +703,8 @@ with ConfigRegistry.register_config("basic") as c:
         c.NuTauTarget.wall=20
     if c.NuTauTarget.Design == 3: #One unique magnet, eventually more than one target volume 
         #c.NuTauTarget.n_plates = 56 
-        c.NuTauTarget.row = 7
-        c.NuTauTarget.col = 7
+        c.NuTauTarget.row = 2
+        c.NuTauTarget.col = 2
         c.NuTauTarget.wall = 19
     c.NuTauTarget.n_plates = 56
      
@@ -713,17 +713,17 @@ with ConfigRegistry.register_config("basic") as c:
     c.NuTauTarget.nuTargetPassive = nuTargetPassive
 
     # space for the structure that holds the brick
-    c.NuTauTarget.Ydist = 0.2*u.cm
+    c.NuTauTarget.Ydist = 0.0*u.cm
     c.NuTauTarget.SingleEmFilm = True
     c.NuTauTarget.EmTh = 0.0070 * u.cm
-    c.NuTauTarget.EmX = 12.5 * u.cm
-    c.NuTauTarget.EmY = 9.9 * u.cm
+    c.NuTauTarget.EmX = 40.0 * u.cm
+    c.NuTauTarget.EmY = 40.0 * u.cm
     c.NuTauTarget.PBTh = 0.0175 * u.cm
     c.NuTauTarget.LeadTh = 0.1 * u.cm
     c.NuTauTarget.EPlW = 2* c.NuTauTarget.EmTh + c.NuTauTarget.PBTh
     c.NuTauTarget.AllPW = c.NuTauTarget.LeadTh + c.NuTauTarget.EPlW
-    c.NuTauTarget.BrX = 12.9 * u.cm
-    c.NuTauTarget.BrY = 10.5 * u.cm
+    c.NuTauTarget.BrX = 41.0 * u.cm
+    c.NuTauTarget.BrY = 41.0 * u.cm
     c.NuTauTarget.BrPackZ = 0.1045 * u.cm
     c.NuTauTarget.BrPackX = c.NuTauTarget.BrX - c.NuTauTarget.EmX
     c.NuTauTarget.BrPackY = c.NuTauTarget.BrY - c.NuTauTarget.EmY


### PR DESCRIPTION
Dear FairShip users,

I noticed that I have still not updated in the master FairShip repository the tranvserse structure of the emulsion target to the structure reported in the CDS document. I am sorry for the delay, and I address this here.

The structure is the one with the 2 x 2 emulsion bricks, presented in both the Collaboration meetings and the CDS report.
On the code side, only some parameters from the geometry file needed to be changed.

As usual, I have confirmed the absence of overlaps. If you have any question, please let me know.

Yours,
Antonio