### PR TITLE
fieldMap generation + tools

### DIFF
--- a/field/ShipFieldMaker.h
+++ b/field/ShipFieldMaker.h
@@ -255,6 +255,9 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction
     void plotField(Int_t type, const TVector3& xAxis, const TVector3& yAxis,
 		   const std::string& plotFile) const;
 
+    void generateFieldMap(TString fileName, const float step=2.5, const float xRange=179, const float yRange=317, const float zRange=1515.5, const float zShift=-4996);
+    //! Generate fieldMap csv file in the given region
+
     //! ClassDef for ROOT
     ClassDef(ShipFieldMaker,1);
 

--- a/field/add_noise_to_field.py
+++ b/field/add_noise_to_field.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import numpy as np
+import matplotlib.pylab as plt
+from scipy.ndimage import gaussian_filter
+import random
+import argparse
+def plot_my_hist(datum):
+    plotData = datum[datum['y'] == 0]
+    H, xedges, yedges = np.histogram2d(plotData['x'], plotData['z'], bins=[50, 500], weights=plotData['by'])
+    plt.figure(figsize=[20, 10])
+    plt.imshow(H, interpolation='nearest', origin='low')
+    # plt.colorbar()
+    plt.show()
+def generate_file(input_fileName, output, xSpace=73, ySpace=128, zSpace=1214, step=2.5, args=None):  # (min, max, max/stepSize + 1)  in case of Z: (0, nSteps*2.5 - 2.5, nSteps)
+    field = pd.read_csv(input_fileName, skiprows=1, sep ='\s+', names=['x', 'y', 'z', 'bx', 'by', 'bz'])
+
+    field_mask = field.copy()
+    field_mask[['bx', 'by', 'bz']] = field_mask[['bx', 'by', 'bz']] != 0
+
+    field_new = field.copy()
+
+    if args.sidesOnly:
+
+        temp_by = field_new['by'].to_numpy().reshape([xSpace, ySpace, zSpace])
+        temp_by = gaussian_filter(temp_by, sigma=args.sigma)
+        field_new['by'] = temp_by.reshape(-1)
+        field_new['by'] = field_new['by'] * field_mask['by']
+        rezult = field_new
+
+    else:
+        field_new[['bx', 'by', 'bz']] = 0
+        index_range = np.random.choice(field_new.index, size=args.nCores)
+        field_new.loc[index_range, 'by'] = random.uniform(-args.peak, args.peak)
+        temp_by = field_new['by'].to_numpy().reshape([xSpace, ySpace, zSpace])
+        temp_by = gaussian_filter(temp_by, sigma=args.sigma)
+        field_new['by'] = temp_by.reshape(-1)
+        field_new['by'] = field_new['by'] / (field_new['by'].abs().max())  # *field_mask['by']
+        field_new['by'] = field_new['by'] * field_mask['by']
+        rezult = field.copy()
+        rezult['by'] = rezult['by'] + rezult['by'] * field_new['by'] * args.fraction
+
+
+
+    # plot_my_hist(field_mask)
+    # plot_my_hist(field)
+    # plot_my_hist(field_new)
+    # plot_my_hist(rezult)
+    rezult.to_csv(output, sep='\t', header=None, index=None)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Process field.')
+    parser.add_argument('--input', default='fieldMap.csv', type=str, action='store')
+    parser.add_argument('--output', default='noisy_fieldMap.csv', type=str, action='store')
+    parser.add_argument('--sidesOnly', default=False,  action='store_true')
+    parser.add_argument('--sigma', default=30, type=float, action='store')
+    parser.add_argument('--nCores', default=1000, type=int, action='store')
+    parser.add_argument('--peak', default=500, type=float, action='store')
+    parser.add_argument('--fraction', default=0.4, type=float, action='store')
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        first_line = f.readline().strip().split()
+        #        myfile<<xSteps<<"    "<<ySteps<<"    "<<zSteps<<"    "<<step<<"    "<<xRange<<"    "<<yRange<<"    "<<zRange<<std::endl;
+
+    generate_file(args.input, args.output, xSpace=int(first_line[0]), ySpace=int(first_line[1]),zSpace=int(first_line[2]), step=float(first_line[3]), args=args)

--- a/field/convertNoisyMap.py
+++ b/field/convertNoisyMap.py
@@ -1,0 +1,230 @@
+#!/bin/python
+
+# Python script to convert a B field map from an ascii text file into
+# a ROOT file for FairShip. The field map needs to use a regular
+# x,y,z binning structure where the co-ordinates are assumed to
+# be in ascending z, y and x, in that order. Each data line needs to
+# contain the values "x y z Bx By Bz", with the field components in Tesla.
+# Comment lines in the datafile starting with the hash symbol # are ignored.
+# Distances for FairShip need to be in cm, so we use a scaling factor
+# cmScale (default = 1.0) to convert the text file distances into cm.
+# For example, if the input data uses mm for lengths, cmScale = 0.1.
+
+import ROOT
+import pandas as pd
+
+# Struct for the ROOT file TTree data: coord range and field binning
+
+ROOT.gROOT.ProcessLine(
+    "struct rangeStruct{\
+       float xMin;\
+       float xMax;\
+       float dx;\
+       float yMin;\
+       float yMax;\
+       float dy;\
+       float zMin;\
+       float zMax;\
+       float dz;\
+    };");
+
+# The field map is assumed to obey the following co-ordinate bin ordering:
+# z is increased first, y is increased 2nd, x is increased last.
+# For the coordinate bin (iX, iY, iZ), the field bin = (iX*Ny + iY)*Nz + iZ,
+# where Ny and Nz are the number of y and z bins
+
+ROOT.gROOT.ProcessLine(
+    "struct dataStruct{\
+       float x;\
+       float y;\
+       float z;\
+       float Bx;\
+       float By;\
+       float Bz;\
+    };");
+
+
+def run(inFileName='FieldTest.txt', rootFileName='BFieldTest.root',
+        cmScale=1.0, storeCoords=False):
+    createRootMap(inFileName, rootFileName, cmScale, storeCoords)
+
+
+def createRootMap(inFileName, rootFileName, cmScale, storeCoords):
+    print ('Create map {0} from {1} using cmScale = {2}'.format(rootFileName,
+                                                               inFileName, cmScale))
+    if storeCoords is True:
+        print ('We will also store the x,y,z field coordinates in {0}'.format(rootFileName))
+
+    rangeInfo = findRanges(inFileName, cmScale)
+
+    # Define ROOT file and its TTree
+    theFile = ROOT.TFile.Open(rootFileName, 'recreate')
+
+    rangeTree = ROOT.TTree('Range', 'Range')
+    rangeTree.SetDirectory(theFile)
+
+    # Co-ordinate ranges
+    rStruct = ROOT.rangeStruct()
+    rangeTree.Branch('xMin', ROOT.AddressOf(rStruct, 'xMin'), 'xMin/F')
+    rangeTree.Branch('xMax', ROOT.AddressOf(rStruct, 'xMax'), 'xMax/F')
+    rangeTree.Branch('dx', ROOT.AddressOf(rStruct, 'dx'), 'dx/F')
+    rangeTree.Branch('yMin', ROOT.AddressOf(rStruct, 'yMin'), 'yMin/F')
+    rangeTree.Branch('yMax', ROOT.AddressOf(rStruct, 'yMax'), 'yMax/F')
+    rangeTree.Branch('dy', ROOT.AddressOf(rStruct, 'dy'), 'dy/F')
+    rangeTree.Branch('zMin', ROOT.AddressOf(rStruct, 'zMin'), 'zMin/F')
+    rangeTree.Branch('zMax', ROOT.AddressOf(rStruct, 'zMax'), 'zMax/F')
+    rangeTree.Branch('dz', ROOT.AddressOf(rStruct, 'dz'), 'dz/F')
+
+    rStruct.xMin = rangeInfo['xMin']
+    rStruct.xMax = rangeInfo['xMax']
+    rStruct.dx = rangeInfo['dx']
+    rStruct.yMin = rangeInfo['yMin']
+    rStruct.yMax = rangeInfo['yMax']
+    rStruct.dy = rangeInfo['dy']
+    rStruct.zMin = rangeInfo['zMin']
+    rStruct.zMax = rangeInfo['zMax']
+    rStruct.dz = rangeInfo['dz']
+
+    # Centre the field map on the local origin (cm)
+    x0 = 0#.5 * (rStruct.xMin + rStruct.xMax)
+    y0 = 0#.5 * (rStruct.yMin + rStruct.yMax)
+    z0 = 0.5 * (rStruct.zMin + rStruct.zMax)
+
+    # Use this if we don't want to centre the field map
+    # x0 = 0.0
+    # y0 = 0.0
+    # z0 = 0.0
+
+    print ('Centering field map using co-ordinate shift {0} {1} {2} cm'.format(x0, y0, z0))
+
+    # Center co-ordinate range limits (cm)
+    rStruct.xMin = rStruct.xMin - x0
+    rStruct.xMax = rStruct.xMax - x0
+
+    rStruct.yMin = rStruct.yMin - y0
+    rStruct.yMax = rStruct.yMax - y0
+
+    rStruct.zMin = rStruct.zMin - z0
+    rStruct.zMax = rStruct.zMax - z0
+
+    print ('x range = {0} to {1}'.format(rStruct.xMin, rStruct.xMax))
+    print ('y range = {0} to {1}'.format(rStruct.yMin, rStruct.yMax))
+    print ('z range = {0} to {1}'.format(rStruct.zMin, rStruct.zMax))
+
+    # Fill info into range tree
+    rangeTree.Fill()
+
+    # Store field data components
+    dataTree = ROOT.TTree('Data', 'Data')
+    dataTree.SetDirectory(theFile)
+
+    # Field components with (x,y,z) coordinate binning ordered such that
+    # z, then y, then x is increased. For the coordinate bin (iX, iY, iZ),
+    # the field bin = (iX*Ny + iY)*Nz + iZ, where Ny and Nz are the number
+    # of y and z bins
+    dStruct = ROOT.dataStruct()
+    if storeCoords is True:
+        dataTree.Branch('x', ROOT.AddressOf(dStruct, 'x'), 'x/F')
+        dataTree.Branch('y', ROOT.AddressOf(dStruct, 'y'), 'y/F')
+        dataTree.Branch('z', ROOT.AddressOf(dStruct, 'z'), 'z/F')
+
+    dataTree.Branch('Bx', ROOT.AddressOf(dStruct, 'Bx'), 'Bx/F')
+    dataTree.Branch('By', ROOT.AddressOf(dStruct, 'By'), 'By/F')
+    dataTree.Branch('Bz', ROOT.AddressOf(dStruct, 'Bz'), 'Bz/F')
+
+    # Reopen the file and store the information in the ROOT file
+
+    inData = pd.read_csv(inFileName, delim_whitespace=True, header=None)
+    inData.columns=["x", "y", "z", "bx", "by", "bz"]
+    inData = inData.sort_values(by=["x","y","z"])
+    for line in inData.index:
+
+        # Bin centre coordinates with origin shift (all in cm)
+        if storeCoords is True:
+            dStruct.x = float(inData.loc[line, "x"]) * cmScale - x0
+            dStruct.y = float(inData.loc[line, "y"]) * cmScale - y0
+            dStruct.z = float(inData.loc[line, "z"]) * cmScale - z0
+
+        # B field components (Tesla)
+        dStruct.Bx = float(inData.loc[line, "bx"])
+        dStruct.By = float(inData.loc[line, "by"])
+        dStruct.Bz = float(inData.loc[line, "bz"])
+
+        dataTree.Fill()
+
+    theFile.cd()
+    rangeTree.Write()
+    dataTree.Write()
+    theFile.Close()
+
+
+def findRanges(inFileName, cmScale):
+    # First read the data file to find the binning and coordinate ranges.
+    # Store the unique (ordered) x, y and z values so we can then find the
+    # bin widths, min/max limits and central offset
+
+    xArray = []
+    yArray = []
+    zArray = []
+
+    with open(inFileName, 'r') as f:
+
+        # Read each line
+        for line in f:
+
+            # Ignore comment lines which begin with "#"
+            if '#' not in line:
+
+                sLine = line.split()
+
+                x = float(sLine[0]) * cmScale
+                y = float(sLine[1]) * cmScale
+                z = float(sLine[2]) * cmScale
+
+                if x not in xArray:
+                    xArray.append(x)
+
+                if y not in yArray:
+                    yArray.append(y)
+
+                if z not in zArray:
+                    zArray.append(z)
+
+    Nx = len(xArray)
+    Ny = len(yArray)
+    Nz = len(zArray)
+
+    xMin = 0.0
+    xMax = 0.0
+    dx = 0.0
+
+    if Nx > 0:
+        xMin = xArray[0]
+        Nx1 = Nx - 1
+        xMax = xArray[Nx1]
+        dx = (xMax - xMin) / (Nx1 * 1.0)
+
+    if Ny > 0:
+        yMin = yArray[0]
+        Ny1 = Ny - 1
+        yMax = yArray[Ny1]
+        dy = (yMax - yMin) / (Ny1 * 1.0)
+
+    if Nz > 0:
+        zMin = zArray[0]
+        Nz1 = Nz - 1
+        zMax = zArray[Nz1]
+        dz = (zMax - zMin) / (Nz1 * 1.0)
+
+    rangeInfo = {'Nx': Nx, 'xMin': xMin, 'xMax': xMax, 'dx': dx,
+                 'Ny': Ny, 'yMin': yMin, 'yMax': yMax, 'dy': dy,
+                 'Nz': Nz, 'zMin': zMin, 'zMax': zMax, 'dz': dz}
+
+    print ('rangeInfo = {0}'.format(rangeInfo))
+
+    return rangeInfo
+
+
+if __name__ == "__main__":
+    run('noisy_fieldMap.csv', 'field.root', 1, False)
+    # run('BFieldTest.txt', 'BFieldTest.root', 1.0)


### PR DESCRIPTION
2 new scripts to add noise and convert fieldmap
1 new method for ShipFieldMaker to generate the fieldmap for the given region.

ShipFieldMaker::generateFieldMap("output_file_name") can be called in the main simulation script to generate the csv fieldMap for the MuonShield region. Can be configured for different step size and positions.

Generated csv should be processed by add_noise_to_field.py.
Options to use:
--input #input file name
--output #output file name
--sidesOnly #not a random noise cores, but just an edge distortions
--sigma #sigma value for Gaussian filter
--nCores #number of  gauss noise cores over the field volume (ignored if sidesOnly is used)
--peak #max peak values for the gaussian cores (ignored if sidesOnly is used)
--fraction #contols the overall noise effect strength (ignored if sidesOnly is used)

New csv should be converted to root by converNoisyMap.py   (modification of the common convert.py. Pandas lib is needed),
no options, hardcoded values only.

Default values (sigma=30, nCores=1000, peak=500, fraction=0.4)    -> Generaly give ~same efficiencies of our standard fieldMap
![Bzy](https://user-images.githubusercontent.com/5690500/92956439-8f3e6680-f46f-11ea-8955-4514cdb1c6a6.png)
(sigma=8, nCores=1000, peak=500, fraction=0.4)
![Bzy](https://user-images.githubusercontent.com/5690500/92956465-982f3800-f46f-11ea-814a-bec8f73cd22a.png)
(sigma=6, sidesOnly)
![Bzy](https://user-images.githubusercontent.com/5690500/92956475-9b2a2880-f46f-11ea-99a5-3bcb73e5385e.png)


