### PR TITLE
Fix LOG calls when printf-style syntax is used

### DIFF
--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -175,7 +175,7 @@ TParticle* ShipStack::PopPrimaryForTracking(Int_t iPrim)
 
   // Test for index
   if (iPrim < 0 || iPrim >= fNPrimaries) {
-    LOG(FATAL) << "ShipStack: Primary index out of range! %i ", iPrim;
+    LOGF(fatal, "ShipStack: Primary index out of range! %i ", iPrim);
   }
 
   // Return the iPrim-th TParticle from the fParticle array. This should be
@@ -199,7 +199,7 @@ TParticle* ShipStack::GetCurrentTrack() const
 {
   TParticle* currentPart = GetParticle(fCurrentTrack);
   if ( ! currentPart) {
-    LOG(WARNING) << "ShipStack: Current track not found in stack!";
+    LOG(WARNING << "ShipStack: Current track not found in stack!";
   }
   return currentPart;
 }
@@ -238,7 +238,7 @@ void ShipStack::FillTrackArray()
 
     fStoreIter = fStoreMap.find(iPart);
     if (fStoreIter == fStoreMap.end() ) {
-      LOG(FATAL) << "ShipStack: Particle %i not found in storage map! ", iPart;
+      LOGF(fatal, "ShipStack: Particle %i not found in storage map! ", iPart);
     }
     Bool_t store = (*fStoreIter).second;
 
@@ -280,7 +280,7 @@ void ShipStack::UpdateTrackIndex(TRefArray* detList)
     Int_t iMotherOld = track->GetMotherId();
     fIndexIter = fIndexMap.find(iMotherOld);
     if (fIndexIter == fIndexMap.end()) {
-      LOG(FATAL) << "ShipStack: Particle index %i not found in dex map! ", iMotherOld;
+      LOGF(fatal, "ShipStack: Particle index %i not found in dex map! ", iMotherOld);
     }
     track->SetMotherId( (*fIndexIter).second );
   }
@@ -312,7 +312,7 @@ void ShipStack::UpdateTrackIndex(TRefArray* detList)
 
         fIndexIter = fIndexMap.find(iTrack);
         if (fIndexIter == fIndexMap.end()) {
-          LOG(FATAL) <<  "ShipStack: Particle index %i not found in index map! ", iTrack;
+          LOGF(fatal, "ShipStack: Particle index %i not found in index map! ", iTrack);
         }
         point->SetTrackID((*fIndexIter).second);
         point->SetLink(FairLink("MCTrack", (*fIndexIter).second));
@@ -320,7 +320,7 @@ void ShipStack::UpdateTrackIndex(TRefArray* detList)
 
     }   // Collections of this detector
   }     // List of active detectors
-  LOG(DEBUG) << "...stack and  %i collections updated.", nColl;
+  LOGF(debug, "...stack and  %i collections updated.", nColl);
 }
 // -------------------------------------------------------------------------
 
@@ -411,7 +411,7 @@ Int_t ShipStack::GetCurrentParentTrackNumber() const
 TParticle* ShipStack::GetParticle(Int_t trackID) const
 {
   if (trackID < 0 || trackID >= fNParticles) {
-    LOG(FATAL) << "ShipStack: Particle index %i out of range. Max=%i",trackID,fNParticles;
+    LOGF(fatal, "ShipStack: Particle index %i out of range. Max=%i", trackID, fNParticles);
   }
   return (TParticle*)fParticles->At(trackID);
 }

--- a/shipgen/DPPythia8Generator.cxx
+++ b/shipgen/DPPythia8Generator.cxx
@@ -291,7 +291,7 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
    } while ( iDP == 0 ); // ----------- avoid rare empty events w/o any DP's produced
    
    if (fShipEventNr%100==0) {
-     LOG(INFO) << "ship event %i / pythia event-nr %i",fShipEventNr,fn;
+     LOGF(info, "ship event %i / pythia event-nr %i", fShipEventNr, fn);
    }
    fShipEventNr += 1;
    // fill a container with pythia indices of the DP decay chain

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -34,10 +34,10 @@ Bool_t GenieGenerator::Init(const char* fileName, const int firstEvent) {
    TString tmp = gSystem->Getenv("EOSSHIP");
    tmp+=fileName;
    fInputFile  = TFile::Open(tmp); 
-   LOG(INFO) << "Opening input file on eos %s",tmp.Data();
+   LOGF(info, "Opening input file on eos %s", tmp.Data());
   }else{
    fInputFile  = new TFile(fileName);
-   LOG(INFO) << "Opening input file %s",fileName;
+   LOGF(info, "Opening input file %s", fileName);
   }
   if (fInputFile->IsZombie() or !fInputFile) {
      LOG(FATAL) << "Error opening input file";

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -40,12 +40,12 @@ Bool_t HNLPythia8Generator::Init()
      TString tmp = gSystem->Getenv("EOSSHIP");
      tmp+=fextFile;
      fInputFile  = TFile::Open(tmp); 
-     LOG(INFO) << "Open external file with charm or beauty hadrons on eos: %s",tmp.Data();
+     LOGF(info, "Open external file with charm or beauty hadrons on eos: %s", tmp.Data());
      if (!fInputFile) {
       LOG(FATAL) << "Error opening input file. You may have forgotten to provide a krb5 token. Try kinit username@lxplus.cern.ch";
       return kFALSE; }
     }else{
-      LOG(INFO) << "Open external file with charm or beauty hadrons: %s",fextFile;
+      LOGF(info, "Open external file with charm or beauty hadrons: %s", fextFile);
       fInputFile  = new TFile(fextFile);
       if (!fInputFile) {
        LOG(FATAL) << "Error opening input file";
@@ -213,7 +213,7 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
    } while ( iHNL == 0 ); // ----------- avoid rare empty events w/o any HNL's produced
 
    if (fShipEventNr%100==0) {
-      LOG(INFO) << "ship event %i / pythia event-nr %i",fShipEventNr,fn;
+      LOGF(info, "ship event %i / pythia event-nr %i", fShipEventNr, fn);
     }
    fShipEventNr += 1;
    // fill a container with pythia indices of the HNL decay chain

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -30,7 +30,7 @@ Bool_t MuDISGenerator::Init(const char* fileName) {
 }
 // -----   Default constructor   -------------------------------------------
 Bool_t MuDISGenerator::Init(const char* fileName, const int firstEvent) {
-  LOG(INFO) << "Opening input file %s",fileName;
+  LOGF(info, "Opening input file %s", fileName);
 
   iMuon = 0;
   dPart = 0; 
@@ -38,7 +38,7 @@ Bool_t MuDISGenerator::Init(const char* fileName, const int firstEvent) {
     TString tmp = gSystem->Getenv("EOSSHIP");
     tmp+=fileName;
     fInputFile  = TFile::Open(tmp); 
-    LOG(INFO) << "Open external file on eos: %s",tmp.Data();
+    LOGF(info, "Open external file on eos: %s", tmp.Data());
   }else{
     fInputFile  = new TFile(fileName);
   }

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -27,7 +27,7 @@ Bool_t MuonBackGenerator::Init(const char* fileName) {
 }
 // -----   Default constructor   -------------------------------------------
 Bool_t MuonBackGenerator::Init(const char* fileName, const int firstEvent, const Bool_t fl = false ) {
-  LOG(INFO) << "Opening input file %s",fileName;
+  LOGF(info, "Opening input file %s", fileName);
   if (0 == strncmp("/eos",fileName,4) ) {
      TString tmp = gSystem->Getenv("EOSSHIP");
      tmp+=fileName;
@@ -36,7 +36,7 @@ Bool_t MuonBackGenerator::Init(const char* fileName, const int firstEvent, const
   fInputFile  = new TFile(fileName);
   }
   if (fInputFile->IsZombie()) {
-     LOG(FATAL) << "Error opening the Signal file:%s",fInputFile;
+     LOGF(fatal, "Error opening the Signal file:%s", fileName);
   }
   fn = firstEvent;
   fPhiRandomize = fl;
@@ -112,7 +112,9 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
    muList.clear(); 
    moList.clear(); 
    fn++;
-   if (fn%100000==0)  {LOG(INFO) << "reading event %i",fn;}
+   if (fn%100000==0) {
+       LOGF(info, "Reading event %i", fn);
+   }
 // test if we have a muon, don't look at neutrinos:
    if (TMath::Abs(int(id))==13) {
         mass = pdgBase->GetParticle(id)->Mass();
@@ -152,17 +154,19 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg)
         }
        it++;
       }
-     if (!found) {LOG(WARNING) <<  "no muon found %i",fn-1;}
+      if (!found) {
+          LOGF(warn, "No muon found %i", fn-1);
+      }
      if (found) {break;}
    }
   }
   if (fn>fNevents-1){ 
-     LOG(INFO) << "End of file reached %i",fNevents;
+     LOGF(info, "End of file reached %i", fNevents);
      return kFALSE;
   } 
   if (fSameSeed) {
     Int_t theSeed = fn + fSameSeed * fNevents;
-    LOG(DEBUG) << TString::Format("Seed: %d", theSeed);
+    LOGF(debug, "Seed: %d", theSeed);
     gRandom->SetSeed(theSeed);
   }
   if (fPhiRandomize){phi = gRandom->Uniform(0.,2.) * TMath::Pi();}

--- a/shipgen/MuonBackGenerator.h
+++ b/shipgen/MuonBackGenerator.h
@@ -29,7 +29,7 @@ class MuonBackGenerator : public FairGenerator
   void FollowAllParticles() { followMuons = false; };
   void SetSmearBeam(Double_t sb) { fsmearBeam = sb; };
   void SetSameSeed(Int_t s) {
-    LOG(INFO)<<TString::Format("Seed: %d", s);
+    LOGF(info, "Seed: %d", s);
     fSameSeed = s;
   };
   Bool_t checkDiMuon(Int_t muIndex);

--- a/shipgen/NuageGenerator.cxx
+++ b/shipgen/NuageGenerator.cxx
@@ -51,7 +51,7 @@ Bool_t NuageGenerator::Init(const char* fileName, const int firstEvent) {
   cout<<"**************************************"<<endl;
   cout<<endl;
   fNuOnly = false;
-  LOG(INFO) << "Opening input file %s",fileName;
+  LOGF(info, "Opening input file %s", fileName);
   fInputFile  = new TFile(fileName);
   if (fInputFile->IsZombie()) {
     LOG(FATAL) << "Error opening the Signal file";

--- a/shipgen/Pythia8Generator.cxx
+++ b/shipgen/Pythia8Generator.cxx
@@ -40,12 +40,12 @@ Bool_t Pythia8Generator::Init()
      TString tmp = gSystem->Getenv("EOSSHIP");
      tmp+=fextFile;
      fInputFile  = TFile::Open(tmp); 
-     LOG(INFO) << "Open external file with charm or beauty hadrons on eos: %s",tmp.Data();
+     LOGF(info, "Open external file with charm or beauty hadrons on eos: %s", tmp.Data());
      if (!fInputFile) {
       LOG(FATAL) << "Error opening input file. You may have forgotten to provide a krb5 token. Try kinit username@lxplus.cern.ch";
       return kFALSE; }
     }else{
-      LOG(INFO) << "Open external file with charm or beauty hadrons: %s",fextFile;
+      LOGF(info, "Open external file with charm or beauty hadrons: %s", fextFile);
       fInputFile  = new TFile(fextFile);
       if (!fInputFile) {
        LOG(FATAL) << "Error opening input file";
@@ -90,7 +90,7 @@ Bool_t Pythia8Generator::Init()
       if (p->tau0()>1){
       std::string particle = std::to_string(n)+":mayDecay = false";
       fPythia->readString(particle);
-      LOG(INFO) << "Made %s stable for Pythia, should decay in Geant4",p->name().c_str();
+      LOGF(info, "Made %s stable for Pythia, should decay in Geant4", p->name().c_str());
       }
      }
   } else {  
@@ -107,7 +107,7 @@ Bool_t Pythia8Generator::Init()
    TGeoVolume* top = gGeoManager->GetTopVolume();
    TGeoNode* target = top->FindNode(targetName);
    if (!target){
-       LOG(ERROR) << "target not found, %s, program will crash",targetName.Data();
+       LOGF(error, "target not found, %s, program will crash", targetName.Data());
    }
    Double_t z_middle = target->GetMatrix()->GetTranslation()[2];
    TGeoBBox* sha = (TGeoBBox*)target->GetVolume()->GetShape();


### PR DESCRIPTION
The renaming left a lot of broken log statements which were using `printf`-style syntax (i.e. `%s`, `%d, `%i` etc.)