### PR TITLE
Use ctypes instead of ROOT.Double

### DIFF
--- a/python/decorators.py
+++ b/python/decorators.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
 from __future__ import division
+from ctypes import c_double
 import ROOT
 import shipunit as u
+
 def MCPointPrintOut(x):
   p = ROOT.TDatabasePDG.Instance().GetParticle(x.PdgCode())
   n=''
@@ -64,7 +66,7 @@ def TLorentzVectorPrintOut(x):
   return txt
 
 def TEvePointSetPrintOut(P):
- x,y,z = ROOT.Double(),ROOT.Double(),ROOT.Double()
+ x, y, z = c_double(), c_double(), c_double()
  txt = ''
  if P.GetN()==0: txt = '<ROOT.TEvePointSet object>'
  for n in range(P.GetN()):


### PR DESCRIPTION
As discussed in #376 .

There are still some instances of `ROOT.Double` remaining in drifttubemonitoring. What shall we do about those, as drifttubemonitoring on master is ancient compared to the one in muflux?