### PR TITLE
Updating package list for ubuntu 20

### DIFF
--- a/system/install_on_ubuntu.sh
+++ b/system/install_on_ubuntu.sh
@@ -1,7 +1,7 @@
 # installation on blank Ubuntu 18.04 LTS:
 # FROM ubuntu:18.04
 sudo apt-get update 
-sudo apt-get install python3-dev python3-pip make patch sed git-all gedit environment-modules \
+sudo apt-get install python3-dev python3-pip python3-tk make patch sed git-all gedit environment-modules \
    libx11-dev libxpm-dev libxext-dev ncurses-dev libxml2-dev libxft-dev \
    libxmu-dev  ncurses-dev  curl bzip2  libbz2-dev gzip unzip tar gfortran libkrb5-dev \
     wget automake autoconf libtool bison  flex byacc libgif-dev libjpeg-dev libtiff5-dev\
@@ -9,7 +9,7 @@ sudo apt-get install python3-dev python3-pip make patch sed git-all gedit enviro
    autopoint texinfo gettext libtool libtool-bin pkg-config python-tk cmake linuxbrew-wrapper 
 
 sudo pip3 install --upgrade pip
-sudo pip3 install matplotlib numpy scipy certifi ipython ipywidgets ipykernel notebook metakernel pyyaml sklearn
+sudo pip3 install matplotlib numpy scipy certifi ipython ipywidgets ipykernel notebook metakernel pyyaml sklearn future
 
 # sudo apt-get krb5-user
 # for kinit: cp from lxplus /etc/krb5.conf
@@ -18,3 +18,9 @@ sudo pip3 install matplotlib numpy scipy certifi ipython ipywidgets ipykernel no
 # cd SHiPBuild
 # git clone https://github.com/ShipSoft/FairShip.git
 # FairShip/aliBuild.sh
+
+#ubuntu 20.04 comments
+
+linuxbrew-wrapper is not present anymore. 
+
+metakernel requires pexpect, which appears to be incompatible with the ubuntu 20 version

--- a/system/install_on_ubuntu.sh
+++ b/system/install_on_ubuntu.sh
@@ -21,6 +21,10 @@ sudo pip3 install matplotlib numpy scipy certifi ipython ipywidgets ipykernel no
 
 #ubuntu 20.04 comments
 
+Useful way to setup python3 as default, instead of the now unused python2:
+
+sudo apt-get install python-is-python3
+
 linuxbrew-wrapper is not present anymore. 
 
 metakernel requires pexpect, which appears to be incompatible with the ubuntu 20 version


### PR DESCRIPTION
Dear FairShip/SNDSW users,

Together with Simona Ilieva, we checked the package requirements list in Ubuntu 20.04 LTS

Most of those from Ubuntu 18 still works, with two exceptions:
* linuxbrew-wrapper
* metakernel

Also added some packages:
* future (required by some python imports)
* python3-tk (requierd by the Event Display)

Best regards,
Antonio Iuliano
