### PR TITLE
IgnoreCommandLIneOptions no longer needed

### DIFF
--- a/macro/flux_map.py
+++ b/macro/flux_map.py
@@ -3,8 +3,6 @@ from __future__ import division
 import argparse
 import numpy as np
 import ROOT as r
-# Fix https://root-forum.cern.ch/t/pyroot-hijacks-help/15207 :
-r.PyConfig.IgnoreCommandLineOptions = True
 import shipunit as u
 import rootUtils as ut
 import logger as log

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -7,8 +7,6 @@ import getopt
 import ROOT
 ROOT.gSystem.Load('libEGPythia8') 
 import makeALPACAEvents
-# Fix https://root-forum.cern.ch/t/pyroot-hijacks-help/15207 :
-ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 import shipunit as u
 import shipRoot_conf

--- a/macro/testbeam_unpack.py
+++ b/macro/testbeam_unpack.py
@@ -2,9 +2,6 @@
 import argparse
 import ROOT
 
-# Fix https://root-forum.cern.ch/t/pyroot-hijacks-help/15207 :
-ROOT.PyConfig.IgnoreCommandLineOptions = True
-
 
 def main():
     source = ROOT.ShipTdcSource(args.input)


### PR DESCRIPTION
On my request the default value in PyROOT has changed to the value we were setting (already a while ago, so all ROOT versions we use should have this fix).

See https://root.cern/manual/python/#configuration-options

Fixes olantwin/FairShip#51