### PR TITLE
Don't import getopt when it's not used

### DIFF
--- a/charmdet/simAbsorber.py
+++ b/charmdet/simAbsorber.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT,os,sys,time,shipRoot_conf
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 
 import shipunit as u

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
 from __future__ import division
 # example for accessing smeared hits and fitted tracks
-import ROOT,os,sys,getopt
+import os
+import sys
+import ROOT
 import ctypes
 import rootUtils as ut
 import shipunit as u

--- a/macro/runMufluxDigi.py
+++ b/macro/runMufluxDigi.py
@@ -17,7 +17,7 @@ def mem_monitor():
     pmsize = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     print("memory: virtuell = %5.2F MB  physical = %5.2F MB"%(vmsize/1.0E3,pmsize/1.0E3))
 
-import ROOT,os,sys,getopt
+import ROOT,os,sys
 import global_variables
 import rootUtils as ut
 import shipunit as u

--- a/macro/run_anaEcal.py
+++ b/macro/run_anaEcal.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time
+import ROOT,os,sys,time
 import shipunit as u
 import shipRoot_conf
 import ShipGeoConfig

--- a/macro/run_simEcal.py
+++ b/macro/run_simEcal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 momentum = 1
-import ROOT,os,sys,getopt,time
+import ROOT,os,sys,time
 import shipunit as u
 import shipRoot_conf
 import ShipGeoConfig

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from __future__ import division
 import os
 import sys
-import getopt
 import ROOT
 ROOT.gSystem.Load('libEGPythia8') 
 import makeALPACAEvents

--- a/muonShieldOptimization/run_MufluxfixedTarget.py
+++ b/muonShieldOptimization/run_MufluxfixedTarget.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT,os,sys,time,shipRoot_conf
 import shipunit as u
 from ShipGeoConfig import ConfigRegistry
 

--- a/muonShieldOptimization/run_fixedTarget.py
+++ b/muonShieldOptimization/run_fixedTarget.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT,os,sys,time,shipRoot_conf
 import shipunit as u
 from ShipGeoConfig import ConfigRegistry
 

--- a/muonShieldOptimization/study_GammaConv.py
+++ b/muonShieldOptimization/study_GammaConv.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT,os,sys,time,shipRoot_conf
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 

--- a/muonShieldOptimization/study_muEloss.py
+++ b/muonShieldOptimization/study_muEloss.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT,os,sys,time,shipRoot_conf
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 

--- a/muonShieldOptimization/study_muMSC.py
+++ b/muonShieldOptimization/study_muMSC.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT,os,sys,time,shipRoot_conf
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 

--- a/muonShieldOptimization/study_thinTarget.py
+++ b/muonShieldOptimization/study_thinTarget.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python 
 from __future__ import print_function
-import ROOT,os,sys,getopt,time,shipRoot_conf
+import ROOT,os,sys,time,shipRoot_conf
 ROOT.gROOT.ProcessLine('#include "FairModule.h"')
 time.sleep(20)
 

--- a/python/dpProductionRates.py
+++ b/python/dpProductionRates.py
@@ -1,6 +1,6 @@
 from __future__ import division
 from __future__ import print_function
-import ROOT,os,sys,getopt,math
+import ROOT,os,sys,math
 import shipunit as u
 import proton_bremsstrahlung
 

--- a/python/makeALPACAEvents.py
+++ b/python/makeALPACAEvents.py
@@ -1,4 +1,4 @@
-import os,sys,getopt
+import os,sys
 import numpy,math
 import ROOT
 

--- a/python/shipStrawTracking_prev.py
+++ b/python/shipStrawTracking_prev.py
@@ -6,7 +6,7 @@
 from __future__ import print_function
 import global_variables
 import shipPatRec_prev 
-import ROOT,os,sys,getopt
+import ROOT,os,sys
 import shipDet_conf
 import shipunit  as u
 


### PR DESCRIPTION
To my surprise I saw that run_simScript still imported getopt, so I did
a quick search and remove for the other locations we import but don't
use it.

Fixes olantwin/FairShip#53