### PR TITLE
Allow selecting debug actions from commandline

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -13,8 +13,6 @@ import rootUtils as ut
 from ShipGeoConfig import ConfigRegistry
 from argparse import ArgumentParser
 
-debug = 0  # 1 print weights and field
-           # 2 make overlap check
 dryrun = False # True: just setup Pythia and exit
 
 DownScaleDiMuon = False
@@ -49,8 +47,6 @@ globalDesigns = {'2016':{'dy':10.,'dv':5,'ds':7,'nud':1,'caloDesign':0,'strawDes
 default = '2018'
 
 inactivateMuonProcesses = False   # provisionally for making studies of various muon background sources
-checking4overlaps = False
-if debug>1 : checking4overlaps = True
 
 parser = ArgumentParser()
 group = parser.add_mutually_exclusive_group()
@@ -112,6 +108,7 @@ parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajecto
 parser.add_argument("--stepMuonShield", dest="muShieldStepGeo", help="activate steps geometry for the muon shield", required=False, action="store_true", default=False)
 parser.add_argument("--coMuonShield", dest="muShieldWithCobaltMagnet", help="replace one of the magnets in the shield with 2.2T cobalt one, downscales other fields, works only for muShieldDesign >2", required=False, type=int, default=0)
 parser.add_argument("--MesonMother",   dest="MM",  help="Choose DP production meson source", required=False,  default=True)
+parser.add_argument("--debug",  help="1: print weights and field 2: make overlap check", required=False, default=0, type=int, choices=range(0,3))
 
 options = parser.parse_args()
 
@@ -532,7 +529,7 @@ if options.charm == 0:   # charm and muflux testbeam not yet updated for using t
   fieldMaker = geomGeant4.addVMCFields(ship_geo, '', True)
 
 # Print VMC fields and associated geometry objects
-if debug > 0:
+if options.debug == 1:
  geomGeant4.printVMCFields()
  geomGeant4.printWeightsandFields(onlyWithField = True,\
              exclude=['DecayVolume','Tr1','Tr2','Tr3','Tr4','Veto','Ecal','Hcal','MuonDetector','SplitCal'])
@@ -569,7 +566,7 @@ import saveBasicParameters
 saveBasicParameters.execute("%s/geofile_full.%s.root" % (options.outputDir, tag),ship_geo)
 
 # checking for overlaps
-if checking4overlaps:
+if options.debug == 2:
  fGeo = ROOT.gGeoManager
  fGeo.SetNmeshPoints(10000)
  fGeo.CheckOverlaps(0.1)  # 1 micron takes 5minutes


### PR DESCRIPTION
The debug actions are also decoupled, so once can run one or the other
in the case where one only wants to check for overlaps.