### PR TITLE
Reducing transverse size magnetic spectrometer

### DIFF
--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -654,8 +654,8 @@ with ConfigRegistry.register_config("basic") as c:
      c.tauMudet.ZEle = 1*u.mm
 
     if nuTauTargetDesign==4:
-     c.tauMudet.XRpc = 400 *u.cm
-     c.tauMudet.YRpc = 400 *u.cm
+     c.tauMudet.XRpc = 120 *u.cm
+     c.tauMudet.YRpc = 120 *u.cm
      c.tauMudet.ZRpc = 8 *u.cm
      #magnetized region
      c.tauMudet.Xtot  = c.tauMudet.XRpc


### PR DESCRIPTION
As noticed by Oliver in issue #423 , the dummy geometry is too large (it was mostly used to test acceptance).

Now it is reduced to a more manageable size (120 cm x 120 cm, instead of 400 cm x 400 cm).

