### PR TITLE
fixing overlap/extrusions in volMuFilter

### DIFF
--- a/nutaudet/NuTauMudet.cxx
+++ b/nutaudet/NuTauMudet.cxx
@@ -771,7 +771,7 @@ void NuTauMudet::ConstructGeometry()
       //code by Daniele from ADVSND air core magnet
       Double_t  fOutMagX = fXtot;
       Double_t  fOutMagY = fYtot;
-      Double_t  fMagZ = fZtot;
+      Double_t  fMagZ = fZtot-0.5*2;
 
       Double_t fInMagX = fXRpc;
       Double_t fInMagY = fYRpc;
@@ -807,8 +807,8 @@ void NuTauMudet::ConstructGeometry()
 
       // Positioning
       volMuFilter->AddNode(volFeYoke, 0);
-      volMuFilter->AddNode(volCoil, 0, new TGeoTranslation(0, (fInMagY+fCoilH)/2., 0));
-      volMuFilter->AddNode(volCoil, 1, new TGeoTranslation(0, -(fInMagY+fCoilH)/2., 0));
+      volMuFilter->AddNode(volCoil, 0, new TGeoTranslation(0, (fInMagY+fCoilH)/2.-0.001, 0));
+      volMuFilter->AddNode(volCoil, 1, new TGeoTranslation(0, -(fInMagY+fCoilH)/2.+0.001, 0));
       volMuFilter->AddNode(volMagRegion, 0, 0);
 
       volMagRegion->SetField(magcheckfield);


### PR DESCRIPTION
Dear all,

During test with --debug 2 this weekend, before launching neutrino simulations, I found some internal overlaps/extrusions in the muon detector (volMuFilter extruded by VolCoil and overlapping with volFeYoke).

This fixes these overlaps, in the meantime I am working on splitting the volumes to add the return magnetic fields.

Best Regards,
Antonio
![overlaps volMuFilter extruded](https://github.com/ShipSoft/FairShip/assets/18480751/7528f636-754c-47fc-972a-a1da6ac0084b)
