### PR TITLE
Use consistent size variables for wall container volumes

### DIFF
--- a/nutaudet/Target.cxx
+++ b/nutaudet/Target.cxx
@@ -516,7 +516,7 @@ void Target::ConstructGeometry()
       volCell->AddNode(volBrick,1,new TGeoTranslation(0,0,-CellWidth/2 + BrickZ/2));
       volCell->AddNode(volCES,1,new TGeoTranslation(0,0,-CellWidth/2 + BrickZ + CESWidth/2));
 
-      TGeoBBox *Row = new TGeoBBox("row",XDimension/2, BrickY/2, CellWidth/2);
+      TGeoBBox *Row = new TGeoBBox("row",WallXDim/2, BrickY/2, CellWidth/2);
       TGeoVolume *volRow = new TGeoVolume("Row",Row,air);
       volRow->SetLineColor(20);
     
@@ -527,7 +527,7 @@ void Target::ConstructGeometry()
 	  d_cl_x += BrickX;
 	}
 
-      TGeoBBox *Wall = new TGeoBBox("wall",XDimension/2, YDimension/2, CellWidth/2);
+      TGeoBBox *Wall = new TGeoBBox("wall",WallXDim/2, WallYDim/2, CellWidth/2);
       TGeoVolume *volWall = new TGeoVolume("Wall",Wall,air);
     
       Double_t d_cl_y = -WallYDim/2;
@@ -565,7 +565,7 @@ void Target::ConstructGeometry()
     
       tTauNuDet->AddNode(volTarget,1,new TGeoTranslation(0,0,fCenterZ));
 	
-      TGeoBBox *Row = new TGeoBBox("row",XDimension/2, BrickY/2, CellWidth/2);
+      TGeoBBox *Row = new TGeoBBox("row",WallXDim/2, BrickY/2, WallZDim/2);
       TGeoVolume *volRow = new TGeoVolume("Row",Row,air);
       volRow->SetLineColor(20);
     
@@ -575,7 +575,7 @@ void Target::ConstructGeometry()
 	  volRow->AddNode(volBrick,j,new TGeoTranslation(d_cl_x+BrickX/2, 0, 0));
 	  d_cl_x += BrickX;
 	}
-      TGeoBBox *Wall = new TGeoBBox("wall",XDimension/2, YDimension/2, BrickZ/2);
+      TGeoBBox *Wall = new TGeoBBox("wall",WallXDim/2, WallYDim/2, WallZDim/2);
       TGeoVolume *volWall = new TGeoVolume("Wall",Wall,air);
       volWall->SetLineColor(kGreen);
     


### PR DESCRIPTION
Dear all,

After today's meeting (https://indico.cern.ch/event/1314106/), I pulled the last FairShip code and, cross-checking the code, I noticed that Wall container volumes actually use as size variable the whole target size (which is a bit larger, now that we changed the TT).

This has no effect at all on the actual material volumes, which are within in the hierarchy and already use WallXDim for positioning. But I have fixed it anyway, since it is safer to be consistent.
![display_SHiPecn3_7august_tilted](https://github.com/ShipSoft/FairShip/assets/18480751/b6336cc2-ad93-4346-a56a-bf3c6351678d)
![display_nutaudetgeometry](https://github.com/ShipSoft/FairShip/assets/18480751/2872658f-9e89-4c8b-9d94-58a2830d0725)

Best Regards,
Antonio Iuliano