### PR TITLE
first version of the helium-filled decay volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ it in future.
 
 ### Added
 
+* Add option for helium-filled decay volume
 * Add pre-commit config: This will be phased in to improve code quality and spot issues as early as possible. Status visible in README and CI enabled for new pull requests.
 * Add CHANGELOG.md
 * Add `.git-blame-ignore-revs` to allow automatic reformatting etc. without polluting git blame

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -60,6 +60,8 @@ if "SC_mag" not in globals():
     SC_mag = False
 if "scName" not in globals():
     scName = None
+if "decayVolumeMed" not in globals():
+    decayVolumeMed = "vacuums"
 
 with ConfigRegistry.register_config("basic") as c:
     c.SC_mag = SC_mag
@@ -134,7 +136,7 @@ with ConfigRegistry.register_config("basic") as c:
       c.Veto.lidThickness = 80.*u.mm
      c.Veto.sensitiveThickness = 0.2 * u.m
      c.Veto.sensitiveMed = "Scintillator"
-     c.Veto.decayMed = "vacuums"
+     c.Veto.decayMed = decayVolumeMed
      c.Veto.rib = 1.5 * u.cm
      c.Veto.ribMed = "steel"
      # horizontal width at start and focus point, for conical/rectangular size

--- a/geometry/media.geo
+++ b/geometry/media.geo
@@ -16,6 +16,11 @@
 //epsil - boundary crossing precision EPSIL
 //npckov - number of values used to define the optical properties of the medium.
 //----------------------------------------------------------
+// basic helium for Decay Volume; June 2024
+helium			   1  4.00    2    1.78e-3
+				   0  1  30.  .001
+				   0 
+
 air                3  14.01  16.  39.95  7.  8.  18.  1.205e-3  .755  .231  .014
                    0  1  30.  .001
                    0

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -138,7 +138,7 @@ parser.add_argument("--noSC", dest="SC_mag", help="Deactivate SC muon shield. Co
 parser.add_argument("--scName", help="The name of the SC shield in the database", default="sc_v6")
 parser.add_argument("--MesonMother",   dest="MM",  help="Choose DP production meson source", required=False,  default=True)
 parser.add_argument("--debug",  help="1: print weights and field 2: make overlap check", required=False, default=0, type=int, choices=range(0,3))
-parser.add_argument("--helium",  help="use helium bag for vacuum tank", required=False, action="store_const", const="air", default="vacuums")
+parser.add_argument("--helium",  help="use helium bag for vacuum tank", required=False, action="store_const", const="helium", default="vacuums")
 
 options = parser.parse_args()
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -138,6 +138,7 @@ parser.add_argument("--noSC", dest="SC_mag", help="Deactivate SC muon shield. Co
 parser.add_argument("--scName", help="The name of the SC shield in the database", default="sc_v6")
 parser.add_argument("--MesonMother",   dest="MM",  help="Choose DP production meson source", required=False,  default=True)
 parser.add_argument("--debug",  help="1: print weights and field 2: make overlap check", required=False, default=0, type=int, choices=range(0,3))
+parser.add_argument("--helium",  help="use helium bag for vacuum tank", required=False, action="store_const", const="air", default="vacuums")
 
 options = parser.parse_args()
 
@@ -214,7 +215,7 @@ if options.charm == 0: ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geom
                                                 muShieldDesign = options.ds, nuTauTargetDesign=options.nud, CaloDesign=options.caloDesign, \
                                                 strawDesign=options.strawDesign, muShieldGeo=options.geofile,
                                                 muShieldStepGeo=options.muShieldStepGeo, muShieldWithCobaltMagnet=options.muShieldWithCobaltMagnet,
-                                                SC_mag=options.SC_mag, scName=options.scName)
+                                                SC_mag=options.SC_mag, scName=options.scName, decayVolumeMed=options.helium)
 else:
  ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/charm-geometry_config.py", Setup = options.CharmdetSetup, cTarget = options.CharmTarget)
  if options.CharmdetSetup == 0: print("Setup for muon flux measurement has been set")

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -138,7 +138,13 @@ parser.add_argument("--noSC", dest="SC_mag", help="Deactivate SC muon shield. Co
 parser.add_argument("--scName", help="The name of the SC shield in the database", default="sc_v6")
 parser.add_argument("--MesonMother",   dest="MM",  help="Choose DP production meson source", required=False,  default=True)
 parser.add_argument("--debug",  help="1: print weights and field 2: make overlap check", required=False, default=0, type=int, choices=range(0,3))
-parser.add_argument("--helium",  help="use helium bag for vacuum tank", required=False, action="store_const", const="helium", default="vacuums")
+parser.add_argument(
+     "--helium",
+     help="Replace vacuum with helium (vessel structure unchanged)",
+     action="store_const",
+     const="helium",
+     default="vacuums"
+)
 
 options = parser.parse_args()
 

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -1111,6 +1111,7 @@ void veto::ConstructGeometry()
     TGeoMedium *Sens =gGeoManager->GetMedium("ShipSens");
     InitMedium("Scintillator");
     TGeoMedium *Se =gGeoManager->GetMedium("Scintillator");
+    InitMedium("helium");
     gGeoManager->SetNsegments(100);
     vetoMed        = gGeoManager->GetMedium(vetoMed_name);      //! medium of veto counter, liquid or plastic scintillator
     supportMedIn   = gGeoManager->GetMedium(supportMedIn_name); //! medium of support structure, iron, balloon


### PR DESCRIPTION
This is the first implementation of the option to run the simulation with helium-filled decay volume. The default behavior is the decay volume under vacuum, to call the helium-filled decay volume you should use the flag "--helium". In this configuration, the helium is only placed up to the tracking stations.

To run:     python $FAIRSHIP/macro/run_simScript.py -n 1 --helium