### PR TITLE
Timing Correction for MuonDIS generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ it in future.
 
 * feat(python): Add experimental script to compare histograms
 * feat(python): Add experimental script to check overlaps quickly
+* **Corrections in MuonDIS simulation**
+  The DIS interactions are now time-shifted to be consistent with the original incoming muon. Additionally, tracks from soft interactions of the original muon along with the muon's veto response are preserved (in muonDis.root) and included up to the DIS interaction point. To be noted that the muon veto points are manually added using add_muonresponse.py, which modifies the simulation file. This replaces the old method of "backward-travelling muon" to generate the incoming muon's veto response. All MuonDIS simulation scripts have been updated and consolidated within FairShip/muonDIS, ensuring consistency for new productions.
 
 ### Fixed
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -510,7 +510,7 @@ if options.dryrun: # Early stop after setting up Pythia 8
  sys.exit(0)
 gMC = ROOT.TVirtualMC.GetMC()
 fStack = gMC.GetStack()
-EnergyCut = 10.*u.MeV if options.mudis else 100.*u.MeV
+EnergyCut = 10. * u.MeV if options.mudis else 100. * u.MeV
 
 if MCTracksWithHitsOnly:
  fStack.SetMinPoints(1)

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 import os
 import sys
 import ROOT
@@ -32,7 +30,7 @@ MCTracksWithHitsOnly   = False  # copy particles which produced a hit and their 
 MCTracksWithEnergyCutOnly = True # copy particles above a certain kin energy cut
 MCTracksWithHitsOrEnergyCut = False # or of above, factor 2 file size increase compared to MCTracksWithEnergyCutOnly
 
-charmonly    = False  # option to be set with -A to enable only charm decays, charm x-sec measurement  
+charmonly    = False  # option to be set with -A to enable only charm decays, charm x-sec measurement
 HNL          = True
 
 inputFile    = "/eos/experiment/ship/data/Charm/Cascade-parp16-MSTP82-1-MSEL4-978Bpot.root"
@@ -71,8 +69,7 @@ globalDesigns = {
 }
 default = '2023'
 
-inactivateMuonProcesses = False   # provisionally for making studies of various muon background sources
-inactivateMuonNuclearProcess = False #Only True for muonDIS
+inactivateMuonProcesses = False         # provisionally for making studies of various muon background sources
 
 parser = ArgumentParser()
 group = parser.add_mutually_exclusive_group()
@@ -152,6 +149,7 @@ parser.add_argument(
     const="vacuums",
     default="helium"
 )
+
 parser.add_argument("--SND", dest="SND", help="Activate SND.", action='store_true')
 parser.add_argument("--noSND", dest="SND", help="Deactivate SND. NOOP, as it currently defaults to off.", action='store_false')
 
@@ -172,7 +170,7 @@ if options.A != 'c':
      if options.A =='b': inputFile = "/eos/experiment/ship/data/Beauty/Cascade-run0-19-parp16-MSTP82-1-MSEL5-5338Bpot.root"
      if options.A.lower() == 'charmonly':
            charmonly = True
-           HNL = False 
+           HNL = False
      if options.A not in ['b','c','bc','meson','pbrem','qcd']: inclusive = True
 if options.MM:
      motherMode=options.MM
@@ -199,11 +197,11 @@ if options.testFlag:
 
 
 #sanity check
-if (HNL and options.RPVSUSY) or (HNL and options.DarkPhoton) or (options.DarkPhoton and options.RPVSUSY): 
+if (HNL and options.RPVSUSY) or (HNL and options.DarkPhoton) or (options.DarkPhoton and options.RPVSUSY):
  print("cannot have HNL and SUSY or DP at the same time, abort")
  sys.exit(2)
 
-if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile: 
+if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile:
   inputFile = "/eos/experiment/ship/data/GenieEvents/genie-nu_mu.root"
 if simEngine == "muonDIS" and defaultInputFile:
   print('input file required if simEngine = muonDIS')
@@ -245,12 +243,11 @@ else: tag = simEngine+"-"+mcEngine
 if charmonly: tag = simEngine+"CharmOnly-"+mcEngine
 if options.eventDisplay: tag = tag+'_D'
 if options.dv > 4 : tag = 'conical.'+tag
-elif dy: tag = str(options.dy)+'.'+tag 
 if not os.path.exists(options.outputDir):
   os.makedirs(options.outputDir)
 outFile = f"{options.outputDir}/ship.{tag}.root"
 
-# rm older files !!! 
+# rm older files !!!
 for x in os.listdir(options.outputDir):
   if not x.find(tag)<0: os.system(f"rm {options.outputDir}/{x}" )
 # Parameter file name
@@ -267,18 +264,17 @@ timer.Start()
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
 run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
-run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C 
-rtdb = run.GetRuntimeDb() 
+run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C
+rtdb = run.GetRuntimeDb()
 # -----Create geometry----------------------------------------------
 # import shipMuShield_only as shipDet_conf # special use case for an attempt to convert active shielding geometry for use with FLUKA
 # import shipTarget_only as shipDet_conf
 import shipDet_conf
-
 modules = shipDet_conf.configure(run,ship_geo)
 # -----Create PrimaryGenerator--------------------------------------
 primGen = ROOT.FairPrimaryGenerator()
 if simEngine == "Pythia8":
- primGen.SetTarget(ship_geo.target.z0, 0.) 
+ primGen.SetTarget(ship_geo.target.z0, 0.)
 # -----Pythia8--------------------------------------
  if HNL or options.RPVSUSY:
   P8gen = ROOT.HNLPythia8Generator()
@@ -301,7 +297,7 @@ if simEngine == "Pythia8":
    pythia8_conf.configurerpvsusy(P8gen,options.theMass,[theCouplings[0],theCouplings[1]],
                                 theCouplings[2],options.RPVSUSYbench,inclusive,options.deepCopy)
   P8gen.SetParameters("ProcessLevel:all = off")
-  if inputFile: 
+  if inputFile:
    ut.checkFileExists(inputFile)
 # read from external file
    P8gen.UseExternalFile(inputFile, options.firstEvent)
@@ -314,7 +310,7 @@ if simEngine == "Pythia8":
   import pythia8darkphoton_conf
   passDPconf = pythia8darkphoton_conf.configure(P8gen,options.theMass,options.theDPepsilon,inclusive, motherMode, options.deepCopy)
   if (passDPconf!=1): sys.exit()
- if HNL or options.RPVSUSY or options.DarkPhoton: 
+ if HNL or options.RPVSUSY or options.DarkPhoton:
   P8gen.SetSmearBeam(1*u.cm) # finite beam size
   P8gen.SetLmin((ship_geo.Chamber1.z - ship_geo.chambers.Tub1length) - ship_geo.target.z0 )
   P8gen.SetLmax(ship_geo.TrackStation1.z - ship_geo.target.z0 )
@@ -322,7 +318,7 @@ if simEngine == "Pythia8":
   primGen.SetTarget(0., 0.) #vertex is set in pythia8Generator
   ut.checkFileExists(inputFile)
   if ship_geo.Box.gausbeam:
-   primGen.SetBeam(0.,0., 0.5, 0.5) #more central beam, for hits in downstream detectors    
+   primGen.SetBeam(0.,0., 0.5, 0.5) #more central beam, for hits in downstream detectors
    primGen.SmearGausVertexXY(True) #sigma = x
   else:
    primGen.SetBeam(0.,0., ship_geo.Box.TX-1., ship_geo.Box.TY-1.) #Uniform distribution in x/y on the target (0.5 cm of margin at both sides)
@@ -344,7 +340,7 @@ if simEngine == "FixedTarget":
  primGen.AddGenerator(P8gen)
 if simEngine == "Pythia6":
 # set muon interaction close to decay volume
- primGen.SetTarget(ship_geo.target.z0+ship_geo.muShield.length, 0.) 
+ primGen.SetTarget(ship_geo.target.z0+ship_geo.muShield.length, 0.)
 # -----Pythia6-------------------------
  test = ROOT.TPythia6() # don't know any other way of forcing to load lib
  P6gen = ROOT.tPythia6Generator()
@@ -367,7 +363,7 @@ if simEngine == "EvtCalc":
     )
 
 # -----Particle Gun-----------------------
-if simEngine == "PG": 
+if simEngine == "PG":
   myPgun = ROOT.FairBoxGenerator(options.pID,1)
   myPgun.SetPRange(options.Estart,options.Eend)
   myPgun.SetPhiRange(0, 360) # // Azimuth angle range [degree]
@@ -377,9 +373,8 @@ if simEngine == "PG":
 # -----muon DIS Background------------------------
 if simEngine == "muonDIS":
  ut.checkFileExists(inputFile)
- primGen.SetTarget(0., 0.) 
+ primGen.SetTarget(0., 0.)
  DISgen = ROOT.MuDISGenerator()
- 
  # from nu_tau detector to tracking station 2
  # mu_start, mu_end =  ship_geo.tauMudet.zMudetC,ship_geo.TrackStation2.z
  #
@@ -390,8 +385,6 @@ if simEngine == "muonDIS":
  DISgen.Init(inputFile,options.firstEvent)
  primGen.AddGenerator(DISgen)
  options.nEvents = min(options.nEvents,DISgen.GetNevents())
- inactivateMuonProcesses = False 
- inactivateMuonNuclearProcess = True #avoid double counting
  print('Generate ',options.nEvents,' with DIS input', ' first event',options.firstEvent)
 # -----neutrino interactions from nuage------------------------
 if simEngine == "Nuage":
@@ -410,7 +403,7 @@ if simEngine == "Nuage":
  nZcells = ntt -1
  startx = -ship_geo.NuTauTarget.xdim/2. + nXcells*ship_geo.NuTauTarget.BrX
  endx = -ship_geo.NuTauTarget.xdim/2. + (nXcells+1)*ship_geo.NuTauTarget.BrX
- starty = -ship_geo.NuTauTarget.ydim/2. + nYcells*ship_geo.NuTauTarget.BrY 
+ starty = -ship_geo.NuTauTarget.ydim/2. + nYcells*ship_geo.NuTauTarget.BrY
  endy = - ship_geo.NuTauTarget.ydim/2. + (nYcells+1)*ship_geo.NuTauTarget.BrY
  startz = ship_geo.EmuMagnet.zC - ship_geo.NuTauTarget.zdim/2. + ntt *ship_geo.NuTauTT.TTZ + nZcells * ship_geo.NuTauTarget.CellW
  endz = ship_geo.EmuMagnet.zC - ship_geo.NuTauTarget.zdim/2. + ntt *ship_geo.NuTauTT.TTZ + nZcells * ship_geo.NuTauTarget.CellW + ship_geo.NuTauTarget.BrZ
@@ -428,7 +421,7 @@ if simEngine == "Genie":
  ut.checkFileExists(inputFile)
  primGen.SetTarget(0., 0.) # do not interfere with GenieGenerator
  Geniegen = ROOT.GenieGenerator()
- Geniegen.Init(inputFile,options.firstEvent) 
+ Geniegen.Init(inputFile,options.firstEvent)
  Geniegen.SetPositions(ship_geo.target.z0, ship_geo.tauMudet.zMudetC-5*u.m, ship_geo.TrackStation2.z)
  primGen.AddGenerator(Geniegen)
  options.nEvents = min(options.nEvents,Geniegen.GetNevents())
@@ -438,7 +431,7 @@ if simEngine == "nuRadiography":
  ut.checkFileExists(inputFile)
  primGen.SetTarget(0., 0.) # do not interfere with GenieGenerator
  Geniegen = ROOT.GenieGenerator()
- Geniegen.Init(inputFile,options.firstEvent) 
+ Geniegen.Init(inputFile,options.firstEvent)
  # Geniegen.SetPositions(ship_geo.target.z0, ship_geo.target.z0, ship_geo.MuonStation3.z)
  Geniegen.SetPositions(ship_geo.target.z0, ship_geo.tauMudet.zMudetC, ship_geo.MuonStation3.z)
  Geniegen.NuOnly()
@@ -449,7 +442,7 @@ if simEngine == "nuRadiography":
  pdg.AddParticle('W','Ion', 1.71350e+02, True, 0., 74, 'XXX', 1000741840)
 #
  run.SetPythiaDecayer('DecayConfigPy8.C')
- # this requires writing a C macro, would have been easier to do directly in python! 
+ # this requires writing a C macro, would have been easier to do directly in python!
  # for i in [431,421,411,-431,-421,-411]:
  # ROOT.gMC.SetUserDecay(i) # Force the decay to be done w/external decayer
 if simEngine == "Ntuple":
@@ -463,10 +456,10 @@ if simEngine == "Ntuple":
  print('Process ',options.nEvents,' from input file')
 #
 if simEngine == "MuonBack":
-# reading muon tracks from previous Pythia8/Geant4 simulation with charm replaced by cascade production 
+# reading muon tracks from previous Pythia8/Geant4 simulation with charm replaced by cascade production
  fileType = ut.checkFileExists(inputFile)
  if fileType == 'tree':
- # 2018 background production 
+ # 2018 background production
   primGen.SetTarget(ship_geo.target.z0+70.845*u.m,0.)
  else:
   primGen.SetTarget(ship_geo.target.z0+50*u.m,0.)
@@ -486,20 +479,20 @@ if simEngine == "MuonBack":
  options.nEvents = min(options.nEvents,MuonBackgen.GetNevents())
  MCTracksWithHitsOnly = True # otherwise, output file becomes too big
  print('Process ',options.nEvents,' from input file, with Phi random=',options.phiRandom, ' with MCTracksWithHitsOnly',MCTracksWithHitsOnly)
- if options.followMuon :  
+ if options.followMuon :
     options.fastMuon = True
     modules['Veto'].SetFollowMuon()
  if options.fastMuon :    modules['Veto'].SetFastMuon()
 
  # optional, boost gamma2muon conversion
- # ROOT.kShipMuonsCrossSectionFactor = 100. 
+ # ROOT.kShipMuonsCrossSectionFactor = 100.
 #
 if simEngine == "Cosmics":
  primGen.SetTarget(0., 0.)
  Cosmicsgen = ROOT.CosmicsGenerator()
  import CMBG_conf
  CMBG_conf.configure(Cosmicsgen, ship_geo)
- if not Cosmicsgen.Init(Opt_high): 
+ if not Cosmicsgen.Init(Opt_high):
       print("initialization of cosmic background generator failed ",Opt_high)
       sys.exit(0)
  Cosmicsgen.n_EVENTS = options.nEvents
@@ -525,17 +518,17 @@ if MCTracksWithHitsOnly:
 elif MCTracksWithEnergyCutOnly:
  fStack.SetMinPoints(-1)
  fStack.SetEnergyCut(100.*u.MeV)
-elif MCTracksWithHitsOrEnergyCut: 
+elif MCTracksWithHitsOrEnergyCut:
  fStack.SetMinPoints(1)
  fStack.SetEnergyCut(100.*u.MeV)
-elif options.deepCopy: 
+elif options.deepCopy:
  fStack.SetMinPoints(0)
  fStack.SetEnergyCut(0.*u.MeV)
 
 if options.eventDisplay:
  # Set cuts for storing the trajectories, can only be done after initialization of run (?!)
   trajFilter = ROOT.FairTrajFilter.Instance()
-  trajFilter.SetStepSizeCut(1*u.mm);  
+  trajFilter.SetStepSizeCut(1*u.mm)
   trajFilter.SetVertexCut(-20*u.m, -20*u.m,ship_geo.target.z0-1*u.m, 20*u.m, 20*u.m, 200.*u.m)
   trajFilter.SetMomentumCutP(0.1*u.GeV)
   trajFilter.SetEnergyCut(0., 400.*u.GeV)
@@ -561,7 +554,7 @@ if options.debug == 1:
 #fieldMaker.plotField(1, ROOT.TVector3(-9000.0, 6000.0, 50.0), ROOT.TVector3(-300.0, 300.0, 6.0), 'Bzx.png')
 #fieldMaker.plotField(2, ROOT.TVector3(-9000.0, 6000.0, 50.0), ROOT.TVector3(-400.0, 400.0, 6.0), 'Bzy.png')
 
-if inactivateMuonProcesses :
+if inactivateMuonProcesses:
  ROOT.gROOT.ProcessLine('#include "Geant4/G4ProcessTable.hh"')
  mygMC = ROOT.TGeant4.GetMC()
  mygMC.ProcessGeantCommand("/process/inactivate muPairProd")
@@ -573,10 +566,11 @@ if inactivateMuonProcesses :
  gProcessTable = ROOT.G4ProcessTable.GetProcessTable()
  procmu = gProcessTable.FindProcess(ROOT.G4String('muIoni'),ROOT.G4String('mu+'))
  procmu.SetVerboseLevel(2)
-if inactivateMuonNuclearProcess:
-  ROOT.gROOT.ProcessLine('#include "Geant4/G4ProcessTable.hh"')
-  mygMC = ROOT.TGeant4.GetMC()
-  mygMC.ProcessGeantCommand("/process/inactivate muonNuclear")
+
+if simEngine == "muonDIS":
+    ROOT.gROOT.ProcessLine('#include "Geant4/G4ProcessTable.hh"')
+    mygMC = ROOT.TGeant4.GetMC()
+    mygMC.ProcessGeantCommand("/process/inactivate muonNuclear")
 # -----Start run----------------------------------------------------
 run.Run(options.nEvents)
 # -----Runtime database---------------------------------------------
@@ -600,7 +594,7 @@ if options.debug == 2:
  fGeo.CheckOverlaps(0.1)  # 1 micron takes 5minutes
  fGeo.PrintOverlaps()
  # check subsystems in more detail
- for x in fGeo.GetTopNode().GetNodes(): 
+ for x in fGeo.GetTopNode().GetNodes():
    x.CheckOverlaps(0.0001)
    fGeo.PrintOverlaps()
 # -----Finish-------------------------------------------------------
@@ -611,11 +605,11 @@ print(' ')
 print("Macro finished successfully.")
 if "P8gen" in globals() :
     if (HNL): print("number of retries, events without HNL ",P8gen.nrOfRetries())
-    elif (options.DarkPhoton): 
+    elif (options.DarkPhoton):
         print("number of retries, events without Dark Photons ",P8gen.nrOfRetries())
         print("total number of dark photons (including multiple meson decays per single collision) ",P8gen.nrOfDP())
 
-print("Output file is ",  outFile) 
+print("Output file is ",  outFile)
 print("Parameter file is ",parFile)
 print("Real time ",rtime, " s, CPU time ",ctime,"s")
 
@@ -637,11 +631,11 @@ if simEngine == "MuonBack":
  nEvents = 0
  pointContainers = []
  for x in sTree.GetListOfBranches():
-   name = x.GetName() 
+   name = x.GetName()
    if not name.find('Point')<0: pointContainers.append('sTree.'+name+'.GetEntries()') # makes use of convention that all sensitive detectors fill XXXPoint containers
  for n in range(t.GetEntries()):
      rc = t.GetEvent(n)
-     empty = True 
+     empty = True
      for x in pointContainers:
         if eval(x)>0: empty = False
      if not empty:

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -373,11 +373,6 @@ if simEngine == "muonDIS":
  ut.checkFileExists(inputFile)
  primGen.SetTarget(0., 0.)
  DISgen = ROOT.MuDISGenerator()
- #  add Carbon to PDG
- pdg = ROOT.TDatabasePDG.Instance()
- pdg.AddParticle("C12", "Carbon-12", 12.0, True, 0, 6.0, "nucleus", 1000060120)
- pdg.AddParticle("C13", "Carbon-13", 13.003355, True, 0, 6.0, "nucleus", 1000060130)
-
  # from nu_tau detector to tracking station 2
  # mu_start, mu_end =  ship_geo.tauMudet.zMudetC,ship_geo.TrackStation2.z
  #
@@ -515,15 +510,17 @@ if options.dryrun: # Early stop after setting up Pythia 8
  sys.exit(0)
 gMC = ROOT.TVirtualMC.GetMC()
 fStack = gMC.GetStack()
+EnergyCut = 10.*u.MeV if options.mudis else 100.*u.MeV
+
 if MCTracksWithHitsOnly:
  fStack.SetMinPoints(1)
  fStack.SetEnergyCut(-100.*u.MeV)
 elif MCTracksWithEnergyCutOnly:
  fStack.SetMinPoints(-1)
- fStack.SetEnergyCut(100.*u.MeV)
+ fStack.SetEnergyCut(EnergyCut)
 elif MCTracksWithHitsOrEnergyCut:
  fStack.SetMinPoints(1)
- fStack.SetEnergyCut(100.*u.MeV)
+ fStack.SetEnergyCut(EnergyCut)
 elif options.deepCopy:
  fStack.SetMinPoints(0)
  fStack.SetEnergyCut(0.*u.MeV)

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
 import os
 import sys
 import ROOT
@@ -30,7 +32,7 @@ MCTracksWithHitsOnly   = False  # copy particles which produced a hit and their 
 MCTracksWithEnergyCutOnly = True # copy particles above a certain kin energy cut
 MCTracksWithHitsOrEnergyCut = False # or of above, factor 2 file size increase compared to MCTracksWithEnergyCutOnly
 
-charmonly    = False  # option to be set with -A to enable only charm decays, charm x-sec measurement
+charmonly    = False  # option to be set with -A to enable only charm decays, charm x-sec measurement  
 HNL          = True
 
 inputFile    = "/eos/experiment/ship/data/Charm/Cascade-parp16-MSTP82-1-MSEL4-978Bpot.root"
@@ -70,6 +72,7 @@ globalDesigns = {
 default = '2023'
 
 inactivateMuonProcesses = False   # provisionally for making studies of various muon background sources
+inactivateMuonNuclearProcess = False #Only True for muonDIS
 
 parser = ArgumentParser()
 group = parser.add_mutually_exclusive_group()
@@ -169,7 +172,7 @@ if options.A != 'c':
      if options.A =='b': inputFile = "/eos/experiment/ship/data/Beauty/Cascade-run0-19-parp16-MSTP82-1-MSEL5-5338Bpot.root"
      if options.A.lower() == 'charmonly':
            charmonly = True
-           HNL = False
+           HNL = False 
      if options.A not in ['b','c','bc','meson','pbrem','qcd']: inclusive = True
 if options.MM:
      motherMode=options.MM
@@ -196,11 +199,11 @@ if options.testFlag:
 
 
 #sanity check
-if (HNL and options.RPVSUSY) or (HNL and options.DarkPhoton) or (options.DarkPhoton and options.RPVSUSY):
+if (HNL and options.RPVSUSY) or (HNL and options.DarkPhoton) or (options.DarkPhoton and options.RPVSUSY): 
  print("cannot have HNL and SUSY or DP at the same time, abort")
  sys.exit(2)
 
-if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile:
+if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile: 
   inputFile = "/eos/experiment/ship/data/GenieEvents/genie-nu_mu.root"
 if simEngine == "muonDIS" and defaultInputFile:
   print('input file required if simEngine = muonDIS')
@@ -242,11 +245,12 @@ else: tag = simEngine+"-"+mcEngine
 if charmonly: tag = simEngine+"CharmOnly-"+mcEngine
 if options.eventDisplay: tag = tag+'_D'
 if options.dv > 4 : tag = 'conical.'+tag
+elif dy: tag = str(options.dy)+'.'+tag 
 if not os.path.exists(options.outputDir):
   os.makedirs(options.outputDir)
 outFile = f"{options.outputDir}/ship.{tag}.root"
 
-# rm older files !!!
+# rm older files !!! 
 for x in os.listdir(options.outputDir):
   if not x.find(tag)<0: os.system(f"rm {options.outputDir}/{x}" )
 # Parameter file name
@@ -263,8 +267,8 @@ timer.Start()
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
 run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
-run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C
-rtdb = run.GetRuntimeDb()
+run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C 
+rtdb = run.GetRuntimeDb() 
 # -----Create geometry----------------------------------------------
 # import shipMuShield_only as shipDet_conf # special use case for an attempt to convert active shielding geometry for use with FLUKA
 # import shipTarget_only as shipDet_conf
@@ -274,7 +278,7 @@ modules = shipDet_conf.configure(run,ship_geo)
 # -----Create PrimaryGenerator--------------------------------------
 primGen = ROOT.FairPrimaryGenerator()
 if simEngine == "Pythia8":
- primGen.SetTarget(ship_geo.target.z0, 0.)
+ primGen.SetTarget(ship_geo.target.z0, 0.) 
 # -----Pythia8--------------------------------------
  if HNL or options.RPVSUSY:
   P8gen = ROOT.HNLPythia8Generator()
@@ -297,7 +301,7 @@ if simEngine == "Pythia8":
    pythia8_conf.configurerpvsusy(P8gen,options.theMass,[theCouplings[0],theCouplings[1]],
                                 theCouplings[2],options.RPVSUSYbench,inclusive,options.deepCopy)
   P8gen.SetParameters("ProcessLevel:all = off")
-  if inputFile:
+  if inputFile: 
    ut.checkFileExists(inputFile)
 # read from external file
    P8gen.UseExternalFile(inputFile, options.firstEvent)
@@ -310,7 +314,7 @@ if simEngine == "Pythia8":
   import pythia8darkphoton_conf
   passDPconf = pythia8darkphoton_conf.configure(P8gen,options.theMass,options.theDPepsilon,inclusive, motherMode, options.deepCopy)
   if (passDPconf!=1): sys.exit()
- if HNL or options.RPVSUSY or options.DarkPhoton:
+ if HNL or options.RPVSUSY or options.DarkPhoton: 
   P8gen.SetSmearBeam(1*u.cm) # finite beam size
   P8gen.SetLmin((ship_geo.Chamber1.z - ship_geo.chambers.Tub1length) - ship_geo.target.z0 )
   P8gen.SetLmax(ship_geo.TrackStation1.z - ship_geo.target.z0 )
@@ -318,7 +322,7 @@ if simEngine == "Pythia8":
   primGen.SetTarget(0., 0.) #vertex is set in pythia8Generator
   ut.checkFileExists(inputFile)
   if ship_geo.Box.gausbeam:
-   primGen.SetBeam(0.,0., 0.5, 0.5) #more central beam, for hits in downstream detectors
+   primGen.SetBeam(0.,0., 0.5, 0.5) #more central beam, for hits in downstream detectors    
    primGen.SmearGausVertexXY(True) #sigma = x
   else:
    primGen.SetBeam(0.,0., ship_geo.Box.TX-1., ship_geo.Box.TY-1.) #Uniform distribution in x/y on the target (0.5 cm of margin at both sides)
@@ -330,7 +334,6 @@ if simEngine == "Pythia8":
 # P8gen.SetMom(500.*u.GeV)
 # P8gen.SetId(-211)
  primGen.AddGenerator(P8gen)
-
 if simEngine == "FixedTarget":
  P8gen = ROOT.FixedTargetGenerator()
  P8gen.SetTarget("volTarget_1",0.,0.)
@@ -341,7 +344,7 @@ if simEngine == "FixedTarget":
  primGen.AddGenerator(P8gen)
 if simEngine == "Pythia6":
 # set muon interaction close to decay volume
- primGen.SetTarget(ship_geo.target.z0+ship_geo.muShield.length, 0.)
+ primGen.SetTarget(ship_geo.target.z0+ship_geo.muShield.length, 0.) 
 # -----Pythia6-------------------------
  test = ROOT.TPythia6() # don't know any other way of forcing to load lib
  P6gen = ROOT.tPythia6Generator()
@@ -364,7 +367,7 @@ if simEngine == "EvtCalc":
     )
 
 # -----Particle Gun-----------------------
-if simEngine == "PG":
+if simEngine == "PG": 
   myPgun = ROOT.FairBoxGenerator(options.pID,1)
   myPgun.SetPRange(options.Estart,options.Eend)
   myPgun.SetPhiRange(0, 360) # // Azimuth angle range [degree]
@@ -374,8 +377,9 @@ if simEngine == "PG":
 # -----muon DIS Background------------------------
 if simEngine == "muonDIS":
  ut.checkFileExists(inputFile)
- primGen.SetTarget(0., 0.)
+ primGen.SetTarget(0., 0.) 
  DISgen = ROOT.MuDISGenerator()
+ 
  # from nu_tau detector to tracking station 2
  # mu_start, mu_end =  ship_geo.tauMudet.zMudetC,ship_geo.TrackStation2.z
  #
@@ -386,7 +390,8 @@ if simEngine == "muonDIS":
  DISgen.Init(inputFile,options.firstEvent)
  primGen.AddGenerator(DISgen)
  options.nEvents = min(options.nEvents,DISgen.GetNevents())
- inactivateMuonProcesses = True # avoid unwanted hadronic events of "incoming" muon flying backward
+ inactivateMuonProcesses = False 
+ inactivateMuonNuclearProcess = True #avoid double counting
  print('Generate ',options.nEvents,' with DIS input', ' first event',options.firstEvent)
 # -----neutrino interactions from nuage------------------------
 if simEngine == "Nuage":
@@ -405,7 +410,7 @@ if simEngine == "Nuage":
  nZcells = ntt -1
  startx = -ship_geo.NuTauTarget.xdim/2. + nXcells*ship_geo.NuTauTarget.BrX
  endx = -ship_geo.NuTauTarget.xdim/2. + (nXcells+1)*ship_geo.NuTauTarget.BrX
- starty = -ship_geo.NuTauTarget.ydim/2. + nYcells*ship_geo.NuTauTarget.BrY
+ starty = -ship_geo.NuTauTarget.ydim/2. + nYcells*ship_geo.NuTauTarget.BrY 
  endy = - ship_geo.NuTauTarget.ydim/2. + (nYcells+1)*ship_geo.NuTauTarget.BrY
  startz = ship_geo.EmuMagnet.zC - ship_geo.NuTauTarget.zdim/2. + ntt *ship_geo.NuTauTT.TTZ + nZcells * ship_geo.NuTauTarget.CellW
  endz = ship_geo.EmuMagnet.zC - ship_geo.NuTauTarget.zdim/2. + ntt *ship_geo.NuTauTT.TTZ + nZcells * ship_geo.NuTauTarget.CellW + ship_geo.NuTauTarget.BrZ
@@ -423,7 +428,7 @@ if simEngine == "Genie":
  ut.checkFileExists(inputFile)
  primGen.SetTarget(0., 0.) # do not interfere with GenieGenerator
  Geniegen = ROOT.GenieGenerator()
- Geniegen.Init(inputFile,options.firstEvent)
+ Geniegen.Init(inputFile,options.firstEvent) 
  Geniegen.SetPositions(ship_geo.target.z0, ship_geo.tauMudet.zMudetC-5*u.m, ship_geo.TrackStation2.z)
  primGen.AddGenerator(Geniegen)
  options.nEvents = min(options.nEvents,Geniegen.GetNevents())
@@ -433,7 +438,7 @@ if simEngine == "nuRadiography":
  ut.checkFileExists(inputFile)
  primGen.SetTarget(0., 0.) # do not interfere with GenieGenerator
  Geniegen = ROOT.GenieGenerator()
- Geniegen.Init(inputFile,options.firstEvent)
+ Geniegen.Init(inputFile,options.firstEvent) 
  # Geniegen.SetPositions(ship_geo.target.z0, ship_geo.target.z0, ship_geo.MuonStation3.z)
  Geniegen.SetPositions(ship_geo.target.z0, ship_geo.tauMudet.zMudetC, ship_geo.MuonStation3.z)
  Geniegen.NuOnly()
@@ -444,7 +449,7 @@ if simEngine == "nuRadiography":
  pdg.AddParticle('W','Ion', 1.71350e+02, True, 0., 74, 'XXX', 1000741840)
 #
  run.SetPythiaDecayer('DecayConfigPy8.C')
- # this requires writing a C macro, would have been easier to do directly in python!
+ # this requires writing a C macro, would have been easier to do directly in python! 
  # for i in [431,421,411,-431,-421,-411]:
  # ROOT.gMC.SetUserDecay(i) # Force the decay to be done w/external decayer
 if simEngine == "Ntuple":
@@ -458,10 +463,10 @@ if simEngine == "Ntuple":
  print('Process ',options.nEvents,' from input file')
 #
 if simEngine == "MuonBack":
-# reading muon tracks from previous Pythia8/Geant4 simulation with charm replaced by cascade production
+# reading muon tracks from previous Pythia8/Geant4 simulation with charm replaced by cascade production 
  fileType = ut.checkFileExists(inputFile)
  if fileType == 'tree':
- # 2018 background production
+ # 2018 background production 
   primGen.SetTarget(ship_geo.target.z0+70.845*u.m,0.)
  else:
   primGen.SetTarget(ship_geo.target.z0+50*u.m,0.)
@@ -481,20 +486,20 @@ if simEngine == "MuonBack":
  options.nEvents = min(options.nEvents,MuonBackgen.GetNevents())
  MCTracksWithHitsOnly = True # otherwise, output file becomes too big
  print('Process ',options.nEvents,' from input file, with Phi random=',options.phiRandom, ' with MCTracksWithHitsOnly',MCTracksWithHitsOnly)
- if options.followMuon :
+ if options.followMuon :  
     options.fastMuon = True
     modules['Veto'].SetFollowMuon()
  if options.fastMuon :    modules['Veto'].SetFastMuon()
 
  # optional, boost gamma2muon conversion
- # ROOT.kShipMuonsCrossSectionFactor = 100.
+ # ROOT.kShipMuonsCrossSectionFactor = 100. 
 #
 if simEngine == "Cosmics":
  primGen.SetTarget(0., 0.)
  Cosmicsgen = ROOT.CosmicsGenerator()
  import CMBG_conf
  CMBG_conf.configure(Cosmicsgen, ship_geo)
- if not Cosmicsgen.Init(Opt_high):
+ if not Cosmicsgen.Init(Opt_high): 
       print("initialization of cosmic background generator failed ",Opt_high)
       sys.exit(0)
  Cosmicsgen.n_EVENTS = options.nEvents
@@ -520,17 +525,17 @@ if MCTracksWithHitsOnly:
 elif MCTracksWithEnergyCutOnly:
  fStack.SetMinPoints(-1)
  fStack.SetEnergyCut(100.*u.MeV)
-elif MCTracksWithHitsOrEnergyCut:
+elif MCTracksWithHitsOrEnergyCut: 
  fStack.SetMinPoints(1)
  fStack.SetEnergyCut(100.*u.MeV)
-elif options.deepCopy:
+elif options.deepCopy: 
  fStack.SetMinPoints(0)
  fStack.SetEnergyCut(0.*u.MeV)
 
 if options.eventDisplay:
  # Set cuts for storing the trajectories, can only be done after initialization of run (?!)
   trajFilter = ROOT.FairTrajFilter.Instance()
-  trajFilter.SetStepSizeCut(1*u.mm)
+  trajFilter.SetStepSizeCut(1*u.mm);  
   trajFilter.SetVertexCut(-20*u.m, -20*u.m,ship_geo.target.z0-1*u.m, 20*u.m, 20*u.m, 200.*u.m)
   trajFilter.SetMomentumCutP(0.1*u.GeV)
   trajFilter.SetEnergyCut(0., 400.*u.GeV)
@@ -568,6 +573,10 @@ if inactivateMuonProcesses :
  gProcessTable = ROOT.G4ProcessTable.GetProcessTable()
  procmu = gProcessTable.FindProcess(ROOT.G4String('muIoni'),ROOT.G4String('mu+'))
  procmu.SetVerboseLevel(2)
+if inactivateMuonNuclearProcess:
+  ROOT.gROOT.ProcessLine('#include "Geant4/G4ProcessTable.hh"')
+  mygMC = ROOT.TGeant4.GetMC()
+  mygMC.ProcessGeantCommand("/process/inactivate muonNuclear")
 # -----Start run----------------------------------------------------
 run.Run(options.nEvents)
 # -----Runtime database---------------------------------------------
@@ -591,7 +600,7 @@ if options.debug == 2:
  fGeo.CheckOverlaps(0.1)  # 1 micron takes 5minutes
  fGeo.PrintOverlaps()
  # check subsystems in more detail
- for x in fGeo.GetTopNode().GetNodes():
+ for x in fGeo.GetTopNode().GetNodes(): 
    x.CheckOverlaps(0.0001)
    fGeo.PrintOverlaps()
 # -----Finish-------------------------------------------------------
@@ -602,11 +611,11 @@ print(' ')
 print("Macro finished successfully.")
 if "P8gen" in globals() :
     if (HNL): print("number of retries, events without HNL ",P8gen.nrOfRetries())
-    elif (options.DarkPhoton):
+    elif (options.DarkPhoton): 
         print("number of retries, events without Dark Photons ",P8gen.nrOfRetries())
         print("total number of dark photons (including multiple meson decays per single collision) ",P8gen.nrOfDP())
 
-print("Output file is ",  outFile)
+print("Output file is ",  outFile) 
 print("Parameter file is ",parFile)
 print("Real time ",rtime, " s, CPU time ",ctime,"s")
 
@@ -628,11 +637,11 @@ if simEngine == "MuonBack":
  nEvents = 0
  pointContainers = []
  for x in sTree.GetListOfBranches():
-   name = x.GetName()
+   name = x.GetName() 
    if not name.find('Point')<0: pointContainers.append('sTree.'+name+'.GetEntries()') # makes use of convention that all sensitive detectors fill XXXPoint containers
  for n in range(t.GetEntries()):
      rc = t.GetEvent(n)
-     empty = True
+     empty = True 
      for x in pointContainers:
         if eval(x)>0: empty = False
      if not empty:

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -373,6 +373,11 @@ if simEngine == "muonDIS":
  ut.checkFileExists(inputFile)
  primGen.SetTarget(0., 0.)
  DISgen = ROOT.MuDISGenerator()
+ #  add Carbon to PDG
+ pdg = ROOT.TDatabasePDG.Instance()
+ pdg.AddParticle("C12", "Carbon-12", 12.0, True, 0, 6.0, "nucleus", 1000060120)
+ pdg.AddParticle("C13", "Carbon-13", 13.003355, True, 0, 6.0, "nucleus", 1000060130)
+
  # from nu_tau detector to tracking station 2
  # mu_start, mu_end =  ship_geo.tauMudet.zMudetC,ship_geo.TrackStation2.z
  #

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -69,8 +69,6 @@ globalDesigns = {
 }
 default = '2023'
 
-inactivateMuonProcesses = False         # provisionally for making studies of various muon background sources
-
 parser = ArgumentParser()
 group = parser.add_mutually_exclusive_group()
 parser.add_argument("--evtcalc", help="Use EventCalc", action="store_true")
@@ -554,23 +552,6 @@ if options.debug == 1:
 #fieldMaker.plotField(1, ROOT.TVector3(-9000.0, 6000.0, 50.0), ROOT.TVector3(-300.0, 300.0, 6.0), 'Bzx.png')
 #fieldMaker.plotField(2, ROOT.TVector3(-9000.0, 6000.0, 50.0), ROOT.TVector3(-400.0, 400.0, 6.0), 'Bzy.png')
 
-if inactivateMuonProcesses:
- ROOT.gROOT.ProcessLine('#include "Geant4/G4ProcessTable.hh"')
- mygMC = ROOT.TGeant4.GetMC()
- mygMC.ProcessGeantCommand("/process/inactivate muPairProd")
- mygMC.ProcessGeantCommand("/process/inactivate muBrems")
- mygMC.ProcessGeantCommand("/process/inactivate muIoni")
- mygMC.ProcessGeantCommand("/process/inactivate muonNuclear")
- mygMC.ProcessGeantCommand("/particle/select mu+")
- mygMC.ProcessGeantCommand("/particle/process/dump")
- gProcessTable = ROOT.G4ProcessTable.GetProcessTable()
- procmu = gProcessTable.FindProcess(ROOT.G4String('muIoni'),ROOT.G4String('mu+'))
- procmu.SetVerboseLevel(2)
-
-if simEngine == "muonDIS":
-    ROOT.gROOT.ProcessLine('#include "Geant4/G4ProcessTable.hh"')
-    mygMC = ROOT.TGeant4.GetMC()
-    mygMC.ProcessGeantCommand("/process/inactivate muonNuclear")
 # -----Start run----------------------------------------------------
 run.Run(options.nEvents)
 # -----Runtime database---------------------------------------------

--- a/muonDIS/add_muonresponse.py
+++ b/muonDIS/add_muonresponse.py
@@ -3,7 +3,6 @@
 
 import argparse
 import logging
-import os
 
 import ROOT as r
 
@@ -23,17 +22,17 @@ parser.add_argument(
 args = parser.parse_args()
 
 
-def read_file():
+def inspect_file(inputfile):
     """Inspecting the produced file for successfully added muon veto points."""
-    inputFile = r.TFile.Open(args.inputfile, "READ")
-    input_tree = inputFile.cbmsim
+    input_file = r.TFile.Open(inputfile, "READ")
+    input_tree = input_file.cbmsim
     input_tree.GetEntry(0)
 
     muons = False
     for hit in input_tree.vetoPoint:
         if hit.GetTrackID() == 0:
             muons = True
-    inputFile.Close()
+    input_file.Close()
 
     if muons:
         print("File is already updated with incoming muon info. Nothing to do.")
@@ -45,77 +44,74 @@ def read_file():
         return True
 
 
-def modify_file():
-    """Modify the input file with muon info."""
-    if args.inputfile[0:4] == "/eos":
-        args.inputfile = os.environ["EOSSHIP"] + args.inputfile
+def modify_file(inputfile, muonfile):
+    """Add information from original muon to input simulation file."""
+    logging.warning(f"{inputfile} will be opened for modification")
 
-    logging.warning(f"{args.inputfile} opened for modification")
-
-    inputFile = r.TFile.Open(args.inputfile, "UPDATE")
+    input_file = r.TFile.Open(inputfile, "UPDATE")
     try:
-        input_tree = inputFile.cbmsim
+        input_tree = input_file.cbmsim
     except Exception as e:
         print(f"Error: {e}")
-        inputFile.Close()
+        input_file.Close()
         exit(1)
 
     # Open the external file with additional vetoPoints
-    muonFile = r.TFile.Open(args.muonfile, "READ")
+    muon_file = r.TFile.Open(muonfile, "READ")
     try:
-        muon_tree = muonFile.DIS
+        muon_tree = muon_file.DIS
     except Exception as e:
         print(f"Error: {e}")
-        muonFile.Close()
+        muon_file.Close()
         exit(1)
 
-    inputFile.cd()
+    input_file.cd()
     output_tree = input_tree.CloneTree(
         0
     )  # Clone the structure of the existing tree, but do not copy the entries
 
     # Access the vetoPoint branch in the original and external trees
-    originalVetoPoints = r.TClonesArray("vetoPoint")
-    muonVetoPoints = r.TClonesArray("vetoPoint")
-    combinedVetoPoints = r.TClonesArray("vetoPoint")
+    original_vetoPoint = r.TClonesArray("vetoPoint")
+    muon_vetoPoint = r.TClonesArray("vetoPoint")
+    combined_vetoPoint = r.TClonesArray("vetoPoint")
 
-    input_tree.SetBranchAddress("vetoPoint", originalVetoPoints)
-    muon_tree.SetBranchAddress("muon_vetoPoints", muonVetoPoints)
-    output_tree.SetBranchAddress("vetoPoint", combinedVetoPoints)
+    input_tree.SetBranchAddress("vetoPoint", original_vetoPoint)
+    muon_tree.SetBranchAddress("muon_vetoPoints", muon_vetoPoint)
+    output_tree.SetBranchAddress("vetoPoint", combined_vetoPoint)
 
     for input_event, muon_event in zip(input_tree, muon_tree):
         interaction_point = r.TVector3()
         input_event.MCTrack[0].GetStartVertex(interaction_point)
 
-        combinedVetoPoints.Clear()
+        combined_vetoPoint.Clear()
 
         index = 0
 
-        for hit in originalVetoPoints:
-            if combinedVetoPoints.GetSize() == index:
-                combinedVetoPoints.Expand(index + 1)
-            combinedVetoPoints[index] = hit
+        for hit in original_vetoPoint:
+            if combined_vetoPoint.GetSize() == index:
+                combined_vetoPoint.Expand(index + 1)
+            combined_vetoPoint[index] = hit  # pending fix to support ROOT 6.32+
             index += 1
 
-        for hit in muonVetoPoints:
+        for hit in muon_vetoPoint:
             if hit.GetZ() < interaction_point.Z():
-                if combinedVetoPoints.GetSize() == index:
-                    combinedVetoPoints.Expand(index + 1)
-                combinedVetoPoints[index] = hit
+                if combined_vetoPoint.GetSize() == index:
+                    combined_vetoPoint.Expand(index + 1)
+                combined_vetoPoint[index] = hit  # pending fix to support ROOT 6.32+
                 index += 1
 
         output_tree.Fill()
 
     # Write the updated tree back to the same file
-    inputFile.cd()
+    input_file.cd()
     output_tree.Write("cbmsim", r.TObject.kOverwrite)
-    inputFile.Close()
-    muonFile.Close()
+    input_file.Close()
+    muon_file.Close()
 
-    print(f"File updated with incoming muon info as {args.inputfile}")
+    print(f"File updated with incoming muon info as {inputfile}")
 
 
-add_muons = read_file()
+add_muons = inspect_file(args.inputfile)
 
 if add_muons:
-    modify_file()
+    modify_file(args.inputfile, args.muonfile)

--- a/muonDIS/add_muonresponse.py
+++ b/muonDIS/add_muonresponse.py
@@ -3,8 +3,12 @@
 
 import argparse
 import logging
+import os
 
 import ROOT as r
+from tabulate import tabulate
+
+logging.basicConfig(level=logging.DEBUG)
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument(
@@ -20,35 +24,61 @@ parser.add_argument(
     help="Muon file used for DIS production (muonDis_<>.root)",
 )
 args = parser.parse_args()
+headers = [
+    "Event",
+    "Muon vetoPoints Available",
+    "Original VetoPoint Count",
+    "Muon vetoPoints Added",
+    "Combined VetoPoint Count",
+]
 
 
-def inspect_file(inputfile):
+def inspect_file(inputfile, muonfile, print_table=False):
     """Inspecting the produced file for successfully added muon veto points."""
-    input_file = r.TFile.Open(inputfile, "READ")
+    input_file = r.TFile.Open(inputfile, "read")
     input_tree = input_file.cbmsim
-    input_tree.GetEntry(0)
 
-    muons = False
-    for hit in input_tree.vetoPoint:
-        if hit.GetTrackID() == 0:
-            muons = True
-    input_file.Close()
+    muon_file = r.TFile.Open(muonfile, "read")
+    muon_tree = muon_file.DIS
 
-    if muons:
-        print("File is already updated with incoming muon info. Nothing to do.")
-        return False
-    else:
-        print(
-            "Incoming muon's vetopoint info missing in file, proceeding with modification"
+    muons_found = False
+
+    table_data = []
+
+    for i, (muon_event, input_event) in enumerate(zip(muon_tree, input_tree)):
+        muon_hits = len(muon_event.muon_vetoPoints)
+        muoncount = 0
+        if muon_hits:
+            for hit in input_event.vetoPoint:
+                if hit.GetTrackID() == 0:
+                    muons_found = True
+                    muoncount += 1
+        table_data.append(
+            [
+                i,
+                muon_hits,
+                len(input_event.vetoPoint) - muoncount,
+                muoncount,
+                len(input_event.vetoPoint),
+            ]
         )
-        return True
+
+    if print_table:
+        print(tabulate(table_data, headers=headers, tablefmt="grid"))
+
+    input_file.Close()
+    muon_file.Close()
+
+    return muons_found
 
 
 def modify_file(inputfile, muonfile):
     """Add information from original muon to input simulation file."""
-    logging.warning(f"{inputfile} will be opened for modification")
+    logging.warning(
+        f"vetoPoints from the incoming muon (saved in {muonfile}) will be added to {inputfile}."
+    )
 
-    input_file = r.TFile.Open(inputfile, "UPDATE")
+    input_file = r.TFile.Open(inputfile, "read")
     try:
         input_tree = input_file.cbmsim
     except Exception as e:
@@ -57,7 +87,7 @@ def modify_file(inputfile, muonfile):
         exit(1)
 
     # Open the external file with additional vetoPoints
-    muon_file = r.TFile.Open(muonfile, "READ")
+    muon_file = r.TFile.Open(muonfile, "read")
     try:
         muon_tree = muon_file.DIS
     except Exception as e:
@@ -65,21 +95,18 @@ def modify_file(inputfile, muonfile):
         muon_file.Close()
         exit(1)
 
-    input_file.cd()
+    temp_filename = inputfile.replace(".root", ".tmp")
+    temp_file = r.TFile.Open(temp_filename, "recreate")
     output_tree = input_tree.CloneTree(
         0
     )  # Clone the structure of the existing tree, but do not copy the entries
 
-    # Access the vetoPoint branch in the original and external trees
-    original_vetoPoint = r.TClonesArray("vetoPoint")
-    muon_vetoPoint = r.TClonesArray("vetoPoint")
     combined_vetoPoint = r.TClonesArray("vetoPoint")
 
-    input_tree.SetBranchAddress("vetoPoint", original_vetoPoint)
-    muon_tree.SetBranchAddress("muon_vetoPoints", muon_vetoPoint)
     output_tree.SetBranchAddress("vetoPoint", combined_vetoPoint)
+    table_data = []
 
-    for input_event, muon_event in zip(input_tree, muon_tree):
+    for i, (input_event, muon_event) in enumerate(zip(input_tree, muon_tree)):
         interaction_point = r.TVector3()
         input_event.MCTrack[0].GetStartVertex(interaction_point)
 
@@ -87,31 +114,50 @@ def modify_file(inputfile, muonfile):
 
         index = 0
 
-        for hit in original_vetoPoint:
+        for hit in input_event.vetoPoint:
             if combined_vetoPoint.GetSize() == index:
                 combined_vetoPoint.Expand(index + 1)
             combined_vetoPoint[index] = hit  # pending fix to support ROOT 6.32+
             index += 1
 
-        for hit in muon_vetoPoint:
+        muoncount = 0
+        for hit in muon_event.muon_vetoPoints:
             if hit.GetZ() < interaction_point.Z():
                 if combined_vetoPoint.GetSize() == index:
                     combined_vetoPoint.Expand(index + 1)
                 combined_vetoPoint[index] = hit  # pending fix to support ROOT 6.32+
                 index += 1
+                muoncount += 1
 
+        table_data.append(
+            [
+                i,
+                len(muon_event.muon_vetoPoints),
+                len(input_event.vetoPoint),
+                muoncount,
+                len(combined_vetoPoint),
+            ]
+        )
         output_tree.Fill()
 
-    # Write the updated tree back to the same file
-    input_file.cd()
     output_tree.Write("cbmsim", r.TObject.kOverwrite)
+    temp_file.Close()
     input_file.Close()
     muon_file.Close()
 
+    os.remove(inputfile)
+    os.rename(temp_filename, inputfile)
     print(f"File updated with incoming muon info as {inputfile}")
+    print(tabulate(table_data, headers=headers, tablefmt="grid"))
 
 
-add_muons = inspect_file(args.inputfile)
+muons_found = inspect_file(args.inputfile, args.muonfile)
 
-if add_muons:
+if not muons_found:
+    print(
+        "Incoming muon's vetopoint info missing in file, proceeding with modification"
+    )
     modify_file(args.inputfile, args.muonfile)
+else:
+    print("File is already updated with incoming muon info. Nothing to do.")
+    muons_found = inspect_file(args.inputfile, args.muonfile, print_table=True)

--- a/muonDIS/add_muonresponse.py
+++ b/muonDIS/add_muonresponse.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""Script to add the incoming muon's MC hits in the SBT to the simulation file."""
+
+import argparse
+import logging
+import os
+
+import ROOT as r
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument(
+    "-f",
+    "--inputfile",
+    required=True,
+    help="Simulation file produced from DIS, WARNING: File will be modified.",
+)
+parser.add_argument(
+    "-m",
+    "--muonfile",
+    required=True,
+    help="Muon file used for DIS production (muonDis_<>.root)",
+)
+args = parser.parse_args()
+
+
+def read_file():
+    """Inspecting the produced file for successfully added muon veto points."""
+    inputFile = r.TFile.Open(args.inputfile, "READ")
+    input_tree = inputFile.cbmsim
+    input_tree.GetEntry(0)
+
+    muons = False
+    for hit in input_tree.vetoPoint:
+        if hit.GetTrackID() == 0:
+            muons = True
+    inputFile.Close()
+
+    if muons:
+        print("File is already updated with incoming muon info. Nothing to do.")
+        return False
+    else:
+        print(
+            "Incoming muon's vetopoint info missing in file, proceeding with modification"
+        )
+        return True
+
+
+def modify_file():
+    """Modify the input file with muon info."""
+    if args.inputfile[0:4] == "/eos":
+        args.inputfile = os.environ["EOSSHIP"] + args.inputfile
+
+    logging.warning(f"{args.inputfile} opened for modification")
+
+    inputFile = r.TFile.Open(args.inputfile, "UPDATE")
+    try:
+        input_tree = inputFile.cbmsim
+    except Exception as e:
+        print(f"Error: {e}")
+        inputFile.Close()
+        exit(1)
+
+    # Open the external file with additional vetoPoints
+    muonFile = r.TFile.Open(args.muonfile, "READ")
+    try:
+        muon_tree = muonFile.DIS
+    except Exception as e:
+        print(f"Error: {e}")
+        muonFile.Close()
+        exit(1)
+
+    inputFile.cd()
+    output_tree = input_tree.CloneTree(
+        0
+    )  # Clone the structure of the existing tree, but do not copy the entries
+
+    # Access the vetoPoint branch in the original and external trees
+    originalVetoPoints = r.TClonesArray("vetoPoint")
+    muonVetoPoints = r.TClonesArray("vetoPoint")
+    combinedVetoPoints = r.TClonesArray("vetoPoint")
+
+    input_tree.SetBranchAddress("vetoPoint", originalVetoPoints)
+    muon_tree.SetBranchAddress("muon_vetoPoints", muonVetoPoints)
+    output_tree.SetBranchAddress("vetoPoint", combinedVetoPoints)
+
+    for input_event, muon_event in zip(input_tree, muon_tree):
+        interaction_point = r.TVector3()
+        input_event.MCTrack[0].GetStartVertex(interaction_point)
+
+        combinedVetoPoints.Clear()
+
+        index = 0
+
+        for hit in originalVetoPoints:
+            if combinedVetoPoints.GetSize() == index:
+                combinedVetoPoints.Expand(index + 1)
+            combinedVetoPoints[index] = hit
+            index += 1
+
+        for hit in muonVetoPoints:
+            if hit.GetZ() < interaction_point.Z():
+                if combinedVetoPoints.GetSize() == index:
+                    combinedVetoPoints.Expand(index + 1)
+                combinedVetoPoints[index] = hit
+                index += 1
+
+        output_tree.Fill()
+
+    # Write the updated tree back to the same file
+    inputFile.cd()
+    output_tree.Write("cbmsim", r.TObject.kOverwrite)
+    inputFile.Close()
+    muonFile.Close()
+
+    print(f"File updated with incoming muon info as {args.inputfile}")
+
+
+add_muons = read_file()
+
+if add_muons:
+    modify_file()

--- a/muonDIS/makeMuonDIS.py
+++ b/muonDIS/makeMuonDIS.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+"""Script to generate DIS events for muons in Pythia6, and sve to a ROOT file (along with the original muon's soft interactions)."""
+
+import argparse
+import logging
+import time
+from array import array
+
+import ROOT as r
+
+logging.basicConfig(level=logging.INFO)
+PDG = r.TDatabasePDG.Instance()
+
+
+def rotate(px, py, pz, theta, phi):
+    """Rotate the daughter particle momentum to align with respect to the muon's momentum."""
+    momentum = r.TVector3(px, py, pz)
+
+    rotation = r.TRotation()
+    rotation.RotateY(theta)  # Rotate around the Y-axis
+    rotation.RotateZ(phi)  # Rotate around the Z-axis
+
+    # Apply the rotation to the momentum vector
+    rotated_momentum = rotation * momentum
+
+    return rotated_momentum.X(), rotated_momentum.Y(), rotated_momentum.Z()
+
+
+def makeMuonDIS():
+    """Generate DIS events."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-f", "--inputFile", help="Input file to use", required=True)
+    parser.add_argument(
+        "-nJob", "--nJob", type=int, help="Process ID, gives muon index", required=True
+    )
+    parser.add_argument(
+        "-nPerJobs",
+        "--nPerJobs",
+        type=int,
+        help="The number of muons per file",
+        required=True,
+    )
+    parser.add_argument(
+        "-nDISPerMuon",
+        "--nDIS",
+        type=int,
+        help="Number of DIS per muon to generate",
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    logging.info(f"Opening input file: {args.inputFile}")
+    muonFile = r.TFile.Open(args.inputFile, "read")
+
+    try:
+        muon_tree = muonFile.MuonAndSoftInteractions
+    except Exception as e:
+        print(f"Error: {e}")
+        muonFile.Close()
+        exit(1)
+
+    nPerJob = args.nPerJobs  # number of muons handled by the python script
+    nStart = args.nPerJobs * args.nJob
+    logging.debug(f"Total entries in the tree: {muon_tree.GetEntries()}")
+    nEnd = min(muon_tree.GetEntries(), nStart + nPerJob)
+
+    logging.info(f"Creating output file: muonDis_{args.nJob}.root")
+
+    outputFile = r.TFile.Open(f"muonDis_{args.nJob}.root", "recreate")
+    output_tree = r.TTree("DIS", "muon DIS")
+
+    iMuon = r.TClonesArray("TVectorD")
+    output_tree.Branch("InMuon", iMuon, 32000, -1)
+
+    dPartDIS = r.TClonesArray("TVectorD")
+    output_tree.Branch("DISParticles", dPartDIS, 32000, -1)
+
+    dPartSoft = r.TClonesArray("TVectorD")
+    output_tree.Branch("SoftParticles", dPartSoft, 32000, -1)
+
+    muon_vetoPoints = r.TClonesArray("vetoPoint")
+    output_tree.Branch("muon_vetoPoints", muon_vetoPoints, 32000, -1)
+
+    myPythia = r.TPythia6()
+    myPythia.SetMSEL(2)
+    myPythia.SetPARP(2, 2)
+    for kf in [211, 321, 130, 310, 3112, 3122, 3222, 3312, 3322, 3334]:
+        kc = myPythia.Pycomp(kf)
+        myPythia.SetMDCY(kc, 1, 0)
+
+    seed = int(time.time() % 900000000)
+    myPythia.SetMRPY(1, seed)
+    mutype = {-13: "gamma/mu+", 13: "gamma/mu-"}
+
+    myPythia.SetMSTU(11, 11)
+    logging.info(f"Processing events from {nStart} to {nEnd-1}...")
+
+    nMade = 0
+
+    for k in range(nStart, nEnd):
+        muon_tree.GetEvent(k)
+
+        imuondata = muon_tree.imuondata
+
+        pid = imuondata[0]
+        px = imuondata[1]
+        py = imuondata[2]
+        pz = imuondata[3]
+        x = imuondata[4]
+        y = imuondata[5]
+        z = imuondata[6]
+        w = imuondata[7]
+        time_muon = imuondata[8]
+
+        p = r.TMath.Sqrt(px**2 + py**2 + pz**2)
+        mass = PDG.GetParticle(abs(int(pid))).Mass()
+        E = r.TMath.Sqrt(mass**2 + p**2)
+
+        theta = r.TMath.ACos(pz / p)
+        phi = r.TMath.ATan2(py, px)
+
+        logging.debug(
+            f"\n\tMuon index:{k} \n\tPID = {pid}, weight = {w} \n\tpx = {px}, py = {py}, pz = {pz}, E = {E},\n\tx = {x}, y = {y}, z = {z}\n"
+        )
+
+        isProton = 1
+        xsec = 0
+
+        mu = array("d", [pid, px, py, pz, E, x, y, z, w, isProton, xsec, time_muon])
+        muPart = r.TVectorD(12, mu)
+        myPythia.Initialize("FIXT", mutype[pid], "p+", p)  # target = "p+"
+        myPythia.Pylist(1)
+
+        for a in range(args.nDIS):
+            if a == args.nDIS // 2:
+                myPythia.Initialize("FIXT", mutype[pid], "n0", p)  # target = "n0"
+                isProton = 0
+                logging.debug("Switching to neutron interaction")
+
+            dPartDIS.Clear()
+            iMuon.Clear()
+            muPart[9] = isProton
+            iMuon[0] = muPart
+            myPythia.GenerateEvent()
+            myPythia.Pyedit(1)
+            logging.debug(
+                f"DIS Event {a} generated, number of particles: {myPythia.GetN()}"
+            )
+
+            for itrk in range(1, myPythia.GetN() + 1):
+                xsec = myPythia.GetPARI(1)
+                muPart[10] = xsec
+                did = myPythia.GetK(itrk, 2)
+                dpx, dpy, dpz = rotate(
+                    myPythia.GetP(itrk, 1),
+                    myPythia.GetP(itrk, 2),
+                    myPythia.GetP(itrk, 3),
+                    theta,
+                    phi,
+                )
+                psq = dpx**2 + dpy**2 + dpz**2
+                masssq = PDG.GetParticle(did).Mass() ** 2
+                E = r.TMath.Sqrt(masssq + psq)
+                m = array("d", [did, dpx, dpy, dpz, E])
+                part = r.TVectorD(5, m)
+                nPart = dPartDIS.GetEntries()
+                if dPartDIS.GetSize() == nPart:
+                    dPartDIS.Expand(nPart + 10)
+                # dPartDIS.ConstructedAt(nPart).Use(part) #to be adapted later
+                dPartDIS[nPart] = part
+                if itrk == 1:
+                    with open(f"sigmadata_{args.nJob}.txt", "a") as fcross:
+                        fcross.write(f"{xsec}\n")
+
+            dPartSoft.Clear()
+
+            for softTrack in muon_tree.tracks:
+                did = softTrack.GetPdgCode()
+                dpx = softTrack.GetPx()
+                dpy = softTrack.GetPy()
+                dpz = softTrack.GetPz()
+
+                psq = dpx**2 + dpy**2 + dpz**2
+                masssq = PDG.GetParticle(did).Mass() ** 2
+                E = r.TMath.Sqrt(masssq + psq)
+
+                softx = softTrack.GetStartX()
+                softy = softTrack.GetStartY()
+                softz = softTrack.GetStartZ()
+                time_ = softTrack.GetStartT()
+
+                m = array("d", [did, dpx, dpy, dpz, E, softx, softy, softz, time_])
+
+                part = r.TVectorD(9, m)
+                nPart = dPartSoft.GetEntries()
+                if dPartSoft.GetSize() == nPart:
+                    dPartSoft.Expand(nPart + 10)
+                # dPartSoft.ConstructedAt(nPart).Use(part) #to be adapted later
+                dPartSoft[nPart] = part
+
+            muon_vetoPoints.Clear()
+
+            index = 0
+            for hit in muon_tree.muon_vetoPoints:
+                if muon_vetoPoints.GetSize() == index:
+                    muon_vetoPoints.Expand(index + 1)
+                hit.SetTrackID(0)  # Set TrackID to match for muon ID for new simulation
+                muon_vetoPoints[index] = hit
+                index += 1
+
+            output_tree.Fill()
+
+        nMade += 1
+
+        if nMade % 10 == 0:
+            logging.info(f"Muons processed: {nMade}")
+
+    outputFile.cd()
+    output_tree.Write()
+    myPythia.SetMSTU(11, 6)
+    logging.info(
+        f"DIS generated for muons (index {nStart} - {nEnd-1}) , output saved in muonDis_{args.nJob}.root, nDISPerMuon = {args.nDIS}"
+    )
+
+
+if __name__ == "__main__":
+    makeMuonDIS()

--- a/muonDIS/makeMuonDIS.py
+++ b/muonDIS/makeMuonDIS.py
@@ -12,6 +12,7 @@ from tabulate import tabulate
 logging.basicConfig(level=logging.INFO)
 PDG = r.TDatabasePDG.Instance()
 PDG.AddParticle("C12", "Carbon-12", 12.0, True, 0, 6.0, "nucleus", 1000060120)
+PDG.AddParticle("C13", "Carbon-13", 13.003355, True, 0, 6.0, "nucleus", 1000060130)
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("-f", "--inputFile", help="Input file to use", required=True)

--- a/muonDIS/make_nTuple_SBT.py
+++ b/muonDIS/make_nTuple_SBT.py
@@ -10,9 +10,12 @@ import shipunit as u
 
 # Argument parser setup
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("-test", dest="testing_code", help="Run Test", action="store_true")
+parser.add_argument("--test", dest="testing_code", help="Run Test", action="store_true")
 parser.add_argument(
-    "-p", dest="path", help="path to muon background files", required=False
+    "-p",
+    "--path",
+    help="path to muon background files",
+    default="/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/8070735",
 )
 parser.add_argument(
     "-o",
@@ -41,10 +44,7 @@ if args.testing_code:
 else:
     selectedmuons = "SelectedMuonsSBT.txt"
 
-if args.path:
-    path = args.path
-else:
-    path = "/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/sc_v6_10_spills"
+path = args.path
 
 fsel = open(selectedmuons, "w")
 
@@ -65,97 +65,97 @@ output_tree.Branch("muon_vetoPoints", muon_vetoPoints)
 logging.basicConfig(level=logging.INFO)
 
 for inputFolder in os.listdir(path):
-    for subFolder in os.listdir(os.path.join(path, inputFolder)):
-        if not os.path.isdir(os.path.join(path, inputFolder, subFolder)):
-            continue
+    if not os.path.isdir(os.path.join(path, inputFolder)):
+        continue
 
-        if args.testing_code and ev >= 100000:
-            break
+    if args.testing_code and ev >= 100000:
+        break
 
-        logging.info(f"Processing folder: {inputFolder}/{subFolder}")
+    logging.info(f"Processing folder: {inputFolder}")
+
+    f = None
+    try:
         f = r.TFile.Open(
-            os.path.join(
-                path, inputFolder, subFolder, "ship.conical.MuonBack-TGeant4.root"
-            ),
+            os.path.join(path, inputFolder, "ship.conical.MuonBack-TGeant4.root"),
             "read",
         )
+        tree = f.cbmsim
+    except Exception as e:
+        print(f"Error :{e}")
 
-        try:
-            tree = f.cbmsim
-        except Exception as e:
-            print(f"Error :{e}")
+        if f:
             f.Close()
-            continue
+        continue
 
-        for event in tree:
-            ev += 1
-            numHitsPermuon = 0
+    for event in tree:
+        ev += 1
+        numHitsPermuon = 0
 
-            # saving soft tracks
-            track_array.Clear()
+        # saving soft tracks
+        track_array.Clear()
 
-            muon_id = None
-            for itrk in range(event.MCTrack.GetEntries()):
-                # loops through MCTracks to find the incoming Muon's track id.
-                if abs(event.MCTrack[itrk].GetPdgCode()) == 13:
-                    muon_id = itrk
-                    break
+        muon_id = None
+        for itrk in range(event.MCTrack.GetEntries()):
+            # loops through MCTracks to find the incoming Muon's track id.
+            if abs(event.MCTrack[itrk].GetPdgCode()) == 13:
+                muon_id = itrk
+                break
 
-            for track in event.MCTrack:
-                if track.GetMotherId() == muon_id and (
-                    not track.GetProcName().Data() == "Muon nuclear interaction"
-                ):
-                    track_array.Add(track)
+        for track in event.MCTrack:
+            if track.GetMotherId() == muon_id and (
+                not track.GetProcName().Data() == "Muon nuclear interaction"
+            ):
+                track_array.Add(track)
 
-            index = 0
-            muon_vetoPoints.Clear()
+        index = 0
+        muon_vetoPoints.Clear()
 
-            # saving the incoming muon's veto response
-            for hit in event.vetoPoint:
-                detID = hit.GetDetectorID()
-                pid = hit.PdgCode()
-                if 1000 < detID < 999999 and abs(pid) == 13:
-                    if muon_vetoPoints.GetSize() == index:
-                        muon_vetoPoints.Expand(index + 1)
-                    muon_vetoPoints[index] = hit
-                    index += 1
+        # saving the incoming muon's veto response
+        for hit in event.vetoPoint:
+            detID = hit.GetDetectorID()
+            pid = hit.PdgCode()
+            if 1000 < detID < 999999 and abs(pid) == 13:
+                if muon_vetoPoints.GetSize() == index:
+                    muon_vetoPoints.Expand(index + 1)
+                muon_vetoPoints[index] = hit
+                index += 1
 
-            for hit in event.vetoPoint:
-                detID = hit.GetDetectorID()
-                pid = hit.PdgCode()
-                trackID = hit.GetTrackID()
+        for hit in event.vetoPoint:
+            detID = hit.GetDetectorID()
+            pid = hit.PdgCode()
+            trackID = hit.GetTrackID()
 
-                if abs(pid) == 13:
-                    numHitsPermuon += 1
-                    if ev not in processed_events:
-                        processed_events.add(ev)
-                        P = r.TMath.Sqrt(
-                            hit.GetPx() ** 2 + hit.GetPy() ** 2 + hit.GetPz() ** 2
+            if abs(pid) == 13:
+                numHitsPermuon += 1
+                if ev not in processed_events:
+                    processed_events.add(ev)
+                    P = r.TMath.Sqrt(
+                        hit.GetPx() ** 2 + hit.GetPy() ** 2 + hit.GetPz() ** 2
+                    )
+                    weight = event.MCTrack[trackID].GetWeight()
+                    hPmuon.Fill(P, weight)
+
+                    if P > 3 / u.GeV:
+                        imuondata[0] = float(pid)
+                        imuondata[1] = float(hit.GetPx() / u.GeV)
+                        imuondata[2] = float(hit.GetPy() / u.GeV)
+                        imuondata[3] = float(hit.GetPz() / u.GeV)
+                        imuondata[4] = float(hit.GetX() / u.m)
+                        imuondata[5] = float(hit.GetY() / u.m)
+                        imuondata[6] = float(hit.GetZ() / u.m)
+                        imuondata[7] = float(weight)
+                        imuondata[8] = float(hit.GetTime())
+
+                        output_tree.Fill()
+
+                        fsel.write(
+                            f"{pid} {hit.GetPx() / u.GeV} {hit.GetPy() / u.GeV} {hit.GetPz() / u.GeV} {hit.GetX() / u.m} {hit.GetY() / u.m} {hit.GetZ() / u.m} {weight}\n"
                         )
-                        weight = event.MCTrack[trackID].GetWeight()
-                        hPmuon.Fill(P, weight)
 
-                        if P > 3 / u.GeV:
-                            imuondata[0] = float(pid)
-                            imuondata[1] = float(hit.GetPx() / u.GeV)
-                            imuondata[2] = float(hit.GetPy() / u.GeV)
-                            imuondata[3] = float(hit.GetPz() / u.GeV)
-                            imuondata[4] = float(hit.GetX() / u.m)
-                            imuondata[5] = float(hit.GetY() / u.m)
-                            imuondata[6] = float(hit.GetZ() / u.m)
-                            imuondata[7] = float(weight)
-                            imuondata[8] = float(hit.GetTime())
+        if numHitsPermuon != 0:
+            hnumSegPermmuon.Fill(numHitsPermuon)
 
-                            output_tree.Fill()
-
-                            fsel.write(
-                                f"{pid} {hit.GetPx() / u.GeV} {hit.GetPy() / u.GeV} {hit.GetPz() / u.GeV} {hit.GetX() / u.m} {hit.GetY() / u.m} {hit.GetZ() / u.m} {weight}\n"
-                            )
-
-            if numHitsPermuon != 0:
-                hnumSegPermmuon.Fill(numHitsPermuon)
-
-        f.Close()
+    f.Close()
 
 
 output_file.cd()

--- a/muonDIS/make_nTuple_SBT.py
+++ b/muonDIS/make_nTuple_SBT.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+"""Script to collect muons hitting the SBT (including soft interaction products) to a ROOT file."""
+
+import argparse
+import logging
+import os
+
+import ROOT as r
+import shipunit as u
+
+# Argument parser setup
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("-test", dest="testing_code", help="Run Test", action="store_true")
+parser.add_argument(
+    "-p", dest="path", help="path to muon background files", required=False
+)
+parser.add_argument(
+    "-o",
+    "--outputfile",
+    default="muonsProduction_wsoft_SBT.root",
+    help="custom outputfile name",
+)
+args = parser.parse_args()
+
+# Histogram setup
+hnumSegPermmuon = r.TH1I(
+    "hnumSegPermmuon", "Numbers of fired segments per muon", 200, 0.0, 200
+)
+hPmuon = r.TH1F("hPmuon", "The momentum of the muons hitting the SBT", 400, 0.0, 400)
+
+# Initialize variables
+ev = 0
+processed_events = set()
+
+if args.testing_code:
+    print(
+        "test code, output file name overwritten as: muonsProduction_wsoft_SBT_test.root"
+    )
+    args.outputfile = "muonsProduction_wsoft_SBT_test.root"
+    selectedmuons = "SelectedMuonsSBT_test.txt"
+else:
+    selectedmuons = "SelectedMuonsSBT.txt"
+
+if args.path:
+    path = args.path
+else:
+    path = "/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/sc_v6_10_spills"
+
+fsel = open(selectedmuons, "w")
+
+output_file = r.TFile.Open(args.outputfile, "recreate")
+output_tree = r.TTree(
+    "MuonAndSoftInteractions", "Muon information and soft interaction tracks"
+)
+
+imuondata = r.TVectorD(9)  # 9 values: pid, px, py, pz, x, y, z, weight,time_of_hit
+output_tree.Branch("imuondata", imuondata)
+
+track_array = r.TObjArray()
+output_tree.Branch("tracks", track_array)
+
+muon_vetoPoints = r.TClonesArray("vetoPoint")
+output_tree.Branch("muon_vetoPoints", muon_vetoPoints)
+
+logging.basicConfig(level=logging.INFO)
+
+for inputFolder in os.listdir(path):
+    for subFolder in os.listdir(os.path.join(path, inputFolder)):
+        if not os.path.isdir(os.path.join(path, inputFolder, subFolder)):
+            continue
+
+        if args.testing_code and ev >= 100000:
+            break
+
+        logging.info(f"Processing folder: {inputFolder}/{subFolder}")
+        f = r.TFile.Open(
+            os.path.join(
+                path, inputFolder, subFolder, "ship.conical.MuonBack-TGeant4.root"
+            ),
+            "read",
+        )
+
+        try:
+            tree = f.cbmsim
+        except Exception as e:
+            print(f"Error :{e}")
+            f.Close()
+            continue
+
+        for event in tree:
+            ev += 1
+            numHitsPermuon = 0
+
+            # saving soft tracks
+            track_array.Clear()
+
+            muon_id = None
+            for itrk in range(event.MCTrack.GetEntries()):
+                # loops through MCTracks to find the incoming Muon's track id.
+                if abs(event.MCTrack[itrk].GetPdgCode()) == 13:
+                    muon_id = itrk
+                    break
+
+            for track in event.MCTrack:
+                if track.GetMotherId() == muon_id and (
+                    not track.GetProcName().Data() == "Muon nuclear interaction"
+                ):
+                    track_array.Add(track)
+
+            index = 0
+            muon_vetoPoints.Clear()
+
+            # saving the incoming muon's veto response
+            for hit in event.vetoPoint:
+                detID = hit.GetDetectorID()
+                pid = hit.PdgCode()
+                if 1000 < detID < 999999 and abs(pid) == 13:
+                    if muon_vetoPoints.GetSize() == index:
+                        muon_vetoPoints.Expand(index + 1)
+                    muon_vetoPoints[index] = hit
+                    index += 1
+
+            for hit in event.vetoPoint:
+                detID = hit.GetDetectorID()
+                pid = hit.PdgCode()
+                trackID = hit.GetTrackID()
+
+                if abs(pid) == 13:
+                    numHitsPermuon += 1
+                    if ev not in processed_events:
+                        processed_events.add(ev)
+                        P = r.TMath.Sqrt(
+                            hit.GetPx() ** 2 + hit.GetPy() ** 2 + hit.GetPz() ** 2
+                        )
+                        weight = event.MCTrack[trackID].GetWeight()
+                        hPmuon.Fill(P, weight)
+
+                        if P > 3 / u.GeV:
+                            imuondata[0] = float(pid)
+                            imuondata[1] = float(hit.GetPx() / u.GeV)
+                            imuondata[2] = float(hit.GetPy() / u.GeV)
+                            imuondata[3] = float(hit.GetPz() / u.GeV)
+                            imuondata[4] = float(hit.GetX() / u.m)
+                            imuondata[5] = float(hit.GetY() / u.m)
+                            imuondata[6] = float(hit.GetZ() / u.m)
+                            imuondata[7] = float(weight)
+                            imuondata[8] = float(hit.GetTime())
+
+                            output_tree.Fill()
+
+                            fsel.write(
+                                f"{pid} {hit.GetPx() / u.GeV} {hit.GetPy() / u.GeV} {hit.GetPz() / u.GeV} {hit.GetX() / u.m} {hit.GetY() / u.m} {hit.GetZ() / u.m} {weight}\n"
+                            )
+
+            if numHitsPermuon != 0:
+                hnumSegPermmuon.Fill(numHitsPermuon)
+
+        f.Close()
+
+
+output_file.cd()
+output_tree.Write()
+hnumSegPermmuon.Write()
+hPmuon.Write()
+output_file.Close()
+fsel.close()
+
+print(
+    "------------------------------------------------------file saved, reading",
+    args.outputfile,
+    " now----------------------------------------------------------------",
+)
+
+with r.TFile.Open(args.outputfile, "read") as file:
+    try:
+        tree = file.MuonAndSoftInteractions
+    except Exception as e:
+        print(f"Error: {e}")
+        exit(1)
+
+    print(f"Processing tree: {tree.GetName()}")
+    print(f"Total number of entries: {tree.GetEntries()}")
+
+    for event in tree:
+        imuondata = event.imuondata
+        pid = imuondata[0]
+        px = imuondata[1]
+        py = imuondata[2]
+        pz = imuondata[3]
+        x = imuondata[4]
+        y = imuondata[5]
+        z = imuondata[6]
+        weight = imuondata[7]
+        time_hit = imuondata[8]
+        num_tracks = len(event.tracks)
+        num_muonhits = len(event.muon_vetoPoints)
+
+        print(
+            f"Muon PID: {pid},  x: {x}, y: {y}, z: {z}, t_muon: {time_hit}, "
+            f"Number of soft tracks in this event: {num_tracks}, "
+            f"Number of SBT hits from the muon: {num_muonhits}"
+        )

--- a/muonDIS/make_nTuple_Tr.py
+++ b/muonDIS/make_nTuple_Tr.py
@@ -22,9 +22,12 @@ parser.add_argument(
     help="custom outputfile name",
 )
 parser.add_argument(
-    "-p", dest="path", help="path to muon background files", required=False
+    "-p",
+    "--path",
+    help="path to muon background files",
+    default="/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/8070735",
 )
-parser.add_argument("-test", dest="testing_code", help="Run Test", action="store_true")
+parser.add_argument("--test", dest="testing_code", help="Run Test", action="store_true")
 args = parser.parse_args()
 
 # Variables
@@ -60,131 +63,128 @@ output_tree.Branch("muon_vetoPoints", muon_vetoPoints)
 if args.path:
     path = args.path
 else:
-    path = "/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/sc_v6_10_spills"
+    path = "/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/8070735"
 
 fsel = open(selectedmuons, "w")
 
 logging.basicConfig(level=logging.INFO)
 
 for inputFolder in os.listdir(path):
-    for subFolder in os.listdir(os.path.join(path, inputFolder)):
-        if not os.path.isdir(os.path.join(path, inputFolder, subFolder)):
-            continue
+    if not os.path.isdir(os.path.join(path, inputFolder)):
+        continue
 
-        if args.testing_code and evs[2] >= 2:
-            break
+    if args.testing_code and evs[2] >= 2:
+        break
 
-        logging.info(f"Processing folder: {inputFolder}/{subFolder}")
+    logging.info(f"Processing folder: {inputFolder}")
+    f = None
+    try:
         f = r.TFile.Open(
-            os.path.join(
-                path, inputFolder, subFolder, "ship.conical.MuonBack-TGeant4.root"
-            ),
+            os.path.join(path, inputFolder, "ship.conical.MuonBack-TGeant4.root"),
             "read",
         )
+        tree = f.cbmsim
+    except Exception as e:
+        print(f"Error :{e}")
 
-        try:
-            tree = f.cbmsim
-        except Exception as e:
-            print(f"Error :{e}")
+        if f:
             f.Close()
-            continue
+        continue
 
-        for event in tree:
-            ev += 1
+    for event in tree:
+        ev += 1
 
-            # saving soft tracks
-            track_array.Clear()
+        # saving soft tracks
+        track_array.Clear()
 
-            muon_id = None
-            for itrk in range(event.MCTrack.GetEntries()):
-                # loops through MCTracks to find the incoming Muon's track id.
-                if abs(event.MCTrack[itrk].GetPdgCode()) == 13:
-                    muon_id = itrk
-                    break
+        muon_id = None
+        for itrk in range(event.MCTrack.GetEntries()):
+            # loops through MCTracks to find the incoming Muon's track id.
+            if abs(event.MCTrack[itrk].GetPdgCode()) == 13:
+                muon_id = itrk
+                break
 
-            for track in event.MCTrack:
-                if track.GetMotherId() == muon_id and (
-                    not track.GetProcName().Data() == "Muon nuclear interaction"
-                ):
-                    track_array.Add(track)
+        for track in event.MCTrack:
+            if track.GetMotherId() == muon_id and (
+                not track.GetProcName().Data() == "Muon nuclear interaction"
+            ):
+                track_array.Add(track)
 
-            # saving the incoming muon's veto response
-            index = 0
-            muon_vetoPoints.Clear()
-            for hit in event.vetoPoint:
-                detID = hit.GetDetectorID()
-                pid = hit.PdgCode()
-                if 1000 < detID < 999999 and abs(pid) == 13:
-                    if muon_vetoPoints.GetSize() == index:
-                        muon_vetoPoints.Expand(index + 1)
-                    muon_vetoPoints[index] = hit
-                    index += 1
+        # saving the incoming muon's veto response
+        index = 0
+        muon_vetoPoints.Clear()
+        for hit in event.vetoPoint:
+            detID = hit.GetDetectorID()
+            pid = hit.PdgCode()
+            if 1000 < detID < 999999 and abs(pid) == 13:
+                if muon_vetoPoints.GetSize() == index:
+                    muon_vetoPoints.Expand(index + 1)
+                muon_vetoPoints[index] = hit
+                index += 1
 
-            strawDic, trackDic = [], []
+        strawDic, trackDic = [], []
 
-            # Process straw tube hits
-            for strawHit in event.strawtubesPoint:
-                P = r.TMath.Sqrt(
-                    strawHit.GetPx() ** 2
-                    + strawHit.GetPy() ** 2
-                    + strawHit.GetPz() ** 2
-                )
-                if P > 3:
-                    detIDmuonS = (
-                        strawHit.GetDetectorID() // 10000000
-                    )  # will need to update if strawtubes detID is changed
-                    if abs(strawHit.PdgCode()) == 13 and detIDmuonS == 1:
-                        # print(detIDmuonS,strawHit.GetTrackID())
-                        if strawHit.GetTrackID() not in strawDic:
-                            strawDic.append(strawHit.GetTrackID())
-                            evs[0] += 1
-                            if evs[0] % 100 == 0:
-                                print(f"evs0: {evs[0]}")
+        # Process straw tube hits
+        for strawHit in event.strawtubesPoint:
+            P = r.TMath.Sqrt(
+                strawHit.GetPx() ** 2 + strawHit.GetPy() ** 2 + strawHit.GetPz() ** 2
+            )
+            if P > 3:
+                detIDmuonS = (
+                    strawHit.GetDetectorID() // 10000000
+                )  # will need to update if strawtubes detID is changed
+                if abs(strawHit.PdgCode()) == 13 and detIDmuonS == 1:
+                    # print(detIDmuonS,strawHit.GetTrackID())
+                    if strawHit.GetTrackID() not in strawDic:
+                        strawDic.append(strawHit.GetTrackID())
+                        evs[0] += 1
+                        if evs[0] % 100 == 0:
+                            print(f"evs0: {evs[0]}")
 
-            # Process vetoPoint hits
-            for hit in event.vetoPoint:
-                detID = hit.GetDetectorID()
-                pid = hit.PdgCode()
-                trackID = hit.GetTrackID()
-                if 1000 < detID < 999999 and abs(pid) == 13:
-                    if trackID not in trackDic:
-                        trackDic.append(trackID)
-                        evs[1] += 1
-                        if evs[1] % 100 == 0:
-                            print(f"evs1: {evs[1]}")
+        # Process vetoPoint hits
+        for hit in event.vetoPoint:
+            detID = hit.GetDetectorID()
+            pid = hit.PdgCode()
+            trackID = hit.GetTrackID()
+            if 1000 < detID < 999999 and abs(pid) == 13:
+                if trackID not in trackDic:
+                    trackDic.append(trackID)
+                    evs[1] += 1
+                    if evs[1] % 100 == 0:
+                        print(f"evs1: {evs[1]}")
 
-            # Check for muons hitting Tr but not SBT and only save them
-            for m in strawDic:
-                if m not in trackDic:
-                    for Hit in event.strawtubesPoint:
-                        if m == Hit.GetTrackID() and ev not in processed_events:
-                            processed_events.add(ev)
-                            evs[2] += 1
-                            print(f"evs2: {evs[2]}")
-                            P = r.TMath.Sqrt(
-                                Hit.GetPx() ** 2 + Hit.GetPy() ** 2 + Hit.GetPz() ** 2
-                            )
-                            weight = tree.MCTrack[m].GetWeight()
-                            hPmuon.Fill(P, weight)
+        # Check for muons hitting Tr but not SBT and only save them
+        for m in strawDic:
+            if m not in trackDic:
+                for Hit in event.strawtubesPoint:
+                    if m == Hit.GetTrackID() and ev not in processed_events:
+                        processed_events.add(ev)
+                        evs[2] += 1
+                        print(f"evs2: {evs[2]}")
+                        P = r.TMath.Sqrt(
+                            Hit.GetPx() ** 2 + Hit.GetPy() ** 2 + Hit.GetPz() ** 2
+                        )
+                        weight = tree.MCTrack[m].GetWeight()
+                        hPmuon.Fill(P, weight)
 
-                            # Fill imuondata
-                            imuondata[0] = float(Hit.PdgCode())
-                            imuondata[1] = float(Hit.GetPx() / u.GeV)
-                            imuondata[2] = float(Hit.GetPy() / u.GeV)
-                            imuondata[3] = float(Hit.GetPz() / u.GeV)
-                            imuondata[4] = float(Hit.GetX() / u.m)
-                            imuondata[5] = float(Hit.GetY() / u.m)
-                            imuondata[6] = float(Hit.GetZ() / u.m)
-                            imuondata[7] = float(weight)
-                            imuondata[8] = float(hit.GetTime())
+                        # Fill imuondata
+                        imuondata[0] = float(Hit.PdgCode())
+                        imuondata[1] = float(Hit.GetPx() / u.GeV)
+                        imuondata[2] = float(Hit.GetPy() / u.GeV)
+                        imuondata[3] = float(Hit.GetPz() / u.GeV)
+                        imuondata[4] = float(Hit.GetX() / u.m)
+                        imuondata[5] = float(Hit.GetY() / u.m)
+                        imuondata[6] = float(Hit.GetZ() / u.m)
+                        imuondata[7] = float(weight)
+                        imuondata[8] = float(hit.GetTime())
 
-                            output_tree.Fill()
+                        output_tree.Fill()
 
-                            fsel.write(
-                                f"{Hit.PdgCode()} {Hit.GetPx() / u.GeV} {Hit.GetPy() / u.GeV} "
-                                f"{Hit.GetPz() / u.GeV} {Hit.GetX() / u.m} {Hit.GetY() / u.m} "
-                                f"{Hit.GetZ() / u.m} {weight}\n"
-                            )
+                        fsel.write(
+                            f"{Hit.PdgCode()} {Hit.GetPx() / u.GeV} {Hit.GetPy() / u.GeV} "
+                            f"{Hit.GetPz() / u.GeV} {Hit.GetX() / u.m} {Hit.GetY() / u.m} "
+                            f"{Hit.GetZ() / u.m} {weight}\n"
+                        )
 
 output_file.cd()
 output_tree.Write()

--- a/muonDIS/make_nTuple_Tr.py
+++ b/muonDIS/make_nTuple_Tr.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+"""Script to collect muons hitting the 1st Tracking Station (including soft interaction products) to a ROOT file."""
+
+import argparse
+import logging
+import os
+
+import ROOT as r
+import shipunit as u
+
+# Histogram
+hPmuon = r.TH1F(
+    "hPmuon", "Momentum of muons hitting the SBT;P [GeV];Entries", 400, 0.0, 400
+)
+
+# Argument parser
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument(
+    "-o",
+    "--outputfile",
+    default="muonsProduction_wsoft_Tr.root",
+    help="custom outputfile name",
+)
+parser.add_argument(
+    "-p", dest="path", help="path to muon background files", required=False
+)
+parser.add_argument("-test", dest="testing_code", help="Run Test", action="store_true")
+args = parser.parse_args()
+
+# Variables
+ev = 0
+evs = [0, 0, 0]
+processed_events = set()
+
+
+if args.testing_code:
+    print(
+        "test code, output file name overwritten as: muonsProduction_wsoft_Tr_test.root"
+    )
+    args.outputfile = "muonsProduction_wsoft_Tr_test.root"
+    selectedmuons = "SelectedMuonsTr_test.txt"
+else:
+    selectedmuons = "SelectedMuonsTr.txt"
+
+# Output file and tree setup
+output_file = r.TFile.Open(args.outputfile, "recreate")
+output_tree = r.TTree(
+    "MuonAndSoftInteractions", "Muon information and soft interaction tracks"
+)
+
+imuondata = r.TVectorD(9)  # 9 values: pid, px, py, pz, x, y, z, weight,time_of_hit
+output_tree.Branch("imuondata", imuondata)
+
+track_array = r.TObjArray()
+output_tree.Branch("tracks", track_array)
+
+muon_vetoPoints = r.TClonesArray("vetoPoint")
+output_tree.Branch("muon_vetoPoints", muon_vetoPoints)
+
+if args.path:
+    path = args.path
+else:
+    path = "/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/sc_v6_10_spills"
+
+fsel = open(selectedmuons, "w")
+
+logging.basicConfig(level=logging.INFO)
+
+for inputFolder in os.listdir(path):
+    for subFolder in os.listdir(os.path.join(path, inputFolder)):
+        if not os.path.isdir(os.path.join(path, inputFolder, subFolder)):
+            continue
+
+        if args.testing_code and evs[2] >= 2:
+            break
+
+        logging.info(f"Processing folder: {inputFolder}/{subFolder}")
+        f = r.TFile.Open(
+            os.path.join(
+                path, inputFolder, subFolder, "ship.conical.MuonBack-TGeant4.root"
+            ),
+            "read",
+        )
+
+        try:
+            tree = f.cbmsim
+        except Exception as e:
+            print(f"Error :{e}")
+            f.Close()
+            continue
+
+        for event in tree:
+            ev += 1
+
+            # saving soft tracks
+            track_array.Clear()
+
+            muon_id = None
+            for itrk in range(event.MCTrack.GetEntries()):
+                # loops through MCTracks to find the incoming Muon's track id.
+                if abs(event.MCTrack[itrk].GetPdgCode()) == 13:
+                    muon_id = itrk
+                    break
+
+            for track in event.MCTrack:
+                if track.GetMotherId() == muon_id and (
+                    not track.GetProcName().Data() == "Muon nuclear interaction"
+                ):
+                    track_array.Add(track)
+
+            # saving the incoming muon's veto response
+            index = 0
+            muon_vetoPoints.Clear()
+            for hit in event.vetoPoint:
+                detID = hit.GetDetectorID()
+                pid = hit.PdgCode()
+                if 1000 < detID < 999999 and abs(pid) == 13:
+                    if muon_vetoPoints.GetSize() == index:
+                        muon_vetoPoints.Expand(index + 1)
+                    muon_vetoPoints[index] = hit
+                    index += 1
+
+            strawDic, trackDic = [], []
+
+            # Process straw tube hits
+            for strawHit in event.strawtubesPoint:
+                P = r.TMath.Sqrt(
+                    strawHit.GetPx() ** 2
+                    + strawHit.GetPy() ** 2
+                    + strawHit.GetPz() ** 2
+                )
+                if P > 3:
+                    detIDmuonS = (
+                        strawHit.GetDetectorID() // 10000000
+                    )  # will need to update if strawtubes detID is changed
+                    if abs(strawHit.PdgCode()) == 13 and detIDmuonS == 1:
+                        # print(detIDmuonS,strawHit.GetTrackID())
+                        if strawHit.GetTrackID() not in strawDic:
+                            strawDic.append(strawHit.GetTrackID())
+                            evs[0] += 1
+                            if evs[0] % 100 == 0:
+                                print(f"evs0: {evs[0]}")
+
+            # Process vetoPoint hits
+            for hit in event.vetoPoint:
+                detID = hit.GetDetectorID()
+                pid = hit.PdgCode()
+                trackID = hit.GetTrackID()
+                if 1000 < detID < 999999 and abs(pid) == 13:
+                    if trackID not in trackDic:
+                        trackDic.append(trackID)
+                        evs[1] += 1
+                        if evs[1] % 100 == 0:
+                            print(f"evs1: {evs[1]}")
+
+            # Check for muons hitting Tr but not SBT and only save them
+            for m in strawDic:
+                if m not in trackDic:
+                    for Hit in event.strawtubesPoint:
+                        if m == Hit.GetTrackID() and ev not in processed_events:
+                            processed_events.add(ev)
+                            evs[2] += 1
+                            print(f"evs2: {evs[2]}")
+                            P = r.TMath.Sqrt(
+                                Hit.GetPx() ** 2 + Hit.GetPy() ** 2 + Hit.GetPz() ** 2
+                            )
+                            weight = tree.MCTrack[m].GetWeight()
+                            hPmuon.Fill(P, weight)
+
+                            # Fill imuondata
+                            imuondata[0] = float(Hit.PdgCode())
+                            imuondata[1] = float(Hit.GetPx() / u.GeV)
+                            imuondata[2] = float(Hit.GetPy() / u.GeV)
+                            imuondata[3] = float(Hit.GetPz() / u.GeV)
+                            imuondata[4] = float(Hit.GetX() / u.m)
+                            imuondata[5] = float(Hit.GetY() / u.m)
+                            imuondata[6] = float(Hit.GetZ() / u.m)
+                            imuondata[7] = float(weight)
+                            imuondata[8] = float(hit.GetTime())
+
+                            output_tree.Fill()
+
+                            fsel.write(
+                                f"{Hit.PdgCode()} {Hit.GetPx() / u.GeV} {Hit.GetPy() / u.GeV} "
+                                f"{Hit.GetPz() / u.GeV} {Hit.GetX() / u.m} {Hit.GetY() / u.m} "
+                                f"{Hit.GetZ() / u.m} {weight}\n"
+                            )
+
+output_file.cd()
+output_tree.Write()
+hPmuon.Write()
+output_file.Close()
+print("Finish:", evs)
+fsel.close()
+
+
+print(
+    "------------------------------------------------------file saved, reading",
+    args.outputfile,
+    " now----------------------------------------------------------------",
+)
+
+with r.TFile.Open(args.outputfile, "read") as file:
+    try:
+        tree = file.MuonAndSoftInteractions
+    except Exception as e:
+        print(f"Error: {e}")
+        exit(1)
+
+    print(f"Processing tree: {tree.GetName()}")
+    print(f"Total number of entries: {tree.GetEntries()}")
+
+    for event in tree:
+        imuondata = event.imuondata
+        pid = imuondata[0]
+        px = imuondata[1]
+        py = imuondata[2]
+        pz = imuondata[3]
+        x = imuondata[4]
+        y = imuondata[5]
+        z = imuondata[6]
+        weight = imuondata[7]
+        time_hit = imuondata[8]
+        num_tracks = len(event.tracks)
+        num_muonhits = len(event.muon_vetoPoints)
+
+        print(
+            f"Muon PID: {pid},  x: {x}, y: {y}, z: {z}, t_muon: {time_hit}, "
+            f"Number of soft tracks in this event: {num_tracks}, "
+            f"Number of SBT hits from the muon: {num_muonhits}"
+        )

--- a/muonDIS/make_nTuple_Tr.py
+++ b/muonDIS/make_nTuple_Tr.py
@@ -2,19 +2,22 @@
 """Script to collect muons hitting the 1st Tracking Station (including soft interaction products) to a ROOT file."""
 
 import argparse
+import csv
 import logging
 import os
 
 import ROOT as r
 import shipunit as u
+from tabulate import tabulate
 
-# Histogram
-hPmuon = r.TH1F(
-    "hPmuon", "Momentum of muons hitting the SBT;P [GeV];Entries", 400, 0.0, 400
-)
+pdg = r.TDatabasePDG.Instance()
 
-# Argument parser
+
+logging.basicConfig(level=logging.INFO)
+
+
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--test", dest="testing_code", help="Run Test", action="store_true")
 parser.add_argument(
     "-o",
     "--outputfile",
@@ -27,14 +30,7 @@ parser.add_argument(
     help="path to muon background files",
     default="/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/8070735",
 )
-parser.add_argument("--test", dest="testing_code", help="Run Test", action="store_true")
 args = parser.parse_args()
-
-# Variables
-ev = 0
-evs = [0, 0, 0]
-processed_events = set()
-
 
 if args.testing_code:
     print(
@@ -45,13 +41,20 @@ if args.testing_code:
 else:
     selectedmuons = "SelectedMuonsTr.txt"
 
-# Output file and tree setup
+path = args.path
+logging.info(f"Path to MuonBackground : {path}")
+
+fsel = open(selectedmuons, "w")
+csvwriter = csv.writer(fsel)
+
 output_file = r.TFile.Open(args.outputfile, "recreate")
 output_tree = r.TTree(
     "MuonAndSoftInteractions", "Muon information and soft interaction tracks"
 )
 
-imuondata = r.TVectorD(9)  # 9 values: pid, px, py, pz, x, y, z, weight,time_of_hit
+imuondata = r.TVectorD(
+    10
+)  # 10 values: pid, px, py, pz, x, y, z, weight,time_of_hit,nmuons_in_event
 output_tree.Branch("imuondata", imuondata)
 
 track_array = r.TObjArray()
@@ -60,20 +63,158 @@ output_tree.Branch("tracks", track_array)
 muon_vetoPoints = r.TClonesArray("vetoPoint")
 output_tree.Branch("muon_vetoPoints", muon_vetoPoints)
 
-if args.path:
-    path = args.path
-else:
-    path = "/eos/experiment/ship/simulation/bkg/MuonBack_2024helium/8070735"
 
-fsel = open(selectedmuons, "w")
+h = {}
+h["PvPt_muon"] = r.TH2F(
+    "PvPt_muon",
+    "The momentum of the muons hitting Tracking Station 1 (unweighted);P(GeV/c);Pt(GeV/c)",
+    200,
+    0.0,
+    400,
+    40,
+    0.0,
+    20,
+)
+h["n_muon"] = r.TH2I(
+    "n_muon",
+    "Number of muons hitting the Tracking Station 1 per Event;number of mu- per event (unweighted) bin width =1;number of mu+ per event (unweighted) bin width=1",
+    6,
+    0.0,
+    6,
+    6,
+    0.0,
+    6,
+)
+h["n_softtracks"] = r.TH1I(
+    "n_softtracks", "Number of soft tracks per muon;;(unweighted)", 200, 0, 2000
+)
 
-logging.basicConfig(level=logging.INFO)
+
+def printMCTrack(n, MCTrack):
+    """Print MCTrack truth."""
+    mcp = MCTrack[n]
+
+    RED = "\033[91m"  # ANSI code Red
+    RESET = "\033[0m"  # ANSI code Reset to default
+
+    try:
+        particle_name = pdg.GetParticle(mcp.GetPdgCode()).GetName()
+
+        if particle_name == "mu+" or particle_name == "mu-":
+            particle_name = (
+                f"{RED}{particle_name}{RESET}       "  # Highlight muons in red
+            )
+
+        print(
+            " %6s %-10s %10i %6.3F %6.3F %7.3F %7.3F %7.3F %7.3F %6s %10.3F %28s"
+            % (
+                n,
+                particle_name,
+                mcp.GetPdgCode(),
+                mcp.GetPx() / u.GeV,
+                mcp.GetPy() / u.GeV,
+                mcp.GetPz() / u.GeV,
+                mcp.GetStartX() / u.m,
+                mcp.GetStartY() / u.m,
+                mcp.GetStartZ() / u.m,
+                mcp.GetMotherId(),
+                mcp.GetWeight(),
+                mcp.GetProcName().Data(),
+            )
+        )
+    except Exception:
+        print(
+            " %6s %-10s %10i %6.3F %6.3F %7.3F %7.3F %7.3F %7.3F %6s %10.3F %28s"
+            % (
+                n,
+                "----",
+                mcp.GetPdgCode(),
+                mcp.GetPx() / u.GeV,
+                mcp.GetPy() / u.GeV,
+                mcp.GetPz() / u.GeV,
+                mcp.GetStartX() / u.m,
+                mcp.GetStartY() / u.m,
+                mcp.GetStartZ() / u.m,
+                mcp.GetMotherId(),
+                mcp.GetWeight(),
+                mcp.GetProcName().Data(),
+            )
+        )
+
+
+def dump(event, pcut=0, print_whole_event=True):
+    """Dump the whole event."""
+    if print_whole_event:
+        print(
+            "\n %6s %-10s %10s %6s %6s %7s %7s %7s %7s %6s %10s %18s"
+            % (
+                "#",
+                "particle",
+                "pid",
+                "px",
+                "py",
+                "pz",
+                "vx",
+                "vy",
+                "vz",
+                "mid",
+                "w",
+                "Process",
+            )
+        )
+        print(
+            " %6s %10s %10s %6s %6s %7s %7s %7s %7s %6s %10s %18s\n "
+            % (
+                " ",
+                "--------",
+                "---",
+                "--",
+                "--",
+                "--",
+                "--",
+                "--",
+                "--",
+                "---",
+                "---",
+                "-------",
+            )
+        )
+    n = -1
+    for mcp in event.MCTrack:
+        n += 1
+        if mcp.GetP() / u.GeV < pcut:
+            continue
+        if print_whole_event:
+            printMCTrack(n, event.MCTrack)
+
+    return
+
+
+events_ = {"Tr": {}, "Tr_SBT": {}, "Tr_noSBT": {}}
+global_event_nr = 0
+processed_events = {}
+
+P_threshold = 3
+
+headers = [
+    f"nMuons in event>{P_threshold}GeV",
+    "Muon PID",
+    "Momentum[GeV/c]",
+    "x[m]",
+    "y[m]",
+    "z[m]",
+    "t_muon [ns]",
+    "nSoft Tracks",
+    "nSBT Hits",
+    "Weight_muon",
+]
+csvwriter.writerow(headers)
 
 for inputFolder in os.listdir(path):
     if not os.path.isdir(os.path.join(path, inputFolder)):
         continue
 
-    if args.testing_code and evs[2] >= 2:
+    if args.testing_code and len(events_["Tr_noSBT"]) >= 5:
         break
 
     logging.info(f"Processing folder: {inputFolder}")
@@ -92,105 +233,151 @@ for inputFolder in os.listdir(path):
         continue
 
     for event in tree:
-        ev += 1
+        nmu = {"mu+": 0, "mu-": 0}
 
-        # saving soft tracks
-        track_array.Clear()
+        muon_table = []
+        global_event_nr += 1
 
-        muon_id = None
-        for itrk in range(event.MCTrack.GetEntries()):
-            # loops through MCTracks to find the incoming Muon's track id.
-            if abs(event.MCTrack[itrk].GetPdgCode()) == 13:
-                muon_id = itrk
-                break
+        muon_ids = []
 
-        for track in event.MCTrack:
-            if track.GetMotherId() == muon_id and (
-                not track.GetProcName().Data() == "Muon nuclear interaction"
-            ):
-                track_array.Add(track)
-
-        # saving the incoming muon's veto response
-        index = 0
-        muon_vetoPoints.Clear()
-        for hit in event.vetoPoint:
+        # Collect track IDs of muons which hit the Tracking Station
+        for hit in event.strawtubesPoint:
             detID = hit.GetDetectorID()
+            trackingstation_id = (
+                detID // 10000000
+            )  # will need to update if strawtubes detID is changed
             pid = hit.PdgCode()
-            if 1000 < detID < 999999 and abs(pid) == 13:
-                if muon_vetoPoints.GetSize() == index:
-                    muon_vetoPoints.Expand(index + 1)
-                muon_vetoPoints[index] = hit
-                index += 1
+            P = r.TMath.Sqrt(hit.GetPx() ** 2 + hit.GetPy() ** 2 + hit.GetPz() ** 2)
+            if abs(pid) == 13 and trackingstation_id == 1 and P > P_threshold / u.GeV:
+                track_id = hit.GetTrackID()
+                particle_name = pdg.GetParticle(hit.PdgCode()).GetName()
+                if track_id not in muon_ids:
+                    muon_ids.append(track_id)
 
-        strawDic, trackDic = [], []
+                if global_event_nr not in events_["Tr"]:
+                    events_["Tr"][global_event_nr] = set()
 
-        # Process straw tube hits
-        for strawHit in event.strawtubesPoint:
-            P = r.TMath.Sqrt(
-                strawHit.GetPx() ** 2 + strawHit.GetPy() ** 2 + strawHit.GetPz() ** 2
-            )
-            if P > 3:
-                detIDmuonS = (
-                    strawHit.GetDetectorID() // 10000000
+                events_["Tr"][global_event_nr].add(track_id)
+
+        if not len(muon_ids):
+            continue
+        # dump(event)
+
+        for muon_ in muon_ids:
+            muon_vetoPoints.Clear()
+
+            if global_event_nr not in events_["Tr_SBT"]:
+                events_["Tr_SBT"][global_event_nr] = set()
+
+            for hit in event.vetoPoint:
+                detID = hit.GetDetectorID()
+                pid = hit.PdgCode()
+                track_id = hit.GetTrackID()
+                P = r.TMath.Sqrt(hit.GetPx() ** 2 + hit.GetPy() ** 2 + hit.GetPz() ** 2)
+
+                if track_id == muon_:
+                    events_["Tr_SBT"][global_event_nr].add(track_id)
+                    continue
+
+                    # if muon_vetoPoints.GetSize() == index:
+                    #    muon_vetoPoints.Expand(index + 1)
+                    # muon_vetoPoints[index] = hit # this should be zero if the code is correct
+                    # index += 1
+
+            if muon_ in events_["Tr_SBT"][global_event_nr]:
+                continue
+
+            track_array.Clear()
+            for track in event.MCTrack:
+                if track.GetMotherId() == muon_ and (
+                    not track.GetProcName().Data() == "Muon nuclear interaction"
+                ):
+                    track_array.Add(track)
+
+            for hit in event.strawtubesPoint:
+                detID = hit.GetDetectorID()
+                track_id = hit.GetTrackID()
+                pid = hit.PdgCode()
+
+                P = r.TMath.Sqrt(hit.GetPx() ** 2 + hit.GetPy() ** 2 + hit.GetPz() ** 2)
+                Pt = r.TMath.Sqrt(hit.GetPx() ** 2 + hit.GetPy() ** 2)
+
+                trackingstation_id = (
+                    detID // 10000000
                 )  # will need to update if strawtubes detID is changed
-                if abs(strawHit.PdgCode()) == 13 and detIDmuonS == 1:
-                    # print(detIDmuonS,strawHit.GetTrackID())
-                    if strawHit.GetTrackID() not in strawDic:
-                        strawDic.append(strawHit.GetTrackID())
-                        evs[0] += 1
-                        if evs[0] % 100 == 0:
-                            print(f"evs0: {evs[0]}")
 
-        # Process vetoPoint hits
-        for hit in event.vetoPoint:
-            detID = hit.GetDetectorID()
-            pid = hit.PdgCode()
-            trackID = hit.GetTrackID()
-            if 1000 < detID < 999999 and abs(pid) == 13:
-                if trackID not in trackDic:
-                    trackDic.append(trackID)
-                    evs[1] += 1
-                    if evs[1] % 100 == 0:
-                        print(f"evs1: {evs[1]}")
+                if (
+                    abs(hit.PdgCode()) == 13
+                    and trackingstation_id == 1
+                    and P > P_threshold / u.GeV
+                ):
+                    if global_event_nr not in events_["Tr_noSBT"]:
+                        events_["Tr_noSBT"][global_event_nr] = set()
 
-        # Check for muons hitting Tr but not SBT and only save them
-        for m in strawDic:
-            if m not in trackDic:
-                for Hit in event.strawtubesPoint:
-                    if m == Hit.GetTrackID() and ev not in processed_events:
-                        processed_events.add(ev)
-                        evs[2] += 1
-                        print(f"evs2: {evs[2]}")
-                        P = r.TMath.Sqrt(
-                            Hit.GetPx() ** 2 + Hit.GetPy() ** 2 + Hit.GetPz() ** 2
-                        )
-                        weight = tree.MCTrack[m].GetWeight()
-                        hPmuon.Fill(P, weight)
+                    events_["Tr_noSBT"][global_event_nr].add(track_id)
+
+                    if global_event_nr not in processed_events:
+                        processed_events[global_event_nr] = []
+
+                    if (
+                        track_id not in processed_events[global_event_nr]
+                    ):  # only save the info of first SBT hit
+                        processed_events[global_event_nr].append(track_id)
+
+                        particle_name = pdg.GetParticle(hit.PdgCode()).GetName()
+
+                        nmu[particle_name] += 1
+
+                        weight = event.MCTrack[track_id].GetWeight()
 
                         # Fill imuondata
-                        imuondata[0] = float(Hit.PdgCode())
-                        imuondata[1] = float(Hit.GetPx() / u.GeV)
-                        imuondata[2] = float(Hit.GetPy() / u.GeV)
-                        imuondata[3] = float(Hit.GetPz() / u.GeV)
-                        imuondata[4] = float(Hit.GetX() / u.m)
-                        imuondata[5] = float(Hit.GetY() / u.m)
-                        imuondata[6] = float(Hit.GetZ() / u.m)
+                        imuondata[0] = float(hit.PdgCode())
+                        imuondata[1] = float(hit.GetPx() / u.GeV)
+                        imuondata[2] = float(hit.GetPy() / u.GeV)
+                        imuondata[3] = float(hit.GetPz() / u.GeV)
+                        imuondata[4] = float(hit.GetX() / u.m)
+                        imuondata[5] = float(hit.GetY() / u.m)
+                        imuondata[6] = float(hit.GetZ() / u.m)
                         imuondata[7] = float(weight)
                         imuondata[8] = float(hit.GetTime())
-
-                        output_tree.Fill()
-
-                        fsel.write(
-                            f"{Hit.PdgCode()} {Hit.GetPx() / u.GeV} {Hit.GetPy() / u.GeV} "
-                            f"{Hit.GetPz() / u.GeV} {Hit.GetX() / u.m} {Hit.GetY() / u.m} "
-                            f"{Hit.GetZ() / u.m} {weight}\n"
+                        imuondata[9] = len(muon_ids)
+                        muon_table.append(
+                            [
+                                track_id,
+                                len(muon_ids),
+                                imuondata[0],
+                                P,
+                                imuondata[4],
+                                imuondata[5],
+                                imuondata[6],
+                                imuondata[8],
+                                len(track_array),
+                                len(muon_vetoPoints),
+                                imuondata[7],
+                            ]
                         )
+                        h["PvPt_muon"].Fill(P, Pt)
+                        h["n_softtracks"].Fill(len(track_array))
+            output_tree.Fill()
 
+        if len(muon_table):
+            h["n_muon"].Fill(nmu["mu-"], nmu["mu+"])
+            csvwriter.writerows(row[1:] for row in muon_table)
+            logging.debug(
+                f"EVENT ID:{global_event_nr}\n\tMuon Summary:\n{tabulate(muon_table, headers=headers, tablefmt='grid')}\n\n"
+            )
+
+for type_ in events_:
+    # Calculate total number of muons
+    total_muons = sum(len(muons) for muons in events_[type_].values())
+    print(
+        f"{type_}, \tnEvents:{sum(bool(len(muons)) for muons in events_[type_].values())}, \tnMuons:{total_muons}"
+    )
 output_file.cd()
 output_tree.Write()
-hPmuon.Write()
+for histname in h:
+    h[histname].Write()
 output_file.Close()
-print("Finish:", evs)
 fsel.close()
 
 
@@ -199,7 +386,7 @@ print(
     args.outputfile,
     " now----------------------------------------------------------------",
 )
-
+event_data = []
 with r.TFile.Open(args.outputfile, "read") as file:
     try:
         tree = file.MuonAndSoftInteractions
@@ -219,13 +406,17 @@ with r.TFile.Open(args.outputfile, "read") as file:
         x = imuondata[4]
         y = imuondata[5]
         z = imuondata[6]
+
         weight = imuondata[7]
         time_hit = imuondata[8]
+        nmuons = imuondata[9]
+
         num_tracks = len(event.tracks)
         num_muonhits = len(event.muon_vetoPoints)
 
-        print(
-            f"Muon PID: {pid},  x: {x}, y: {y}, z: {z}, t_muon: {time_hit}, "
-            f"Number of soft tracks in this event: {num_tracks}, "
-            f"Number of SBT hits from the muon: {num_muonhits}"
+        P = r.TMath.Sqrt(px**2 + py**2 + pz**2)
+
+        event_data.append(
+            [nmuons, pid, P, x, y, z, time_hit, num_tracks, num_muonhits, weight]
         )
+print(tabulate(event_data, headers=headers, tablefmt="grid"))

--- a/python/shipRoot_conf.py
+++ b/python/shipRoot_conf.py
@@ -68,6 +68,8 @@ def configure(darkphoton=None):
    pdg.AddParticle('Pomeron','Pomeron',   0., False, 0., 0., 'Pomeron', 990)
    pdg.AddParticle('p_diffr+','p_diffr+', 0., False, 0., 0., 'XXX', 9902210)
    pdg.AddParticle('n_diffr0','n_diffr0', 0., False, 0., 0., 'XXX', 9902110)
+   pdg.AddParticle("C12", "Carbon-12", 12.0, True, 0, 6.0, "nucleus", 1000060120)
+   pdg.AddParticle("C13", "Carbon-13", 13.003355, True, 0, 6.0, "nucleus", 1000060130)
    pdg.AddParticle('J/psi[3PJ(8)]'    ,'J/psi[3PJ(8)]'    ,3.29692,False,0.,      0.,'Meson', 9942003)
    pdg.AddParticle('J/psi[1S0(8)]'    ,'J/psi[1S0(8)]'    ,3.29692,False,0.,      0.,'Meson', 9941003)
    pdg.AddParticle('f0(980)'          ,'f0(980)'          ,1.0,    False,0.0,     0.,'Meson', 9010221)
@@ -81,6 +83,7 @@ def configure(darkphoton=None):
    pdg.AddParticle('chi_1c[3S1(8)]'    ,'chi_1c[3S1(8)]'  ,3.71066,False,0.0,     0, 'Meson', 9940023)
    pdg.AddParticle('chi_2c[3S1(8)]'    ,'chi_2c[3S1(8)]'  ,3.75620,False,0.0,     0, 'Meson', 9940005)
    pdg.AddParticle('Upsilon[3S1(8)]'   ,'Upsilon[3S1(8)]' ,9.66030,False,0.0,     0, 'Meson', 9950003)
+   
    atexit.register(pyExit)
    if darkphoton==0: return # will be added by pythia8_conf
    if (darkphoton):

--- a/python/shipRoot_conf.py
+++ b/python/shipRoot_conf.py
@@ -83,7 +83,7 @@ def configure(darkphoton=None):
    pdg.AddParticle('chi_1c[3S1(8)]'    ,'chi_1c[3S1(8)]'  ,3.71066,False,0.0,     0, 'Meson', 9940023)
    pdg.AddParticle('chi_2c[3S1(8)]'    ,'chi_2c[3S1(8)]'  ,3.75620,False,0.0,     0, 'Meson', 9940005)
    pdg.AddParticle('Upsilon[3S1(8)]'   ,'Upsilon[3S1(8)]' ,9.66030,False,0.0,     0, 'Meson', 9950003)
-   
+
    atexit.register(pyExit)
    if darkphoton==0: return # will be added by pythia8_conf
    if (darkphoton):

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -1,35 +1,34 @@
-#include <math.h>
-#include "TSystem.h"
-#include "TROOT.h"
-#include "TMath.h"
-#include "TFile.h"
-#include "TRandom.h"
-#include "FairPrimaryGenerator.h"
 #include "MuDISGenerator.h"
-#include "TGeoVolume.h"
-#include "TGeoNode.h"
-#include "TGeoManager.h"
-#include "TGeoEltu.h"
-#include "TVectorD.h"
+
+#include "FairLogger.h"
+#include "FairPrimaryGenerator.h"
+#include "TFile.h"
 #include "TGeoCompositeShape.h"
+#include "TGeoEltu.h"
+#include "TGeoManager.h"
+#include "TGeoNode.h"
+#include "TGeoVolume.h"
+#include "TMath.h"
+#include "TROOT.h"
+#include "TRandom.h"
+#include "TSystem.h"
+#include "TVectorD.h"
 
-using std::cout;
-using std::endl;
-
-const Double_t c_light = 29.9792458;//speed of light in cm/ns
+#include <math.h>
 
 // MuDIS momentum GeV
 // Vertex in SI units, assume this means m
-
 
 // -----   Default constructor   -------------------------------------------
 MuDISGenerator::MuDISGenerator() {}
 // -------------------------------------------------------------------------
 // -----   Default constructor   -------------------------------------------
-Bool_t MuDISGenerator::Init(const char* fileName) {
-  return Init(fileName, 0);
+Bool_t MuDISGenerator::Init(const char* fileName)
+{
+    return Init(fileName, 0);
 }
-Bool_t MuDISGenerator::Init(const char* fileName, const int firstEvent) {
+Bool_t MuDISGenerator::Init(const char* fileName, const int firstEvent)
+{
     LOGF(info, "Opening input file %s", fileName);
 
   iMuon = 0;
@@ -47,42 +46,50 @@ Bool_t MuDISGenerator::Init(const char* fileName, const int firstEvent) {
   fTree->SetBranchAddress("InMuon", &iMuon);    // incoming muon
   fTree->SetBranchAddress("DISParticles", &dPart);
   fTree->SetBranchAddress("SoftParticles", &dPartSoft); // Soft interaction particles
+  LOG(INFO) << "MuDISGenerator: Initialization successful.";
   return kTRUE;
 }
 
-Double_t MuDISGenerator::MeanMaterialBudget(const Double_t *start, const Double_t *end, Double_t *mparam)
+Double_t MuDISGenerator::MeanMaterialBudget(const Double_t* start, const Double_t* end, Double_t* mparam)
 {
-  //
-  // Calculate mean material budget and material properties between
-  //    the points "start" and "end".
-  //
-  // "mparam" - parameters used for the energy and multiple scattering
-  //  corrections:
-  //
-  // mparam[0] - mean density: sum(x_i*rho_i)/sum(x_i) [g/cm3]
-  // mparam[1] - equivalent rad length fraction: sum(x_i/X0_i) [adimensional]
-  // mparam[2] - mean A: sum(x_i*A_i)/sum(x_i) [adimensional]
-  // mparam[3] - mean Z: sum(x_i*Z_i)/sum(x_i) [adimensional]
-  // mparam[4] - length: sum(x_i) [cm]
-  // mparam[5] - Z/A mean: sum(x_i*Z_i/A_i)/sum(x_i) [adimensional]
-  // mparam[6] - number of boundary crosses
-  // mparam[7] - maximum density encountered (g/cm^3)
-  //
-  //  Origin:  Marian Ivanov, Marian.Ivanov@cern.ch
-  //
-  //  Corrections and improvements by
-  //        Andrea Dainese, Andrea.Dainese@lnl.infn.it,
-  //        Andrei Gheata,  Andrei.Gheata@cern.ch
-  //        Anupama Reghunath, anupama.reghunath@cern.ch
-  //
+    //
+    // Calculate mean material budget and material properties between
+    //    the points "start" and "end".
+    //
+    // "mparam" - parameters used for the energy and multiple scattering
+    //  corrections:
+    //
+    // mparam[0] - mean density: sum(x_i*rho_i)/sum(x_i) [g/cm3]
+    // mparam[1] - equivalent rad length fraction: sum(x_i/X0_i) [adimensional]
+    // mparam[2] - mean A: sum(x_i*A_i)/sum(x_i) [adimensional]
+    // mparam[3] - mean Z: sum(x_i*Z_i)/sum(x_i) [adimensional]
+    // mparam[4] - length: sum(x_i) [cm]
+    // mparam[5] - Z/A mean: sum(x_i*Z_i/A_i)/sum(x_i) [adimensional]
+    // mparam[6] - number of boundary crosses
+    // mparam[7] - maximum density encountered (g/cm^3)
+    //
+    //  Origin:  Marian Ivanov, Marian.Ivanov@cern.ch
+    //
+    //  Corrections and improvements by
+    //        Andrea Dainese, Andrea.Dainese@lnl.infn.it,
+    //        Andrei Gheata,  Andrei.Gheata@cern.ch
+    //        Anupama Reghunath, anupama.reghunath@cern.ch
+    //
 
-  mparam[0]=0; mparam[1]=1; mparam[2] =0; mparam[3] =0;
-  mparam[4]=0; mparam[5]=0; mparam[6]=0; mparam[7]=0;
-  //
-  Double_t bparam[6]; // total parameters
-  Double_t lparam[6]; // local parameters
+    mparam[0] = 0;
+    mparam[1] = 1;
+    mparam[2] = 0;
+    mparam[3] = 0;
+    mparam[4] = 0;
+    mparam[5] = 0;
+    mparam[6] = 0;
+    mparam[7] = 0;
+    //
+    Double_t bparam[6];   // total parameters
+    Double_t lparam[6];   // local parameters
 
-  for (Int_t i=0;i<6;i++) bparam[i]=0;
+    for (Int_t i = 0; i < 6; i++)
+        bparam[i] = 0;
 
   if (!gGeoManager) {
       return 0.;
@@ -123,218 +130,244 @@ Double_t MuDISGenerator::MeanMaterialBudget(const Double_t *start, const Double_
     for (Int_t iel=0;iel<mixture->GetNelements();iel++){
       sum  += mixture->GetWmixt()[iel];
       lparam[5]+= mixture->GetZmixt()[iel]*mixture->GetWmixt()[iel]/mixture->GetAmixt()[iel];
+        }
+        lparam[5] /= sum;
     }
-    lparam[5]/=sum;
-  }
 
-  // Locate next boundary within length without computing safety.
-  // Propagate either with length (if no boundary found) or just cross boundary
-  gGeoManager->FindNextBoundaryAndStep(length, kFALSE);
-  Double_t step = 0.0; // Step made
-  Double_t snext = gGeoManager->GetStep();
-  // If no boundary within proposed length, return current density
-  if (!gGeoManager->IsOnBoundary()) {
-    mparam[0] = lparam[0];
-    mparam[1] = lparam[4]/lparam[1];
-    mparam[2] = lparam[2];
-    mparam[3] = lparam[3];
-    mparam[4] = lparam[4];
-    return lparam[0];
-  }
-  // Try to cross the boundary and see what is next
-  Int_t nzero = 0;
-  while (length>TGeoShape::Tolerance()) {
-    currentnode = gGeoManager->GetCurrentNode();
-    if (snext<2.*TGeoShape::Tolerance()) nzero++;
-    else nzero = 0;
-    if (nzero>3) {
-      // This means navigation has problems on one boundary
-      // Try to cross by making a small step
-      //AliErrorClass("Cannot cross boundary\n");
-      mparam[0] = bparam[0]/step;
-      mparam[1] = bparam[1];
-      mparam[2] = bparam[2]/step;
-      mparam[3] = bparam[3]/step;
-      mparam[5] = bparam[5]/step;
-      mparam[4] = step;
-      mparam[0] = 0.;             // if crash of navigation take mean density 0
-      mparam[1] = 1000000;        // and infinite rad length
-      return bparam[0]/step;
-    }
-    mparam[6]+=1.;
-    step += snext;
-    bparam[1]    += snext/lparam[1];
-    bparam[2]    += snext*lparam[2];
-    bparam[3]    += snext*lparam[3];
-    bparam[5]    += snext*lparam[5];
-    bparam[0]    += snext*lparam[0];
-
-    if (snext>=length) break;
-    if (!currentnode) break;
-    length -= snext;
-    material = currentnode->GetVolume()->GetMedium()->GetMaterial();
-    lparam[0] = material->GetDensity();
-    if (lparam[0] > mparam[7]) mparam[7]=lparam[0];
-    lparam[1]  = material->GetRadLen();
-    lparam[2]  = material->GetA();
-    lparam[3]  = material->GetZ();
-    lparam[5]   = lparam[3]/lparam[2];
-    if (material->IsMixture()) {
-      TGeoMixture * mixture = (TGeoMixture*)material;
-      lparam[5]=0;
-      Double_t sum =0;
-      for (Int_t iel=0;iel<mixture->GetNelements();iel++){
-        sum+= mixture->GetWmixt()[iel];
-        lparam[5]+= mixture->GetZmixt()[iel]*mixture->GetWmixt()[iel]/mixture->GetAmixt()[iel];
-      }
-      lparam[5]/=sum;
-    }
+    // Locate next boundary within length without computing safety.
+    // Propagate either with length (if no boundary found) or just cross boundary
     gGeoManager->FindNextBoundaryAndStep(length, kFALSE);
-    snext = gGeoManager->GetStep();
-  }
-  mparam[0] = bparam[0]/step;
-  mparam[1] = bparam[1];
-  mparam[2] = bparam[2]/step;
-  mparam[3] = bparam[3]/step;
-  mparam[5] = bparam[5]/step;
-  return bparam[0]/step;
+    Double_t step = 0.0;   // Step made
+    Double_t snext = gGeoManager->GetStep();
+    // If no boundary within proposed length, return current density
+    if (!gGeoManager->IsOnBoundary()) {
+        mparam[0] = lparam[0];
+        mparam[1] = lparam[4] / lparam[1];
+        mparam[2] = lparam[2];
+        mparam[3] = lparam[3];
+        mparam[4] = lparam[4];
+        return lparam[0];
+    }
+    // Try to cross the boundary and see what is next
+    Int_t nzero = 0;
+    while (length > TGeoShape::Tolerance()) {
+        currentnode = gGeoManager->GetCurrentNode();
+        if (snext < 2. * TGeoShape::Tolerance())
+            nzero++;
+        else
+            nzero = 0;
+        if (nzero > 3) {
+            // This means navigation has problems on one boundary
+            // Try to cross by making a small step
+            // AliErrorClass("Cannot cross boundary\n");
+            mparam[0] = bparam[0] / step;
+            mparam[1] = bparam[1];
+            mparam[2] = bparam[2] / step;
+            mparam[3] = bparam[3] / step;
+            mparam[5] = bparam[5] / step;
+            mparam[4] = step;
+            mparam[0] = 0.;        // if crash of navigation take mean density 0
+            mparam[1] = 1000000;   // and infinite rad length
+            return bparam[0] / step;
+        }
+        mparam[6] += 1.;
+        step += snext;
+        bparam[1] += snext / lparam[1];
+        bparam[2] += snext * lparam[2];
+        bparam[3] += snext * lparam[3];
+        bparam[5] += snext * lparam[5];
+        bparam[0] += snext * lparam[0];
+
+        if (snext >= length)
+            break;
+        if (!currentnode)
+            break;
+        length -= snext;
+        material = currentnode->GetVolume()->GetMedium()->GetMaterial();
+        lparam[0] = material->GetDensity();
+        if (lparam[0] > mparam[7])
+            mparam[7] = lparam[0];
+        lparam[1] = material->GetRadLen();
+        lparam[2] = material->GetA();
+        lparam[3] = material->GetZ();
+        lparam[5] = lparam[3] / lparam[2];
+        if (material->IsMixture()) {
+            TGeoMixture* mixture = (TGeoMixture*)material;
+            lparam[5] = 0;
+            Double_t sum = 0;
+            for (Int_t iel = 0; iel < mixture->GetNelements(); iel++) {
+                sum += mixture->GetWmixt()[iel];
+                lparam[5] += mixture->GetZmixt()[iel] * mixture->GetWmixt()[iel] / mixture->GetAmixt()[iel];
+            }
+            lparam[5] /= sum;
+        }
+        gGeoManager->FindNextBoundaryAndStep(length, kFALSE);
+        snext = gGeoManager->GetStep();
+    }
+    mparam[0] = bparam[0] / step;
+    mparam[1] = bparam[1];
+    mparam[2] = bparam[2] / step;
+    mparam[3] = bparam[3] / step;
+    mparam[5] = bparam[5] / step;
+    return bparam[0] / step;
 }
 
 // -----   Destructor   ----------------------------------------------------
 MuDISGenerator::~MuDISGenerator()
 {
- fInputFile->Close();
- fInputFile->Delete();
- delete fInputFile;
+    fInputFile->Close();
+    fInputFile->Delete();
+    delete fInputFile;
 }
 // -----   Passing the event   ---------------------------------------------
 Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg)
 {
-    if (fn==fNevents) {LOG(WARNING) << "End of input file. Rewind.";}
-    fTree->GetEntry(fn%fNevents);
-    fn++;
-    if (fn%10==0) {
-      cout << "Info MuDISGenerator: MuDIS event-nr "<< fn << endl;
+    if (fn == fNevents) {
+        LOG(WARNING) << "End of input file. Rewind.";
     }
-    
+    fTree->GetEntry(fn % fNevents);
+    fn++;
+    if (fn % 10 == 0) {
+        LOG(INFO) << "Info MuDISGenerator: MuDIS event-nr " << fn;
+    }
 
     int nf = dPart->GetEntries();
-    int ns = dPartSoft->GetEntries(); 
-    //cout << "*********************************************************" << endl;
-    //cout << "muon DIS Generator debug " << iMuon->GetEntries()<< " "<< iMuon->AddrAt(0) << " nf "<< nf << " fn=" << fn <<endl; 
+    int ns = dPartSoft->GetEntries();
+    LOG(DEBUG) << "*********************************************************";
+    LOG(DEBUG) << "muon DIS Generator debug " << iMuon->GetEntries() << " " << iMuon->AddrAt(0) << " nf " << nf
+               << " fn=" << fn;
 
-    //some start/end positions in z (f.i. emulsion to Tracker 1)
-    Double_t start[3]={0.,0.,startZ};
-    Double_t end[3]={0.,0.,endZ};
+    // some start/end positions in z (f.i. emulsion to Tracker 1)
+    Double_t start[3] = {0., 0., startZ};
+    Double_t end[3] = {0., 0., endZ};
 
-// incoming muon  array('d',[pid,px,py,pz,E,x,y,z,w,t])
+    // incoming muon  array('d',[pid,px,py,pz,E,x,y,z,w,t])
     TVectorD* mu = dynamic_cast<TVectorD*>(iMuon->AddrAt(0));
-    //cout << "muon DIS Generator in muon " << int(mu[0][0])<< endl; 
-    Double_t x = mu[0][5]*100.; // come in m -> cm
-    Double_t y = mu[0][6]*100.; // come in m -> cm
-    Double_t z = mu[0][7]*100.; // come in m -> cm
+    LOG(DEBUG) << "muon DIS Generator in muon " << int(mu[0][0]);
+    Double_t x = mu[0][5] * 100.;   // come in m -> cm
+    Double_t y = mu[0][6] * 100.;   // come in m -> cm
+    Double_t z = mu[0][7] * 100.;   // come in m -> cm
     Double_t w = mu[0][8];
-    Double_t t_muon = mu[0][11]; // in ns
+    Double_t t_muon = mu[0][11];   // in ns
 
-// calculate start/end positions along this muon, and amout of material in between
-                    
-    Double_t txmu=mu[0][1]/mu[0][3];
-    Double_t tymu=mu[0][2]/mu[0][3];
-    start[0]=x-(z-start[2])*txmu;
-    start[1]=y-(z-start[2])*tymu;
-    end[0]=x-(z-end[2])*txmu;
-    end[1]=y-(z-end[2])*tymu;
-    //cout << "MuDIS: mu xyz position " << x << ", " << y << ", " << z << endl;
-    //cout << "MuDIS: mu pxyz position " << mu[0][1] << ", " << mu[0][2] << ", " << mu[0][3] << endl;
-    //cout << "MuDIS: mu weight " << w << endl;
-    //cout << "MuDIS: start position " << start[0] << ", " << start[1] << ", " << start[2] << endl;
-    //cout << "MuDIS: end position " << end[0] << ", " << end[1] << ", " << end[2] << endl;
+    // calculate start/end positions along this muon, and amout of material in between
+
+    Double_t txmu = mu[0][1] / mu[0][3];
+    Double_t tymu = mu[0][2] / mu[0][3];
+    start[0] = x - (z - start[2]) * txmu;
+    start[1] = y - (z - start[2]) * tymu;
+    end[0] = x - (z - end[2]) * txmu;
+    end[1] = y - (z - end[2]) * tymu;
+    LOG(DEBUG) << "MuDIS: mu xyz position " << x << ", " << y << ", " << z;
+    LOG(DEBUG) << "MuDIS: mu pxyz position " << mu[0][1] << ", " << mu[0][2] << ", " << mu[0][3];
+    LOG(DEBUG) << "MuDIS: mu weight " << w;
+    LOG(DEBUG) << "MuDIS: start position " << start[0] << ", " << start[1] << ", " << start[2];
+    LOG(DEBUG) << "MuDIS: end position " << end[0] << ", " << end[1] << ", " << end[2];
     Double_t bparam;
     Double_t mparam[8];
-    bparam=MeanMaterialBudget(start, end, mparam);
-    //loop over trajectory between start and end to pick an interaction point
+    bparam = MeanMaterialBudget(start, end, mparam);
+    // loop over trajectory between start and end to pick an interaction point
     Double_t prob2int = 0.;
     Double_t xmu;
     Double_t ymu;
     Double_t zmu;
-    Int_t count=0;
-    //cout << "Info MuDISGenerator Start prob2int while loop, bparam= " << bparam << ", " << bparam*1.e8 <<endl;
-    //cout << "Info MuDISGenerator What was maximum density, mparam[7]= " << mparam[7] << ", " << mparam[7]*1.e8 <<endl;
-    
+    Int_t count = 0;
+    LOG(DEBUG) << "Info MuDISGenerator Start prob2int while loop, bparam= " << bparam << ", " << bparam * 1.e8;
+    LOG(DEBUG) << "Info MuDISGenerator What was maximum density, mparam[7]= " << mparam[7] << ", " << mparam[7] * 1.e8;
 
-    while (prob2int<gRandom->Uniform(0.,1.)) {
-      zmu=gRandom->Uniform(start[2],end[2]);
-      xmu=x-(z-zmu)*txmu;
-      ymu=y-(z-zmu)*tymu;
-      //get local material at this point
-      TGeoNode *node = gGeoManager->FindNode(xmu,ymu,zmu);
-      TGeoMaterial *mat = 0;
-      if (node && !gGeoManager->IsOutside()) mat = node->GetVolume()->GetMaterial();
-      //cout << "Info MuDISGenerator: mat " <<  count << ", " << mat->GetName() << ", " << mat->GetDensity() << endl;
-      //density relative to Prob largest density along this trajectory, i.e. use rho(Pt)
-      prob2int= mat->GetDensity()/mparam[7];
-      if (prob2int>1.) cout << "***WARNING*** MuDISGenerator: prob2int > Maximum density????" << prob2int << " maxrho:" << mparam[7] << " material: " <<  mat->GetName() << endl;
-      count+=1;
+    while (prob2int < gRandom->Uniform(0., 1.)) {
+        zmu = gRandom->Uniform(start[2], end[2]);
+        xmu = x - (z - zmu) * txmu;
+        ymu = y - (z - zmu) * tymu;
+        // get local material at this point
+        TGeoNode* node = gGeoManager->FindNode(xmu, ymu, zmu);
+        TGeoMaterial* mat = 0;
+        if (node && !gGeoManager->IsOutside())
+            mat = node->GetVolume()->GetMaterial();
+        LOG(DEBUG) << "Info MuDISGenerator: mat " << count << ", " << mat->GetName() << ", " << mat->GetDensity();
+        // density relative to Prob largest density along this trajectory, i.e. use rho(Pt)
+        prob2int = mat->GetDensity() / mparam[7];
+        if (prob2int > 1.) {
+            LOG(WARNING) << "MuDISGenerator: prob2int > Maximum density????";
+            LOG(WARNING) << "prob2int: " << prob2int;
+            LOG(WARNING) << "maxrho: " << mparam[7];
+            LOG(WARNING) << "material: " << mat->GetName();
+        }
+        count += 1;
     }
-    //cout << "Info MuDISGenerator: prob2int " << prob2int << ", " << count << endl;
 
-    //cout << "MuDIS: put position " << xmu << ", " << ymu << ", " << zmu << endl;
+    LOG(DEBUG) << "Info MuDISGenerator: prob2int " << prob2int << ", " << count;
+    LOG(DEBUG) << "MuDIS: put position " << xmu << ", " << ymu << ", " << zmu;
 
-    double total_mom = TMath::Sqrt(TMath::Power(mu[0][1], 2) +
-                                  TMath::Power(mu[0][2], 2) +
-                                  TMath::Power(mu[0][3], 2));    //in GeV
+    Double_t total_mom =
+        TMath::Sqrt(TMath::Power(mu[0][1], 2) + TMath::Power(mu[0][2], 2) + TMath::Power(mu[0][3], 2));   // in GeV
 
-    double distance = TMath::Sqrt(TMath::Power(x - xmu, 2) +
-                                  TMath::Power(y - ymu, 2) +
-                                  TMath::Power(z - zmu, 2));    // in cm
+    Double_t distance =
+        TMath::Sqrt(TMath::Power(x - xmu, 2) + TMath::Power(y - ymu, 2) + TMath::Power(z - zmu, 2));   // in cm
 
-    
-    double mass = 0.10565999895334244;  //muon mass in GeV
-    double v    = c_light*total_mom/TMath::Sqrt(TMath::Power(total_mom,2)+
-                                                TMath::Power(mass,2));
-    double t_rmu=distance/v;
+    Double_t v = c_light * total_mom / TMath::Sqrt(TMath::Power(total_mom, 2) + TMath::Power(muon_mass, 2));
+    Double_t t_rmu = distance / v;
 
     // Adjust time based on the relative positions
     if (zmu < z) {
         t_rmu = -t_rmu;
     }
 
-    double t_DIS=(t_muon+t_rmu)/1e9; //time taken in seconds to reach [xmu,ymu,zmu]
-    
-    cpg->AddTrack(int(mu[0][0]),mu[0][1],mu[0][2],mu[0][3],xmu,ymu,zmu,-1,false,mu[0][4],t_DIS,w);//set time of the track start as t_muon from the input file
+    Double_t t_DIS = (t_muon + t_rmu) / 1e9;   // time taken in seconds to reach [xmu,ymu,zmu]
 
-    // outgoing particles, [did,dpx,dpy,dpz,E], put density along trajectory as weight, g/cm^2
-    w=mparam[0]*mparam[4];//modify weight, by multiplying with average densiy along track??
-    
-    for(int i=0; i<nf; i++)
-    	{
-         TVectorD* Part = dynamic_cast<TVectorD*>(dPart->AddrAt(i));
-         //cout << "muon DIS Generator out part " << int(Part[0][0]) << endl; 
-         //cout << "muon DIS Generator out part mom " << Part[0][1]<<" " << Part[0][2] <<" " << Part[0][3] << " " << Part[0][4] << endl; 
-         //cout << "muon DIS Generator out part pos " << mu[0][5]<<" " << mu[0][6] <<" " << mu[0][7] << endl; 
-         //cout << "muon DIS Generator out part w " << mu[0][8] << endl; 
-         cpg->AddTrack(int(Part[0][0]),Part[0][1],Part[0][2],Part[0][3],xmu,ymu,zmu,0,true,Part[0][4],t_DIS,w); //it takes times in seconds.
-         //cout << "muon DIS part added "<<endl;
-       }
-    
-    //Soft interaction tracks
-    
+    cpg->AddTrack(int(mu[0][0]),   // incoming muon track ()
+                  mu[0][1],
+                  mu[0][2],
+                  mu[0][3],
+                  xmu,
+                  ymu,
+                  zmu,
+                  -1,
+                  false,   // tracking disabled
+                  mu[0][4],
+                  t_DIS,   // shift time of the incoming muon track wrt t_muon from the input file.
+                  w);      // weight associated with a spill.
 
-    for (int i = 0; i < ns; i++) {
-        TVectorD* SoftPart = dynamic_cast<TVectorD*>(dPartSoft->AddrAt(i));
-        if ( SoftPart[0][7] > zmu ) { //if the softinteractions are after the DIS point, don't save the soft interaction.
-          continue;
-        }
-        double t_soft=SoftPart[0][8]/1e9;
-        cpg->AddTrack(int(SoftPart[0][0]), SoftPart[0][1], SoftPart[0][2], SoftPart[0][3], SoftPart[0][5], SoftPart[0][6], SoftPart[0][7], 0, true, SoftPart[0][4], t_soft, w);
+    // outgoing DIS particles, [did,dpx,dpy,dpz,E], put density along trajectory as weight, g/cm^2
 
+    w = mparam[0] * mparam[4];   // modify weight, by multiplying with average densiy * track length
+
+    for (auto&& particle : *dPart) {
+        TVectorD* Part = dynamic_cast<TVectorD*>(particle);
+        LOG(DEBUG) << "muon DIS Generator out part " << int((*Part)[0]);
+        LOG(DEBUG) << "muon DIS Generator out part mom " << (*Part)[1] << " " << (*Part)[2] << " " << (*Part)[3] << " "
+                   << (*Part)[4];
+        LOG(DEBUG) << "muon DIS Generator out part pos " << xmu << " " << ymu << "" << zmu;
+        LOG(DEBUG) << "muon DIS Generator out part w " << w;
+        cpg->AddTrack(
+            int((*Part)[0]), (*Part)[1], (*Part)[2], (*Part)[3], xmu, ymu, zmu, 0, true, (*Part)[4], t_DIS, w);
     }
 
-  return kTRUE;
+    // Soft interaction tracks
+    for (auto&& softParticle : *dPartSoft) {
+        TVectorD* SoftPart = dynamic_cast<TVectorD*>(softParticle);
+        if ((*SoftPart)[7] > zmu) {
+            continue;
+        }   // Soft interactions after the DIS point are not saved
+        Double_t t_soft = (*SoftPart)[8] / 1e9;   // Time in seconds
+        cpg->AddTrack(int((*SoftPart)[0]),
+                      (*SoftPart)[1],
+                      (*SoftPart)[2],
+                      (*SoftPart)[3],
+                      (*SoftPart)[5],
+                      (*SoftPart)[6],
+                      (*SoftPart)[7],
+                      0,
+                      true,
+                      (*SoftPart)[4],
+                      t_soft,
+                      w);
+    }
+
+    return kTRUE;
 }
 // -------------------------------------------------------------------------
 Int_t MuDISGenerator::GetNevents()
 {
- return fNevents;
+    return fNevents;
 }
-

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -33,7 +33,7 @@ Bool_t MuDISGenerator::Init(const char* fileName, const int firstEvent)
 
   iMuon = 0;
   dPart = 0;
-  dPartSoft = 0; 
+  dPartSoft = 0;
   fInputFile = TFile::Open(fileName);
   if (!fInputFile) {
       LOG(FATAL) << "Error opening input file";

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -334,7 +334,7 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg)
     // outgoing DIS particles, [did,dpx,dpy,dpz,E], put density along trajectory as weight, g/cm^2
 
     w = mparam[0] * mparam[4];   // modify weight, by multiplying with average density * track length
-
+    int index = 0;
     for (auto&& particle : *dPart) {
         TVectorD* Part = dynamic_cast<TVectorD*>(particle);
         LOG(DEBUG) << "muon DIS Generator out part " << int((*Part)[0]);
@@ -343,7 +343,7 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg)
         LOG(DEBUG) << "muon DIS Generator out part pos " << xmu << " " << ymu << "" << zmu;
         LOG(DEBUG) << "muon DIS Generator out part w " << w;
 
-        if (int(mu[0][0]) == int((*Part)[0])) {
+        if (index == 0) {
             cpg->AddTrack(int((*Part)[0]),
                           (*Part)[1],
                           (*Part)[2],
@@ -355,11 +355,12 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg)
                           true,
                           (*Part)[4],
                           t_DIS,
-                          cross_sec);
+                          cross_sec);   // save DIS cross section in MCTrack[1]
         } else {
             cpg->AddTrack(
                 int((*Part)[0]), (*Part)[1], (*Part)[2], (*Part)[3], xmu, ymu, zmu, 0, true, (*Part)[4], t_DIS, w);
         }
+        index += 1;
     }
 
     // Soft interaction tracks

--- a/shipgen/MuDISGenerator.h
+++ b/shipgen/MuDISGenerator.h
@@ -49,6 +49,10 @@ class MuDISGenerator : public FairGenerator
   int fNevents;
   int fn;
   bool fFirst;
+
+  const Double_t c_light = 29.9792458;//speed of light in cm/ns
+  const Double_t muon_mass = 0.10565999895334244;  //muon mass in GeV
+  
   ClassDef(MuDISGenerator,1);
 };
 #endif /* !PNDMuGENERATOR_H */

--- a/shipgen/MuDISGenerator.h
+++ b/shipgen/MuDISGenerator.h
@@ -42,6 +42,7 @@ class MuDISGenerator : public FairGenerator
   Double_t startZ,endZ;
   TClonesArray* iMuon ;
   TClonesArray* dPart ;
+  TClonesArray* dPartSoft ;
   FairLogger*  fLogger; //!   don't make it persistent, magic ROOT command
   TFile* fInputFile;
   TTree* fTree;

--- a/shipgen/MuDISGenerator.h
+++ b/shipgen/MuDISGenerator.h
@@ -1,58 +1,56 @@
-#ifndef PNDMuGENERATOR_H
-#define PNDMuGENERATOR_H 1
+#ifndef SHIPGEN_MUDISGENERATOR_H_
+#define SHIPGEN_MUDISGENERATOR_H_ 1
 
-#include "TROOT.h"
 #include "FairGenerator.h"
-#include "TTree.h"                      // for TTree
-#include "TF1.h"                        // for TF1
+#include "FairLogger.h"   // for FairLogger, MESSAGE_ORIGIN
 #include "TClonesArray.h"
+#include "TF1.h"   // for TF1
+#include "TROOT.h"
+#include "TTree.h"   // for TTree
 #include "TVector3.h"
-#include "FairLogger.h"                 // for FairLogger, MESSAGE_ORIGIN
 #include "vector"
 
 class FairPrimaryGenerator;
 
 class MuDISGenerator : public FairGenerator
 {
- public:
+  public:
+    /** default constructor **/
+    MuDISGenerator();
 
-  /** default constructor **/
-  MuDISGenerator();
+    /** destructor **/
+    virtual ~MuDISGenerator();
 
-  /** destructor **/
-  virtual ~MuDISGenerator();
+    /** public method ReadEvent **/
+    Bool_t ReadEvent(FairPrimaryGenerator*);
+    virtual Bool_t Init(const char*, int);   //!
+    virtual Bool_t Init(const char*);        //!
+    Int_t GetNevents();
 
-  /** public method ReadEvent **/
-  Bool_t ReadEvent(FairPrimaryGenerator*);
-  virtual Bool_t Init(const char*, int); //!
-  virtual Bool_t Init(const char*); //!
-  Int_t GetNevents();
+    void SetPositions(Double_t z_start, Double_t z_end)
+    {
+        startZ = z_start;
+        endZ = z_end;
+    }
 
-  void SetPositions(Double_t z_start, Double_t z_end)
-  {
-      startZ = z_start;
-      endZ = z_end;
-  }
+  private:
+    Double_t MeanMaterialBudget(const Double_t* start, const Double_t* end, Double_t* mparam);
 
- private:
-  Double_t MeanMaterialBudget(const Double_t *start, const Double_t *end, Double_t *mparam);
+  protected:
+    Double_t startZ, endZ;
+    TClonesArray* iMuon;
+    TClonesArray* dPart;
+    TClonesArray* dPartSoft;
+    FairLogger* fLogger;   //!   don't make it persistent, magic ROOT command
+    TFile* fInputFile;
+    TTree* fTree;
+    int fNevents;
+    int fn;
+    bool fFirst;
 
+    const Double_t c_light = 29.9792458;              // speed of light in cm/ns
+    const Double_t muon_mass = 0.10565999895334244;   // muon mass in GeV
 
- protected:
-  Double_t startZ,endZ;
-  TClonesArray* iMuon ;
-  TClonesArray* dPart ;
-  TClonesArray* dPartSoft ;
-  FairLogger*  fLogger; //!   don't make it persistent, magic ROOT command
-  TFile* fInputFile;
-  TTree* fTree;
-  int fNevents;
-  int fn;
-  bool fFirst;
-
-  const Double_t c_light = 29.9792458;//speed of light in cm/ns
-  const Double_t muon_mass = 0.10565999895334244;  //muon mass in GeV
-  
-  ClassDef(MuDISGenerator,1);
+    ClassDef(MuDISGenerator, 1);
 };
-#endif /* !PNDMuGENERATOR_H */
+#endif   // SHIPGEN_MUDISGENERATOR_H_

--- a/shipgen/MuDISGenerator.h
+++ b/shipgen/MuDISGenerator.h
@@ -48,9 +48,6 @@ class MuDISGenerator : public FairGenerator
     int fn;
     bool fFirst;
 
-    const Double_t c_light = 29.9792458;              // speed of light in cm/ns
-    const Double_t muon_mass = 0.10565999895334244;   // muon mass in GeV
-
     ClassDef(MuDISGenerator, 1);
 };
 #endif   // SHIPGEN_MUDISGENERATOR_H_


### PR DESCRIPTION
Attached are the SBT response plots produced for the previous MuonDIS(involving backwards travelling muons), and with the suggested corrections with the new MuonDIS. SBThits are color coded wrt to the time of DIS. New method preserves the incoming muon's time as well as its veto response, and ensures that the event is temporally consistent.

Before:
![SBT_event_oldmuDIS](https://github.com/user-attachments/assets/cdab65b4-fdc2-48d6-963a-b299d35b6a68)
After:
![SBT_event_newmuDIS](https://github.com/user-attachments/assets/dfcfcca9-c0d1-401d-a727-864e9181b463)
