### PR TITLE
Fix unused variable in MuDISGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ it in future.
 * Cleaned up Veto Implementation
 * Fix crash of event display, PID when no entrance lid present
 * Close ShipReco.py output file
+* Remove unused (silently ignored!) argument for MuDISGenerator::SetPositions
 
 ### Changed
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -403,7 +403,7 @@ if simEngine == "muonDIS":
  # in front of UVT up to tracking station 1
  mu_start, mu_end = ship_geo.Chamber1.z-ship_geo.chambers.Tub1length-10.*u.cm,ship_geo.TrackStation1.z
  print('MuDIS position info input=',mu_start, mu_end)
- DISgen.SetPositions(ship_geo.target.z0, mu_start, mu_end)
+ DISgen.SetPositions(mu_start, mu_end)
  DISgen.Init(inputFile,options.firstEvent)
  primGen.AddGenerator(DISgen)
  options.nEvents = min(options.nEvents,DISgen.GetNevents())

--- a/shipgen/MuDISGenerator.h
+++ b/shipgen/MuDISGenerator.h
@@ -28,9 +28,10 @@ class MuDISGenerator : public FairGenerator
   virtual Bool_t Init(const char*); //!
   Int_t GetNevents();
 
-  void SetPositions(Double_t zTa, Double_t zS=-3400., Double_t zE=2650.){
-    startZ      = zS;
-    endZ        = zE;
+  void SetPositions(Double_t z_start, Double_t z_end)
+  {
+      startZ = z_start;
+      endZ = z_end;
   }
 
  private:


### PR DESCRIPTION
First argument of SetPositions was unused and as a result silently ignored. As we are already changing it, remove default parameters, which are probably outdated, and could lead to surprising behaviour. Code using the old signature should break noticeably, and should be trivial to fix by removing the first argument.

Thanks to @siilieva for pointing out the issue, fixed in https://github.com/SND-LHC/sndsw/tree/XY_range_for_muonDIS_sim/ on the SND@LHC side.