### PR TITLE
millepede removed from CMakeLists.txt in the main folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,6 @@ add_subdirectory (shipgen)
 add_subdirectory (field)
 add_subdirectory (pid)
 add_subdirectory (muonShieldOptimization)
-add_subdirectory (millepede)
 
 FIND_PATH(TEvePath NAMES TEveEventManager.h PATHS
   ${SIMPATH}/tools/root/include


### PR DESCRIPTION
Hi,
I removed the ```add_subdirectory (millepede)``` from ./CMakeLists.cxx because it caused the errors during the build of Fairship due to the last commit