### PR TITLE
SST boxes medium will now follow DecayVolumeMedium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ it in future.
 ### Changed
 
 * Set Decay Volume Medium as helium (previously vacuums),can be explicitly switched to vacuum with --vacuums.
+* Medium of SST boxes will be the same as DecayVolumeMedium (previously, always vacuum)
 
 ### Removed
 

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -701,8 +701,9 @@ def configure(run, ship_geo):
             ship_geo.strawtubes.DeltazFrame = 10.0 * u.cm
             ship_geo.strawtubes.FrameLateralWidth = 1.0 * u.cm
             ship_geo.strawtubes.FrameMaterial = "aluminium"
+        ship_geo.strawtubes.medium = "vacuums" if ship_geo.DecayVolumeMedium == "vaccums" else "air"
 
-        Strawtubes = ROOT.strawtubes("Strawtubes", ROOT.kTRUE)
+        Strawtubes = ROOT.strawtubes(ship_geo.strawtubes.medium)
         Strawtubes.SetZpositions(
             ship_geo.vetoStation.z,
             ship_geo.TrackStation1.z,

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -37,15 +37,29 @@ using std::cout;
 using std::endl;
 
 strawtubes::strawtubes()
-  : FairDetector("strawtubes", kTRUE, kStraw),
-    fTrackID(-1),
-    fVolumeID(-1),
-    fPos(),
-    fMom(),
-    fTime(-1.),
-    fLength(-1.),
-    fELoss(-1),
-    fstrawtubesPointCollection(new TClonesArray("strawtubesPoint"))
+    : FairDetector("Strawtubes", kTRUE, kStraw)
+    , fTrackID(-1)
+    , fVolumeID(-1)
+    , fPos()
+    , fMom()
+    , fTime(-1.)
+    , fLength(-1.)
+    , fELoss(-1)
+    , fMedium("air")
+    , fstrawtubesPointCollection(new TClonesArray("strawtubesPoint"))
+{}
+
+strawtubes::strawtubes(std::string medium)
+    : FairDetector("Strawtubes", kTRUE, kStraw)
+    , fTrackID(-1)
+    , fVolumeID(-1)
+    , fPos()
+    , fMom()
+    , fTime(-1.)
+    , fLength(-1.)
+    , fELoss(-1)
+    , fMedium(medium)
+    , fstrawtubesPointCollection(new TClonesArray("strawtubesPoint"))
 {
 }
 
@@ -337,8 +351,8 @@ void strawtubes::ConstructGeometry()
     TGeoMedium *tungsten          = gGeoManager->GetMedium("tungsten");
     InitMedium(fFrame_material);
     TGeoMedium *FrameMatPtr       = gGeoManager->GetMedium(fFrame_material);
-    InitMedium("vacuum");
-    TGeoMedium *med          = gGeoManager->GetMedium("vacuum");
+    InitMedium(fMedium.c_str());
+    TGeoMedium* med = gGeoManager->GetMedium(fMedium.c_str());
 
     gGeoManager->SetVisLevel(4);
     gGeoManager->SetTopVisible();

--- a/strawtubes/strawtubes.h
+++ b/strawtubes/strawtubes.h
@@ -21,6 +21,8 @@ class strawtubes: public FairDetector
     */
     strawtubes(const char* Name, Bool_t Active);
 
+    strawtubes(std::string medium);
+
     /**      default constructor    */
     strawtubes();
 
@@ -147,9 +149,10 @@ class strawtubes: public FairDetector
     Int_t        fStraws_per_layer_tr34;  //!  Number of straws in one tr34 layer
     Double_t     v_drift;                 //! drift velocity
     Double_t     sigma_spatial;           //! spatial resolution
+    std::string fMedium;                  //! vacuum box medium
     /** container for data points */
 
-    TClonesArray*  fstrawtubesPointCollection;
+    TClonesArray* fstrawtubesPointCollection;
 
     strawtubes(const strawtubes&);
     strawtubes& operator=(const strawtubes&);


### PR DESCRIPTION
@evanherwijnen noticed that the boxes containing the stations were still `vaccums`. This change should now make the medium follow the one used for the decay volume.