### PR TITLE
Fix: Pass correct detector IDs to Genfit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ it in future.
 * Use ConstructedAt instead of remove pythonization for TClonesArray
 * Octant symmetry was incorrect for B_z when using field maps (reported and fixed by M. Ferro-Luzzi)
 * Tof calculation corrected in GenieGenerator.cxx, wrong units previously used.
+* Genfit measurements now give the correct detector ID
 
 ### Changed
 


### PR DESCRIPTION
As pointed out by @evanherwijnen, the detector IDs for Genfit measurements were not being set correctly.

This should fix this issue. All of this code is quite hard to follow and could benefit from a rewrite.

