### PR TITLE
Fix event display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ it in future.
 * Tof calculation corrected in GenieGenerator.cxx, wrong units previously used.
 * Genfit measurements now give the correct detector ID
 * Fix TEvePointSetPrintOut
+* Event Display: Fix drawing of MC and Geo tracks
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ it in future.
 * Octant symmetry was incorrect for B_z when using field maps (reported and fixed by M. Ferro-Luzzi)
 * Tof calculation corrected in GenieGenerator.cxx, wrong units previously used.
 * Genfit measurements now give the correct detector ID
+* Fix TEvePointSetPrintOut
 
 ### Changed
 

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -1319,8 +1319,8 @@ fMan.SetPriOnly(False)  # display everything
 # ----------------------Tracks and points -------------------------------------
 verbose = 0  # 3 lot of output
 if withGeo:
-    Track = ROOT.FairMCTracks("Monte-Carlo Tracks", verbose)
-    GTrack = ROOT.FairMCTracks("GeoTracks", verbose)
+    Track = ROOT.FairMCTracksDraw("Monte-Carlo Tracks")
+    GTrack = ROOT.FairGeoTracksDraw("GeoTracks")
     fMan.AddTask(GTrack)
     fMan.AddTask(Track)
 

--- a/python/decorators.py
+++ b/python/decorators.py
@@ -69,7 +69,8 @@ def TEvePointSetPrintOut(P):
  if P.GetN()==0: txt = '<ROOT.TEvePointSet object>'
  for n in range(P.GetN()):
   rc = P.GetPoint(n,x,y,z)
-  txt += '%6i %7.1F,%7.1F,%9.1F x,y,z cm\n'%(n,x,y,z)
+  txt += f'{n:6d} {x.value:7.1f}, {y.value:7.1f}, {z.value:9.1f} x, y, z cm\n'
+
  return txt
 
 


### PR DESCRIPTION
Fixes @evanherwijnen's issue with the event display when running run_simScript.py with the --display option, and a secondary issue discovered along the way.

This will require a small patch to FairRoot to work, which I'll link here.

Detailed explanation to follow in the thread on the mailing list.