### PR TITLE
Switch Shield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ it in future.
 ### Changed
 
 * Don't special case EOS paths (fix #566)
+* Setting up the Muon shield geometry by ROOT files is completely replaced with the temporary solution of dict in the ```geometry/geometry_config.py```. Set up the shield name is now done by --shieldName key instead of --scName.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ it in future.
 ### Changed
 
 * Don't special case EOS paths (fix #566)
-* Setting up the Muon shield geometry by ROOT files is completely replaced with the temporary solution of dict in the ```geometry/geometry_config.py```. Set up the shield name is now done by --shieldName key instead of --scName.
+* Setting up the Muon shield geometry by ROOT files is completely replaced with the temporary solution of dict in the `geometry/geometry_config.py`.
+* Set up of the shield name is now done using the `--shieldName` flag instead of `--scName`.
 
 ### Removed
 

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -56,8 +56,8 @@ if "muShieldWithCobaltMagnet" not in globals():
     muShieldWithCobaltMagnet = 0
 if "SC_mag" not in globals():
     SC_mag = False
-if "scName" not in globals():
-    scName = None
+if "shieldName" not in globals():
+    shieldName = None
 if "DecayVolumeMedium" not in globals():
     DecayVolumeMedium = "vacuums"
 if "SND" not in globals():
@@ -69,7 +69,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.SND = SND
 
     c.SC_mag = SC_mag
-    c.scName = scName
+    c.shieldName = shieldName
     # global muShieldDesign, targetOpt, strawDesign, Yheight
     c.Yheight = Yheight*u.m
     # decision by the SP
@@ -315,16 +315,19 @@ with ConfigRegistry.register_config("basic") as c:
         c.muShield.half_Y_max = 317 * u.cm
     elif muShieldDesign == 8:
         if not SC_mag:
-            assert muShieldGeo
-            c.muShieldGeo = muShieldGeo
-            print("Load geo")
-            f = r.TFile.Open(muShieldGeo)
-            params = r.TVectorD()
-            params.Read('params')
-            f.Close()
+            # assert muShieldGeo
+            # c.muShieldGeo = muShieldGeo
+            # print("Load geo")
+            # f = r.TFile.Open(muShieldGeo)
+            # params = r.TVectorD()
+            # params.Read('params')
+            # f.Close()
+            assert shieldName
+            params = shield_db[shieldName]
+            c.muShield.params = params
         else:
-            assert scName
-            params = shield_db[scName]
+            assert shieldName
+            params = shield_db[shieldName]
             c.muShield.params = params
         c.muShield.dZ1 = 0.35*u.m + zGap
         c.muShield.dZ2 = 2.26*u.m + zGap

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -314,21 +314,9 @@ with ConfigRegistry.register_config("basic") as c:
         c.muShield.half_X_max = 179 * u.cm
         c.muShield.half_Y_max = 317 * u.cm
     elif muShieldDesign == 8:
-        if not SC_mag:
-            # assert muShieldGeo
-            # c.muShieldGeo = muShieldGeo
-            # print("Load geo")
-            # f = r.TFile.Open(muShieldGeo)
-            # params = r.TVectorD()
-            # params.Read('params')
-            # f.Close()
-            assert shieldName
-            params = shield_db[shieldName]
-            c.muShield.params = params
-        else:
-            assert shieldName
-            params = shield_db[shieldName]
-            c.muShield.params = params
+        assert shieldName
+        params = shield_db[shieldName]
+        c.muShield.params = params
         c.muShield.dZ1 = 0.35*u.m + zGap
         c.muShield.dZ2 = 2.26*u.m + zGap
         c.muShield.dZ3 = params[2]

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -203,7 +203,6 @@ if (HNL and options.RPVSUSY) or (HNL and options.DarkPhoton) or (options.DarkPho
 
 if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile:
   inputFile = "/eos/experiment/ship/data/GenieEvents/genie-nu_mu.root"
-            "/eos/experiment/ship/data/GenieEvents/genie-nu_mu_bar.root"
 if simEngine == "muonDIS" and defaultInputFile:
   print('input file required if simEngine = muonDIS')
   print(" for example -f  /eos/experiment/ship/data/muonDIS/muonDis_1.root")

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -131,7 +131,7 @@ parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajecto
 parser.add_argument("--stepMuonShield", dest="muShieldStepGeo", help="activate steps geometry for the muon shield", required=False, action="store_true", default=False)
 parser.add_argument("--coMuonShield", dest="muShieldWithCobaltMagnet", help="replace one of the magnets in the shield with 2.2T cobalt one, downscales other fields, works only for muShieldDesign >2", required=False, type=int, default=0)
 parser.add_argument("--noSC", dest="SC_mag", help="Deactivate SC muon shield. Configuration: 1 SC magnet (3*B_warm) + 3 warm magnets with inverted fields", action='store_false')
-parser.add_argument("--scName", help="The name of the SC shield in the database", default="sc_v6")
+parser.add_argument("--shieldName", help="The name of the SC shield in the database. SC default: sc_v6, Warm default: combi", default="sc_v6")
 parser.add_argument("--MesonMother",   dest="MM",  help="Choose DP production meson source", required=False,  default=True)
 parser.add_argument("--debug",  help="1: print weights and field 2: make overlap check", required=False, default=0, type=int, choices=range(0,3))
 parser.add_argument(
@@ -201,8 +201,8 @@ if (HNL and options.RPVSUSY) or (HNL and options.DarkPhoton) or (options.DarkPho
  print("cannot have HNL and SUSY or DP at the same time, abort")
  sys.exit(2)
 
-if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile:
-  inputFile = "/eos/experiment/ship/data/GenieEvents/genie-nu_mu.root"
+# if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile:
+#   inputFile = "/eos/experiment/ship/data/GenieEvents/genie-nu_mu.root"
             # "/eos/experiment/ship/data/GenieEvents/genie-nu_mu_bar.root"
 if simEngine == "muonDIS" and defaultInputFile:
   print('input file required if simEngine = muonDIS')
@@ -233,7 +233,7 @@ ship_geo = ConfigRegistry.loadpy(
      muShieldStepGeo=options.muShieldStepGeo,
      muShieldWithCobaltMagnet=options.muShieldWithCobaltMagnet,
      SC_mag=options.SC_mag,
-     scName=options.scName,
+     shieldName=options.shieldName,
      DecayVolumeMedium=options.decayVolMed,
      SND=options.SND,
 )

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -201,9 +201,9 @@ if (HNL and options.RPVSUSY) or (HNL and options.DarkPhoton) or (options.DarkPho
  print("cannot have HNL and SUSY or DP at the same time, abort")
  sys.exit(2)
 
-# if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile:
-#   inputFile = "/eos/experiment/ship/data/GenieEvents/genie-nu_mu.root"
-            # "/eos/experiment/ship/data/GenieEvents/genie-nu_mu_bar.root"
+if (simEngine == "Genie" or simEngine == "nuRadiography") and defaultInputFile:
+  inputFile = "/eos/experiment/ship/data/GenieEvents/genie-nu_mu.root"
+            "/eos/experiment/ship/data/GenieEvents/genie-nu_mu_bar.root"
 if simEngine == "muonDIS" and defaultInputFile:
   print('input file required if simEngine = muonDIS')
   print(" for example -f  /eos/experiment/ship/data/muonDIS/muonDis_1.root")

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -29,7 +29,7 @@ class ShipMuonShield : public FairModule
    ShipMuonShield(TString geofile, Double_t floor=500, const Int_t withCoMagnet=0, const Bool_t StepGeo=false,
    const Bool_t WithConstAbsorberField=true, const Bool_t WithConstShieldField=true);
    ShipMuonShield(TVectorT<Double_t> in_params,
-                  Double_t floor, const Int_t withCoMagnet, const Bool_t StepGeo, const Bool_t WithConstAbsorberField, const Bool_t WithConstShieldField);
+                  Double_t floor, const Int_t withCoMagnet, const Bool_t StepGeo, const Bool_t WithConstAbsorberField, const Bool_t WithConstShieldField, const Bool_t SC_key);
    ShipMuonShield();
    virtual ~ShipMuonShield();
    void ConstructGeometry();

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -156,7 +156,7 @@ def configure(run, ship_geo):
         nuTauTargetDesign=ship_geo.nuTauTargetDesign,
         muShieldGeo=ship_geo.muShieldGeo,
         SC_mag=ship_geo.SC_mag,
-        scName=ship_geo.scName,
+        shieldName=ship_geo.shieldName,
     )
     # -----Create media-------------------------------------------------
     run.SetMaterials("media.geo")  # Materials
@@ -229,27 +229,18 @@ def configure(run, ship_geo):
             ship_geo.muShield.WithConstField,
         )
     elif ship_geo.muShieldDesign == 8:
-        if not ship_geo.SC_mag:
-            MuonShield = ROOT.ShipMuonShield(
-                ship_geo.muShieldGeo,
-                ship_geo.cave.floorHeightMuonShield,
-                ship_geo.muShieldWithCobaltMagnet,
-                ship_geo.muShieldStepGeo,
-                ship_geo.hadronAbsorber.WithConstField,
-                ship_geo.muShield.WithConstField,
-            )
-        else:
-            in_params = ROOT.TVectorD(
-                len(ship_geo.muShield.params), array("d", ship_geo.muShield.params)
-            )
-            MuonShield = ROOT.ShipMuonShield(
-                in_params,
-                ship_geo.cave.floorHeightMuonShield,
-                ship_geo.muShieldWithCobaltMagnet,
-                ship_geo.muShieldStepGeo,
-                ship_geo.hadronAbsorber.WithConstField,
-                ship_geo.muShield.WithConstField,
-            )
+        in_params = ROOT.TVectorD(
+            len(ship_geo.muShield.params), array("d", ship_geo.muShield.params)
+        )
+        MuonShield = ROOT.ShipMuonShield(
+            in_params,
+            ship_geo.cave.floorHeightMuonShield,
+            ship_geo.muShieldWithCobaltMagnet,
+            ship_geo.muShieldStepGeo,
+            ship_geo.hadronAbsorber.WithConstField,
+            ship_geo.muShield.WithConstField,
+            ship_geo.SC_mag
+        )
     detectorList.append(MuonShield)
 
     if not hasattr(ship_geo, "magnetDesign"):
@@ -884,7 +875,7 @@ def configure(run, ship_geo):
                 ship_geo.Yheight / 2.0 * u.m,
             )
         run.SetField(fMagField)
-    #
+
     exclusionList = []
     # exclusionList = ["Muon","Ecal","Hcal","Strawtubes","TargetTrackers","NuTauTarget","HighPrecisionTrackers",\
     #                 "Veto","Magnet","MuonShield","TargetStation","NuTauMudet","EmuMagnet", "TimeDet", "UpstreamTagger"]


### PR DESCRIPTION
Here is the stable version in which the usage of ROOT file for setting the dinensions of Muon Shield is removed (at least now it takes info directly from the geometry_config.py script). Several things to mention and to discuss:

1. During the simulation the geometry registration is conducted twice for some reason, which seems very redundant. First time in run_simScript.py and then in shipDet_conf.py. If there is no hidden reason, I can remove these entities.
2. Reading the Muon Shield dimensions from the dictionary in geometry_config.py script doesn't look perfect since the geometry of Muon Shield is not fixed yet. During optimization me and Evgeny were using json files for storing different geometries, would be nice to repeat this implementation now. Or maybe use yaml file since the info about decay volume is stored in yaml files and it would be more consistent.
3. Current warm version overlaps with the floor. Floor can be excavated though, we need a permission to make so, don't we?


<img width="1110" alt="Screenshot 2025-02-07 at 16 29 23" src="https://github.com/user-attachments/assets/e9a1b4e2-25bf-4c5a-89c7-dcdcf06dd8db" />
