### PR TITLE
fix: Don't use TFile's deprecated attribute syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ it in future.
 * fix: autoload Pythia8 instead of manually loading in run_simScript.py
 * fix(geometry): fix typo of "vacuums" for strawtubes medium
 * fix(reco): Fix segmentation fault due to dummy containers (#453, #519)
+* fix: don't use TFile's deprecated attribute syntax
 
 ### Changed
 

--- a/examples/analysis_example.py
+++ b/examples/analysis_example.py
@@ -15,7 +15,7 @@ def main():
     options = parser.parse_args()
 
     f = ROOT.TFile.Open(options.path + "/ship.conical.Pythia8-TGeant4_rec.root", "read")
-    tree = f.cbmsim
+    tree = f.Get("cbmsim")
 
     geo_file = ROOT.TFile.Open(
         options.path + "/geofile_full.conical.Pythia8-TGeant4.root", "read"

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -34,7 +34,7 @@ if not options.inputFile.find(',')<0 :
     sTree.AddFile(x)
 else:
   f = ROOT.TFile(options.inputFile)
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
 
 # try to figure out which ecal geo to load
 if not options.geoFile:
@@ -64,7 +64,7 @@ if hasattr(ShipGeo.Bfield,"fieldMap"):
 else:
   print("no fieldmap given, geofile too old, not anymore support")
   exit(-1)
-sGeo   = fgeo.FAIRGeom
+sGeo = fgeo.Get("FAIRGeom")
 geoMat =  ROOT.genfit.TGeoMaterialInterface()
 ROOT.genfit.MaterialEffects.getInstance().init(geoMat)
 bfield = ROOT.genfit.FairShipFields()

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -104,7 +104,7 @@ rtdb = run.GetRuntimeDb()
 # -----Create geometry----------------------------------------------
 modules = shipDet_conf.configure(run,ShipGeo)
 # run.Init()
-fgeo.FAIRGeom
+fgeo.Get("FAIRGeom")
 import geomGeant4
 
 if hasattr(ShipGeo.Bfield,"fieldMap"):

--- a/macro/getGeoInformation.py
+++ b/macro/getGeoInformation.py
@@ -99,7 +99,7 @@ parser.add_argument("-X", "--moreInfo", help="Print weight and capacity", action
 options = parser.parse_args()
 fname = options.geometry
 fgeom = ROOT.TFile.Open(fname)
-fGeo = fgeom.FAIRGeom
+fGeo = fgeom.Get("FAIRGeom")
 top = fGeo.GetTopVolume()
 
 

--- a/macro/inspectGeant4Geo.py
+++ b/macro/inspectGeant4Geo.py
@@ -9,7 +9,7 @@ if len(sys.argv) > 1:
     fname = sys.argv[1]
 
 fgeo = ROOT.TFile(fname)
-sGeo = fgeo.FAIRGeom
+sGeo = fgeo.Get("FAIRGeom")
 import shipDet_conf
 run = ROOT.FairRunSim()
 upkl = Unpickler(fgeo)

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -620,7 +620,7 @@ if simEngine == "MuonBack":
     nm = ff.GetName().split('/')
     if nm[len(nm)-1] == check: fin = ff
  if not fin: fin   = ROOT.TFile.Open(outFile)
- t     = fin.cbmsim
+ t = fin.Get("cbmsim")
  fout  = ROOT.TFile(tmpFile,'recreate')
  fSink = ROOT.FairRootFileSink(fout)
 

--- a/muonShieldOptimization/ana_ShipMuon.py
+++ b/muonShieldOptimization/ana_ShipMuon.py
@@ -330,7 +330,7 @@ if prefixes[0]!='': testdir = path+prefixes[0]+'1'
 for f in os.listdir(testdir):
   if not f.find("geofile_full")<0:
      fgeo = ROOT.TFile(testdir+'/'+f)
-     sGeo = fgeo.FAIRGeom
+     sGeo = fgeo.Get("FAIRGeom")
      inputFile = f.replace("geofile_full","ship")
      break
 # try to extract from input file name
@@ -623,7 +623,7 @@ def BigEventLoop():
 
 def executeOneFile(fn,output=None,pid=None):
   f     = ROOT.TFile.Open(fn)
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   nEvents = sTree.GetEntries()
   if sTree.GetBranch("GeoTracks"): sTree.SetBranchStatus("GeoTracks",0)
   sTree.GetEntry(0)
@@ -814,7 +814,7 @@ def AnaEventLoop():
   if not f.FindObjectAny('cbmsim'):
    print('skip file ',f.GetName())
    continue
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   sTree.GetEvent(0)
   if sTree.GetBranch("GeoTracks"): sTree.SetBranchStatus("GeoTracks",0)
   nEvents = sTree.GetEntries()
@@ -852,7 +852,7 @@ def muDISntuple(fn):
   fout = ROOT.TFile('muDISVetoCounter.root','recreate')
   h['ntuple'] = ROOT.TNtuple("muons","muon flux VetoCounter","id:px:py:pz:x:y:z:w")
   f = ROOT.TFile(fn)
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   nEvents = sTree.GetEntries()
   for n in range(nEvents):
    sTree.GetEntry(n)
@@ -889,7 +889,7 @@ def analyzeConcrete():
   if not f.FindObjectAny('cbmsim'):
    print('skip file ',f.GetName())
    continue
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   nEvents = sTree.GetEntries()
   ROOT.gROOT.cd()
   for n in range(nEvents):
@@ -946,7 +946,7 @@ def rareEventEmulsion(fname = 'rareEmulsion.txt'):
   if not f.FindObjectAny('cbmsim'):
    print('skip file ',f.GetName())
    continue
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   sTree.GetEvent(0)
   if sTree.GetBranch("GeoTracks"): sTree.SetBranchStatus("GeoTracks",0)
   nEvents = sTree.GetEntries()
@@ -982,7 +982,7 @@ def extractRareEvents(single = None):
   if not f.FindObjectAny('cbmsim'):
    print('skip file ',f.GetName())
    continue
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   nEvents = sTree.GetEntries()
   raref = ROOT.TFile(fn.replace(".root","_rare.root"),"recreate")
   newTree = sTree.CloneTree(0)
@@ -1017,7 +1017,7 @@ def extractMuCloseByEvents(single = None):
   if not f.FindObjectAny('cbmsim'):
    print('skip file ',f.GetName())
    continue
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   nEvents = sTree.GetEntries()
   raref = ROOT.TFile(fn.replace(".root","_clby.root"),"recreate")
   newTree = sTree.CloneTree(0)
@@ -1097,7 +1097,7 @@ def debugGeoTracks():
      print(i,n,gt.GetFirstPoint()[2],gt.GetLastPoint()[2],gt.GetParticle().GetPdgCode(),gt.GetParticle().P())
      n+=1
 def eventsWithStrawPoints(i):
- sTree = fchain[i].cbmsim
+ sTree = fchain[i].Get("cbmsim")
  mom = ROOT.TVector3()
  for i in range(sTree.GetEntries()):
    sTree.GetEntry(i)
@@ -1112,7 +1112,7 @@ def eventsWithStrawPoints(i):
      mom.Print()
      print('-----------------------')
 def eventsWithEntryPoints(i):
- sTree = fchain[i].cbmsim
+ sTree = fchain[i].Get("cbmsim")
  mom = ROOT.TVector3()
  for i in range(sTree.GetEntries()):
    sTree.GetEntry(i)

--- a/muonShieldOptimization/compactingBackgroundProduction.py
+++ b/muonShieldOptimization/compactingBackgroundProduction.py
@@ -251,7 +251,7 @@ def compactify(charm):
 
 def makeHistos(rfile):
  f=ROOT.TFile.Open(rfile)
- sTree = f.cbmsim
+ sTree = f.Get("cbmsim")
  nTot = 0
  for k in f.GetListOfKeys():
   if k.GetName() == 'FileHeader':

--- a/muonShieldOptimization/extractMuonsAndUpdateWeight.py
+++ b/muonShieldOptimization/extractMuonsAndUpdateWeight.py
@@ -65,7 +65,7 @@ def PoT(f):
      xSecboost+=float(txt[i+1:].split(' ')[0])
  diMuboost=diMuboost/float(ncycles)
  xSecboost=xSecboost/float(ncycles)
- print("POT = ",nTot," number of events:",f.cbmsim.GetEntries(),' diMuboost=',diMuboost,' XsecBoost=',xSecboost)
+ print("POT = " ,nTot, " number of events:", f.Get("cbmsim").GetEntries(), ' diMuboost=', diMuboost, ' XsecBoost=', xSecboost)
  return nTot,diMuboost,xSecboost
 
 def TotStat():
@@ -80,7 +80,7 @@ def TotStat():
 def processFile(fin,noCharm=True):
     f   = ROOT.TFile.Open(os.environ['EOSSHIP']+path+fin)
     nPot,diMuboost,xSecboost  = PoT(f)
-    sTree = f.cbmsim
+    sTree = f.Get("cbmsim")
     outFile = fin.replace(".root","_mu.root")
     fmu = ROOT.TFile(outFile,"recreate")
     newTree = sTree.CloneTree(0)
@@ -182,7 +182,7 @@ def mergeMbiasAndCharm(flavour="charm"):
  Nall = 0
  for x in allFiles:
   f=ROOT.TFile.Open(pp+allFiles[x])
-  nEntries[x]=f.cbmsim.GetEntries()
+  nEntries[x]=f.Get("cbmsim").GetEntries()
   Nall += nEntries[x]
  nCharm = 0
  nDone  = 0
@@ -196,7 +196,7 @@ def mergeMbiasAndCharm(flavour="charm"):
   os.system('hadd -f tmp.root '+ allFiles[flavour] + ' '+ allFiles[k] )
   os.system('rm '+allFiles[k])
   f = ROOT.TFile('tmp.root')
-  sTree = f.cbmsim
+  sTree = f.Get("cbmsim")
   sTree.LoadBaskets(30000000000)
   if flavour=="charm":
    outFile = tmp.replace('cXX','withCharm'+k)
@@ -250,7 +250,7 @@ def mergeMbiasAndCharm(flavour="charm"):
 
 def testRatio(fname):
  f=ROOT.TFile.Open(os.environ['EOSSHIP']+path+fname)
- sTree = f.cbmsim
+ sTree = f.Get("cbmsim")
  Nall = sTree.GetEntries()
  charm = 0
  for n in range(Nall):

--- a/muonShieldOptimization/extractNeutrinosAndUpdateWeight.py
+++ b/muonShieldOptimization/extractNeutrinosAndUpdateWeight.py
@@ -47,7 +47,7 @@ for idnu in range(12,17,2):
 def processFile(fin,noCharm=True):
     f   = ROOT.TFile.Open(os.environ['EOSSHIP']+path+fin)
     print("opened file ",fin)
-    sTree = f.cbmsim
+    sTree = f.Get("cbmsim")
     for n in range(sTree.GetEntries()):
       sTree.GetEntry(n)
       for v in sTree.vetoPoint:

--- a/muonShieldOptimization/radio.py
+++ b/muonShieldOptimization/radio.py
@@ -7,7 +7,7 @@ myHist2 = ROOT.TH3F('myh2','radio',500,-3000,3000,100,-300,300,100,-600,600)
 
 for x in fs:
   fl = ROOT.TFile(path+x)
-  sTree=fl.cbmsim
+  sTree = fl.Get("cbmsim")
   ROOT.gROOT.cd()
   for n in range(sTree.GetEntries()):
     rc=sTree.GetEvent(n)

--- a/muonShieldOptimization/run_fixedTarget.py
+++ b/muonShieldOptimization/run_fixedTarget.py
@@ -293,7 +293,7 @@ if nt:
  tnt.Write()
  tf.Close()
 
-t     = fin.cbmsim
+t = fin.Get("cbmsim")
 fout  = ROOT.TFile(tmpFile,'recreate' )
 sTree = t.CloneTree(0)
 nEvents = 0

--- a/muonShieldOptimization/study_GammaConv.py
+++ b/muonShieldOptimization/study_GammaConv.py
@@ -128,7 +128,7 @@ f=ROOT.gROOT.GetListOfFiles()[0]
 h={}
 ut.bookHist(h,'muons','muon mult',10,-0.5,9.5)
 ut.bookHist(h,'electrons','e mult',10,-0.5,9.5)
-sTree = f.cbmsim
+sTree = f.Get("cbmsim")
 for n in range(sTree.GetEntries()):
  rc = sTree.GetEvent(n)
  nMu = 0

--- a/muonShieldOptimization/study_muEloss.py
+++ b/muonShieldOptimization/study_muEloss.py
@@ -128,7 +128,7 @@ def makePlot(f,book=True):
   ut.bookHist(h,'theta','scattering angle '+str(momentum)+'GeV/c;{Theta}(rad)',500,0,maxTheta)
   ut.bookHist(h,'eloss','rel energy loss as function of momentum GeV/c',100,0,maxTheta,10000,0.,1.)
   ut.bookHist(h,'elossRaw','energy loss as function of momentum GeV/c',100,0,maxTheta, 10000,0.,100.)
- sTree = f.cbmsim
+ sTree = f.Get("cbmsim")
  for n in range(sTree.GetEntries()):
   rc = sTree.GetEvent(n)
   Ein  = sTree.MCTrack[0].GetEnergy()

--- a/muonShieldOptimization/study_muMSC.py
+++ b/muonShieldOptimization/study_muMSC.py
@@ -113,7 +113,7 @@ import rootUtils as ut
 f=ROOT.gROOT.GetListOfFiles()[0]
 h={}
 ut.bookHist(h,'theta','scattering angle '+str(momentum)+'GeV/c;{Theta}(rad)',500,0,maxTheta)
-sTree = f.cbmsim
+sTree = f.Get("cbmsim")
 for n in range(sTree.GetEntries()):
  rc = sTree.GetEvent(n)
  for aHit in sTree.vetoPoint:

--- a/muonShieldOptimization/study_thinTarget.py
+++ b/muonShieldOptimization/study_thinTarget.py
@@ -105,7 +105,7 @@ import rootUtils as ut
 f=ROOT.TFile('TLV.root')
 pdg = ROOT.TDatabasePDG.Instance()
 h={}
-sTree = f.cbmsim
+sTree = f.Get("cbmsim")
 ut.bookHist(h,'Ekin','Ekin of particles in sens plane',400000,0.,400)
 ut.bookHist(h,'EkinLow','Ekin of particles in sens plane',1000,0.,0.001)
 for n in range(sTree.GetEntries()):

--- a/python/experimental/analysis_toolkit.py
+++ b/python/experimental/analysis_toolkit.py
@@ -15,7 +15,7 @@ class selection_check:
 
     def __init__(self, geo_file):
         """Initialize the selection_check class with geometry and configuration."""
-        self.geometry_manager = geo_file.FAIRGeom
+        self.geometry_manager = geo_file.Get("FAIRGeom")
         unpickler = Unpickler(geo_file)
         self.ship_geo = unpickler.load("ShipGeo")
 

--- a/python/rootUtils.py
+++ b/python/rootUtils.py
@@ -142,7 +142,7 @@ def container_sizes(sTree,perEvent=False):
 
 def stripOffBranches(fout):
     f = TFile(fout)
-    sTree = f.cbmsim
+    sTree = f.Get("cbmsim")
     nEvents = sTree.GetEntries()
     strip = False
     oldTargetClass = False
@@ -174,7 +174,7 @@ def stripOffBranches(fout):
     recf.Close()
     # should do some sanity checks before deleting old file
     f = TFile(sFile)
-    sTree = f.cbmsim
+    sTree = f.Get("cbmsim")
     if nEvents == sTree.GetEntries(): print("looks ok, could be deleted",os.path.abspath('.'))
     else:  print("stripping failed, keep old file",os.path.abspath('.'))
     # os.system('mv '+sFile +' '+fout)

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -13,13 +13,13 @@ class ShipDigiReco:
  " convert FairSHiP MC hits / digitized hits to measurements"
  def __init__(self,fout,fgeo):
   self.fn = ROOT.TFile.Open(fout,'update')
-  self.sTree     = self.fn.cbmsim
+  self.sTree     = self.fn.Get("cbmsim")
   if self.sTree.GetBranch("FitTracks"):
     print("remove RECO branches and rerun reconstruction")
     self.fn.Close()
     # make a new file without reco branches
     f = ROOT.TFile(fout)
-    sTree = f.cbmsim
+    sTree = f.Get("cbmsim")
     if sTree.GetBranch("FitTracks"): sTree.SetBranchStatus("FitTracks",0)
     if sTree.GetBranch("goodTracks"): sTree.SetBranchStatus("goodTracks",0)
     if sTree.GetBranch("VetoHitOnTrack"): sTree.SetBranchStatus("VetoHitOnTrack",0)
@@ -47,7 +47,7 @@ class ShipDigiReco:
     recf.Close()
     os.system('cp '+rawFile +' '+fout)
     self.fn = ROOT.TFile(fout,'update')
-    self.sTree     = self.fn.cbmsim
+    self.sTree = self.fn.Get("cbmsim")
 #
   if self.sTree.GetBranch("GeoTracks"): self.sTree.SetBranchStatus("GeoTracks",0)
 # prepare for output
@@ -970,7 +970,6 @@ class ShipDigiReco:
       error = "Fit not converged"
       ut.reportError(error)
     nmeas = fitStatus.getNdf()
-    global_variables.h['nmeas'].Fill(nmeas)
     if nmeas > 0:
       chi2 = fitStatus.getChi2() / nmeas
       global_variables.h['chi2'].Fill(chi2)

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -47,7 +47,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
         print("An error with opening the ship geo file.")
         raise
 
-    sGeo = fgeo.FAIRGeom
+    sGeo = fgeo.Get("FAIRGeom")
 
     # Prepare ShipGeo dictionary
     if not fgeo.FindKey('ShipGeo'):
@@ -96,7 +96,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
     else:
       print("no fieldmap given, geofile too old, not anymore support")
       exit(-1)
-    sGeo   = fgeo.FAIRGeom
+    sGeo = fgeo.Get("FAIRGeom")
     geoMat =  ROOT.genfit.TGeoMaterialInterface()
     ROOT.genfit.MaterialEffects.getInstance().init(geoMat)
     bfield = ROOT.genfit.FairShipFields()
@@ -114,7 +114,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method):
         print("An error with opening the input data file.")
         raise
 
-    sTree = fn.cbmsim
+    sTree = fn.Get("cbmsim")
     sTree.Write()
 
     ############################################# Create hists #########################################################


### PR DESCRIPTION
Use the item-getting syntax instead.
Fixed for FAIRGeom and cbmsim. Other uses might have escaped notice. Fixes #644.