### PR TITLE
Update muon shield to support latest Zürich designs, remove old code and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ it in future.
 * Added new parameters to muon shield to support configurations from current optimisation campaign
 * Added event_inspector class to experimental analysis_toolkit to streamline usage of helper functions; Added dump_event() as a start.
 * Add (optional) MgB2 field map
+* ShipBFieldMap: Added LOG info and fatal
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ it in future.
 * **Corrections in MuonDIS simulation**
   The DIS interactions are now time-shifted to be consistent with the original incoming muon. Additionally, tracks from soft interactions of the original muon along with the muon's veto response are preserved (in muonDis.root) and included up to the DIS interaction point. To be noted that the muon veto points are manually added using add_muonresponse.py, which modifies the simulation file. This replaces the old method of "backward-travelling muon" to generate the incoming muon's veto response. All MuonDIS simulation scripts have been updated and consolidated within FairShip/muonDIS, ensuring consistency for new productions.
 * Added a custom CrossSection branch to the simulation file to save the DIS cross sections from muonDIS.
+* Added new warm muon shield `warm_opt` in geometry_config
+* Added new parameters to muon shield to support configurations from current optimisation campaign
 * Added event_inspector class to experimental analysis_toolkit to streamline usage of helper functions; Added dump_event() as a start.
 * Add (optional) MgB2 field map
 
@@ -42,6 +44,7 @@ it in future.
 * Set up of the shield name is now done using the `--shieldName` flag instead of `--scName`.
 * Allow using standalone TPythia for use with ROOT 6.32+
 * Use git-lfs to track ROOT files
+* shipDet_conf behaviour no longer depends on the muon shield version.
 * feat(digi): Use STL vectors for SST digitisation
 * feat(digi): Use STL vectors for SBT digitisation
 * Change max x of stereo hits to match straw length
@@ -54,6 +57,11 @@ it in future.
 
 * fix: Remove unused, unrunnable shipPatRec_prev.py
 * feat(geometry): Dropped support for old geometries without DecayVolumeMedium explicitly set(pre 24.11 release case).
+* MS: Removed old options 7, 9, 10
+* MS: Removed cobalt option
+* MS: Removed stepGeo option
+* MS: Removed the flag constant field in Absorber (HS) -> fixed to 1.7 T
+* MS: run_simScript.py: The --noSC flag is removed, whether or not a configuration is SC hybrid depends on the config selected. Configurations are defined in the shield_db in geometry_config.py
 * Removed old nuTauTargetDesign configurations from 0 to 2. Currently supported: 3 (2018, magnetized target) and 4 (Current, not magnetized target and spectrometer)
 * build(field,nutaudet): remove unnecessary ROOT_INCLUDE_DIR include
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ it in future.
 * fix: don't use TFile's deprecated attribute syntax
 * fix(digi): Fix logic of SST digitisation (#662)
 * Fix double append of recognized stracks
+* fix(ShieldUtils.py): The fieldmap offset was calibrated with the old version of MS
 
 ### Changed
 

--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -9,6 +9,8 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#include "FairLogger.h"   /// for FairLogger, MESSAGE_ORIGIN
+
 #include <fstream>
 #include <iostream>
 
@@ -231,8 +233,8 @@ void ShipBFieldMap::initialise()
 void ShipBFieldMap::readMapFile()
 {
 
-    std::cout<<"ShipBFieldMap::readMapFile() creating field "<<this->GetName()
-	     <<" using file "<<mapFileName_<<std::endl;
+    LOG(INFO) << "ShipBFieldMap::readMapFile() creating field " << this->GetName()
+	     << " using file " << mapFileName_;
 
     // Check to see if we have a ROOT file
     if (mapFileName_.find(".root") != std::string::npos) {
@@ -252,15 +254,15 @@ void ShipBFieldMap::readRootFile() {
     TFile* theFile = TFile::Open(mapFileName_.c_str());
 
     if (!theFile) {
-	std::cout<<"ShipBFieldMap: could not find the file "<<mapFileName_<<std::endl;
-	return;
+	    LOG(FATAL) << "ShipBFieldMap: could not find the file " << mapFileName_;
+
     }
 
     // Coordinate ranges
     TTree* rTree = dynamic_cast<TTree*>(theFile->Get("Range"));
     if (!rTree) {
-	std::cout<<"ShipBFieldMap: could not find Range tree in "<<mapFileName_<<std::endl;
-	return;
+	    LOG(FATAL) << "ShipBFieldMap: could not find Range tree in " << mapFileName_;
+
     }
 
     rTree->SetBranchAddress("xMin", &xMin_);
@@ -286,8 +288,8 @@ void ShipBFieldMap::readRootFile() {
 
 	TTree* dTree = dynamic_cast<TTree*>(theFile->Get("Data"));
 	if (!dTree) {
-	    std::cout<<"ShipBFieldMap: could not find Data tree in "<<mapFileName_<<std::endl;
-	    return;
+	    LOG(FATAL) << "ShipBFieldMap: could not find Data tree in " << mapFileName_;
+
 	}
 
 	Float_t Bx, By, Bz;
@@ -303,7 +305,7 @@ void ShipBFieldMap::readRootFile() {
 
 	Int_t nEntries = dTree->GetEntries();
 	if (nEntries != N_) {
-	    std::cout<<"Expected "<<N_<<" field map entries but found "<<nEntries<<std::endl;
+	    LOG(FATAL) << "Expected " << N_ << " field map entries but found " << nEntries;
 	    nEntries = 0;
 	}
 
@@ -335,6 +337,10 @@ void ShipBFieldMap::readRootFile() {
 void ShipBFieldMap::readTextFile() {
 
     std::ifstream getData(mapFileName_.c_str());
+
+    if (!getData.is_open()) {
+        LOG(FATAL) << "Error: Cannot open magnetic field map file: " << mapFileName_;
+    }
 
     std::string tmpString("");
 
@@ -417,16 +423,14 @@ void ShipBFieldMap::setLimits() {
 
     N_ = Nx_*Ny_*Nz_;
 
-    std::cout<<"x limits: "<<xMin_<<", "<<xMax_<<", dx = "<<dx_<<std::endl;
-    std::cout<<"y limits: "<<yMin_<<", "<<yMax_<<", dy = "<<dy_<<std::endl;
-    std::cout<<"z limits: "<<zMin_<<", "<<zMax_<<", dz = "<<dz_<<std::endl;
+    LOG(INFO) << "x limits: " << xMin_ << ", " << xMax_ << ", dx = " << dx_;
+    LOG(INFO) << "y limits: " << yMin_ << ", " << yMax_ << ", dy = " << dy_;
+    LOG(INFO) << "z limits: " << zMin_ << ", " << zMax_ << ", dz = " << dz_;
 
-    std::cout<<"Offsets: x = "<<xOffset_<<", y = "<<yOffset_<<", z = "<<zOffset_<<std::endl;
-    std::cout<<"Angles : phi = "<<phi_<<", theta = "<<theta_<<", psi = "<<psi_<<std::endl;
+    LOG(INFO) << "Offsets: x = " << xOffset_ << ", y = " << yOffset_ << ", z = " << zOffset_;
+    LOG(INFO) << "Angles : phi = " << phi_ << ", theta = " << theta_ << ", psi = " << psi_;
 
-    std::cout<<"Total number of bins = "<<N_
-	     <<"; Nx = "<<Nx_<<", Ny = "<<Ny_<<", Nz = "<<Nz_<<std::endl;
-
+    LOG(INFO) << "Total number of bins = " << N_ << "; Nx = " << Nx_ << ", Ny = " << Ny_ << ", Nz = " << Nz_;
 }
 
 

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -10,15 +10,37 @@ from ShipGeoConfig import AttrDict, ConfigRegistry
 # targetOpt      = 5  # 0=solid   >0 sliced, 5: 5 pieces of tungsten, 4 air slits, 17: molybdenum tungsten interleaved with H20
 # strawOpt       = 0  # 0=simplistic tracking stations defined in veto.cxx  1=detailed strawtube design 4=sophisticated straw tube design, horizontal wires (default) 10=2cm straw diameter for 2018 layout
 # tankDesign = 5 #  4=TP elliptical tank design, 5 = optimized conical rectangular design, 6=5 without segment-1
+
+# Here you can select the MS geometry, if the MS design is using SC magnet change the hybrid to True
+# The first row is the length of the magnets
+# The other rows are the transverse dimensions of the magnets:  dXIn[i], dXOut[i] , dYIn[i], dYOut[i], gapIn[i], gapOut[i].
 shield_db = {
-    'combi': [ 70.  , 170.  , 208.  , 207.  , 281.  , 172.82, 212.54, 168.64,
-    40.  ,  40.  , 150.  , 150.  ,   2.  ,   2.  ,  80.  ,  80.  ,
-    150.  , 150.  ,   2.  ,   2.  ,  72.  ,  51.  ,  29.  ,  46.  ,
-    10.  ,   7.  ,  54.  ,  38.  ,  46.  , 192.  ,  14.  ,   9.  ,
-    10.  ,  31.  ,  35.  ,  31.  ,  51.  ,  11.  ,   3.  ,  32.  ,
-    54.  ,  24.  ,   8.  ,   8.  ,  22.  ,  32.  , 209.  ,  35.  ,
-    8.  ,  13.  ,  33.  ,  77.  ,  85.  , 241.  ,   9.  ,  26.  ],
-    'sc_v6': [70,170,0,353.078,125.083,184.834,150.193,186.812,40,40,150,150,2,2,80,80,150,150,2,2,72,51,29,46,10,7,45.6888,45.6888,22.1839,22.1839,27.0063,16.2448,10,31,35,31,51,11,24.7961,48.7639,8,104.732,15.7991,16.7793,3,100,192,192,2,4.8004,3,100,8,172.729,46.8285,2]
+    "warm_opt": {
+        "hybrid": False,
+        "params": [
+            231.0, 208.0, 207.0, 281.0, 172.82, 212.54, 168.64,
+            50.0, 50.0, 119.0, 119.0, 2.0, 2.0, 1.0, 1.0, 50.0, 50.0, 0.0, 0.0, 0.0,
+            72.0, 51.0, 29.0, 46.0, 10.0, 7.0,  1.0, 1.0,72.0, 51.0, 0.0, 0.0, 0.0,
+            54.0, 38.0, 46.0, 122.0, 14.0, 9.0,  1.0, 1.0,54.0, 38.0, 0.0, 0.0, 0.0,
+            10.0, 31.0, 35.0, 31.0, 51.0, 11.0, 1.0, 1.0,0.0, 31.0, 0.0, 0.0, 0.0,
+            3.0, 32.0, 54.0, 24.0, 8.0, 8.0, 3.0, 1.0, 1.0,32.0,  0.0, 0.0, 0.0,
+            22.0, 32.0, 209.0, 35.0, 8.0, 13.0, 1.0, 1.0,22.0, 32.0, 0.0, 0.0, 0.0,
+            33.0, 77.0, 85.0, 241.0, 9.0, 26.0, 1.0, 1.0,33.0, 77.0, 0.0, 0.0, 0.0,
+        ]
+    },
+    "sc_v6": {
+        "hybrid": True,
+        "params": [
+            231.0, 0.0, 353.1, 125.1, 184.8, 150.2, 186.8,
+            50.0, 50.0, 119.0, 119.0, 2.0, 2.0, 1.0, 1.0, 50.0, 50.0, 0.0, 0.0, 0.0,
+            72.0, 51.0, 29.0, 46.0, 10.0, 7.0, 1.0, 1.0, 72.0, 51.0, 0.0, 0.0, 0.0,
+            45.7, 45.7, 22.2, 22.2, 27.0, 16.3, 1.0, 1.0, 45.7, 45.7, 0.0, 0.0, 0.0,
+            10.0, 31.0, 35.0, 31.0, 51.0, 11.0, 1.0, 1.0, 10.0, 31.0, 0.0, 0.0, 0.0,
+            24.8, 48.8, 8.0, 104.8, 15.8, 16.8, 1.0, 1.0, 24.8, 48.8, 0.0, 0.0, 0.0,
+            3.0, 100.0, 192.0, 192.0, 2.0, 4.8, 1.0, 1.0, 3.0, 100.0, 0.0, 0.0, 0.0,
+            3.0, 100.0, 8.0, 172.7, 46.8, 2.0, 1.0, 1.0, 3.0, 100.0, 0.0, 0.0, 0.0,
+        ]
+    }
 }
 if "muShieldDesign" not in globals():
     muShieldDesign = 7
@@ -48,12 +70,6 @@ if "HcalGeoFile" not in globals():
         HcalGeoFile = "hcal_rect.geo"
     else:
         HcalGeoFile = "hcal.geo"
-if "muShieldStepGeo" not in globals():
-    muShieldStepGeo = False
-if "muShieldWithCobaltMagnet" not in globals():
-    muShieldWithCobaltMagnet = 0
-if "SC_mag" not in globals():
-    SC_mag = False
 if "shieldName" not in globals():
     shieldName = None
 if "SND" not in globals():
@@ -64,8 +80,12 @@ with ConfigRegistry.register_config("basic") as c:
     c.DecayVolumeMedium = DecayVolumeMedium
     c.SND = SND
 
-    c.SC_mag = SC_mag
+    if not shieldName:
+        raise ValueError("shieldName must not be empty!")
+
     c.shieldName = shieldName
+    c.SC_mag = shield_db[shieldName]['hybrid']
+
     # global muShieldDesign, targetOpt, strawDesign, Yheight
     c.Yheight = Yheight*u.m
     # decision by the SP
@@ -281,70 +301,28 @@ with ConfigRegistry.register_config("basic") as c:
     c.muShield.LE = 7 * u.m     # - 0.5 m air - Goliath: 4.5 m - 0.5 m air - nu-tau mu-det: 3 m - 0.5 m air. finally 10m asked by Giovanni
     c.muShield.dZ0 = 1 * u.m
 
-    c.muShieldStepGeo = muShieldStepGeo
-    c.muShieldWithCobaltMagnet = muShieldWithCobaltMagnet
 
     # zGap to compensate automatic shortening of magnets
     zGap = 0.05 * u.m  # halflengh of gap
-    if muShieldDesign == 7:
-        c.muShield.Field = 1.8  # Tesla
-        c.muShield.dZ1 = 0.7 * u.m + zGap
-        c.muShield.dZ2 = 1.7 * u.m + zGap
-        c.muShield.dZ3 = 2.0*u.m + zGap
-        c.muShield.dZ4 = 2.0*u.m + zGap
-        c.muShield.dZ5 = 2.75*u.m + zGap
-        c.muShield.dZ6 = 2.4*u.m + zGap
-        c.muShield.dZ7 = 3.0*u.m + zGap
-        c.muShield.dZ8 = 2.35*u.m + zGap
-        c.muShield.dXgap = 0.*u.m
-    elif muShieldDesign == 9:
-        c.muShield.dZ1 = 0.35 * u.m + zGap
-        c.muShield.dZ2 = 2.26 * u.m + zGap
-        c.muShield.dZ3 = 2.08 * u.m + zGap
-        c.muShield.dZ4 = 2.07 * u.m + zGap
-        c.muShield.dZ5 = 2.81 * u.m + zGap
-        c.muShield.dZ6 = 2.48 * u.m + zGap
-        c.muShield.dZ7 = 3.05 * u.m + zGap
-        c.muShield.dZ8 = 2.42 * u.m + zGap
-        c.muShield.dXgap = 0. * u.m
-        c.muShield.half_X_max = 179 * u.cm
-        c.muShield.half_Y_max = 317 * u.cm
-    elif muShieldDesign == 8:
-        assert shieldName
-        params = shield_db[shieldName]
-        c.muShield.params = params
-        c.muShield.dZ1 = 0.35*u.m + zGap
-        c.muShield.dZ2 = 2.26*u.m + zGap
-        c.muShield.dZ3 = params[2]
-        c.muShield.dZ4 = params[3]
-        c.muShield.dZ5 = params[4]
-        c.muShield.dZ6 = params[5]
-        c.muShield.dZ7 = params[6]
-        c.muShield.dZ8 = params[7]
-        c.muShield.dXgap = 0.*u.m
 
-        offset = 7
-        c.muShield.half_X_max = 0
-        c.muShield.half_Y_max = 0
-        for index in range(2, 8):
-            f_l = params[offset + index * 6 + 1]
-            f_r = params[offset + index * 6 + 2]
-            h_l = params[offset + index * 6 + 3]
-            h_r = params[offset + index * 6 + 4]
-            g_l = params[offset + index * 6 + 5]
-            g_r = params[offset + index * 6 + 6]
-            c.muShield.half_X_max = max(c.muShield.half_X_max, 2 * f_l + g_l, 2 * f_r + g_r)
-            c.muShield.half_Y_max = max(c.muShield.half_Y_max, h_l + f_l, h_r + f_r)
-        c.muShield.half_X_max += 15 * u.cm
-        c.muShield.half_Y_max += 15 * u.cm
-    else:
-        raise NotImplementedError(f"muShieldDesign {muShieldDesign} not supported")
+
+    params = shield_db[shieldName]['params']
+    c.muShield.params = params
+    c.muShield.dZ1 = params[0]
+    c.muShield.dZ2 = params[1]
+    c.muShield.dZ3 = params[2]
+    c.muShield.dZ4 = params[3]
+    c.muShield.dZ5 = params[4]
+    c.muShield.dZ6 = params[5]
+    c.muShield.dZ7 = params[6]
+    c.muShield.dXgap = 0. *u.m
+
 
     c.muShield.length = 2 * (
             c.muShield.dZ1 + c.muShield.dZ2 +
             c.muShield.dZ3 + c.muShield.dZ4 +
             c.muShield.dZ5 + c.muShield.dZ6 +
-            c.muShield.dZ7 + c.muShield.dZ8
+            c.muShield.dZ7
     ) + c.muShield.LE
     c.muShield.z = -(c.decayVolume.length + c.muShield.length) / 2.
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -118,9 +118,6 @@ parser.add_argument("-F",        dest="deepCopy",  help="default = False: copy o
 parser.add_argument("-t", "--test", dest="testFlag",  help="quick test", required=False,action="store_true")
 parser.add_argument("--dry-run", dest="dryrun",  help="stop after initialize", required=False,action="store_true")
 parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajectories", required=False, action="store_true")
-parser.add_argument("--stepMuonShield", dest="muShieldStepGeo", help="activate steps geometry for the muon shield", required=False, action="store_true", default=False)
-parser.add_argument("--coMuonShield", dest="muShieldWithCobaltMagnet", help="replace one of the magnets in the shield with 2.2T cobalt one, downscales other fields, works only for muShieldDesign >2", required=False, type=int, default=0)
-parser.add_argument("--noSC", dest="SC_mag", help="Deactivate SC muon shield. Configuration: 1 SC magnet (3*B_warm) + 3 warm magnets with inverted fields", action='store_false')
 parser.add_argument("--shieldName", help="The name of the SC shield in the database. SC default: sc_v6, Warm default: combi", default="sc_v6")
 parser.add_argument("--MesonMother",   dest="MM",  help="Choose DP production meson source: pi0, eta, omega, eta1, eta11", required=False,  default='pi0')
 parser.add_argument("--debug",  help="1: print weights and field 2: make overlap check", required=False, default=0, type=int, choices=range(0,3))
@@ -221,9 +218,6 @@ ship_geo = ConfigRegistry.loadpy(
      CaloDesign=options.caloDesign,
      strawDesign=options.strawDesign,
      muShieldGeo=options.geofile,
-     muShieldStepGeo=options.muShieldStepGeo,
-     muShieldWithCobaltMagnet=options.muShieldWithCobaltMagnet,
-     SC_mag=options.SC_mag,
      shieldName=options.shieldName,
      DecayVolumeMedium=options.decayVolMed,
      SND=options.SND,

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -1,5 +1,6 @@
 #include "ShipMuonShield.h"
 
+#include "FairLogger.h"   /// for FairLogger, MESSAGE_ORIGIN
 #include "TGeoManager.h"
 #include "TObjArray.h"                  // for TObjArray
 #include "TString.h"                    // for TString
@@ -25,112 +26,32 @@ Double_t tesla = 10 * kilogauss;
 ShipMuonShield::~ShipMuonShield() {}
 ShipMuonShield::ShipMuonShield() : FairModule("ShipMuonShield", "") {}
 
-ShipMuonShield::ShipMuonShield(TString geofile,
-                               Double_t floor,
-                               const Int_t withCoMagnet, const Bool_t StepGeo,
-                               const Bool_t WithConstAbsorberField, const Bool_t WithConstShieldField)
+ShipMuonShield::ShipMuonShield(std::vector<double> in_params,
+Double_t floor, const Bool_t WithConstShieldField,  const Bool_t SC_key)
   : FairModule("MuonShield", "ShipMuonShield")
 {
-  fWithConstAbsorberField = WithConstAbsorberField;
-  fWithConstShieldField = WithConstShieldField;
-  fStepGeo = StepGeo;
-  fWithCoMagnet = withCoMagnet;
-  fGeofile = geofile;
-  auto f = TFile::Open(geofile, "read");
-  TVectorT<Double_t> params;
-  params.Read("params");
-  Double_t LE = 7 * m;
-  fDesign = 8;
-  fSC_mag = false;
-  fField = 1.7;
-  dZ0 = 1 * m;
-  dZ1 = 0.4 * m;
-  dZ2 = 2.31 * m;
-  dZ3 = params[2];
-  dZ4 = params[3];
-  dZ5 = params[4];
-  dZ6 = params[5];
-  dZ7 = params[6];
-  dZ8 = params[7];
-  fMuonShieldLength = 2 * (dZ1 + dZ2 + dZ3 + dZ4 + dZ5 + dZ6 + dZ7 + dZ8) + LE;
-
-  fFloor = floor;
-  fSupport = false;
-
-  Double_t Z = -25 * m - fMuonShieldLength / 2.;
-
-  zEndOfAbsorb = Z + - fMuonShieldLength / 2.;
-}
-
-ShipMuonShield::ShipMuonShield(TVectorT<Double_t> in_params,
-Double_t floor, const Int_t withCoMagnet, const Bool_t StepGeo, const Bool_t WithConstAbsorberField, const Bool_t WithConstShieldField,  const Bool_t SC_key)
-  : FairModule("MuonShield", "ShipMuonShield")
-{
-  for(int i = 0; i < 56; i++){
+  for(size_t i = 0; i < in_params.size(); i++){
       shield_params.push_back(in_params[i]);
   }
-  fWithConstAbsorberField = WithConstAbsorberField;
   fWithConstShieldField = WithConstShieldField;
-  fStepGeo = StepGeo;
-  fWithCoMagnet = withCoMagnet;
-  Double_t LE = 7 * m;
-  fDesign = 8;
+  Double_t LE = 7 * m; // FIXME: space reserved for old SND
   fSC_mag = SC_key;
   fField = 1.7;
-  dZ0 = 1 * m;
-  dZ1 = 0.4 * m;
-  dZ2 = 2.31 * m;
+  HA_field = 1.6; // FIXME: to be updated in the next workshop meeting
+  dZ1 = in_params[0];
+  dZ2 = in_params[1];
   dZ3 = in_params[2];
   dZ4 = in_params[3];
   dZ5 = in_params[4];
   dZ6 = in_params[5];
   dZ7 = in_params[6];
-  dZ8 = in_params[7];
-  fMuonShieldLength = 2 * (dZ1 + dZ2 + dZ3 + dZ4 + dZ5 + dZ6 + dZ7 + dZ8) + LE;
+  fMuonShieldLength = 2 * (dZ1 + dZ2 + dZ3 + dZ4 + dZ5 + dZ6 + dZ7 ) + LE;
 
   fFloor = floor;
-  fSupport = false;
 
   Double_t Z = -25 * m - fMuonShieldLength / 2.;
 
   zEndOfAbsorb = Z + - fMuonShieldLength / 2.;
-}
-
-ShipMuonShield::ShipMuonShield(const char* name, const Int_t Design, const char* Title,
-                               Double_t Z, Double_t L0, Double_t L1, Double_t L2, Double_t L3, Double_t L4, Double_t L5, Double_t L6,
-                               Double_t L7, Double_t L8, Double_t gap, Double_t LE, Double_t, Double_t floor, Double_t field,
-                               const Int_t withCoMagnet, const Bool_t StepGeo,
-                               const Bool_t WithConstAbsorberField, const Bool_t WithConstShieldField)
-  : FairModule(name ,Title)
-{
- fDesign = Design;
- fField  = field;
- fSC_mag = false;
- fGeofile = "";
- fWithConstAbsorberField = WithConstAbsorberField;
- fWithConstShieldField = WithConstShieldField;
- fStepGeo = StepGeo;
- fWithCoMagnet = withCoMagnet;
- if (fDesign < 7){
-     Fatal("ShipMuonShield","Design %i not anymore supported",fDesign);
- } else if (fDesign >= 7){
-     dZ1 = L1;
-     dZ2 = L2;
-     dZ3 = L3;
-     dZ4 = L4;
-     dZ5 = L5;
-     dZ6 = L6;
-     dZ7 = L7;
-     dZ8 = L8;
-     fMuonShieldLength =
-	 2 * (dZ1 + dZ2 + dZ3 + dZ4 + dZ5 + dZ6 + dZ7 + dZ8) + LE;
- }
-
- fFloor = floor;
-
- zEndOfAbsorb = Z - fMuonShieldLength/2.;
-
- fSupport = false;
 }
 
 // -----   Private method InitMedium
@@ -151,18 +72,6 @@ Int_t ShipMuonShield::InitMedium(TString name)
    return geoBuild->createMedium(ShipMedium);
 }
 
-void ShipMuonShield::CreateTube(TString tubeName, TGeoMedium *medium,
-				Double_t dX, Double_t dY, Double_t dZ,
-				Int_t color, TGeoVolume *tShield,
-				Double_t x_translation, Double_t y_translation,
-				Double_t z_translation) {
-  TGeoVolume *absorber = gGeoManager->MakeTube(tubeName, medium, dX, dY, dZ);
-  absorber->SetLineColor(color);
-  tShield->AddNode(
-      absorber, 1,
-      new TGeoTranslation(x_translation, y_translation, z_translation));
-}
-
 void ShipMuonShield::CreateArb8(TString arbName, TGeoMedium *medium,
 				Double_t dZ, std::array<Double_t, 16> corners,
 				Int_t color, TGeoUniformMagField *magField,
@@ -172,109 +81,28 @@ void ShipMuonShield::CreateArb8(TString arbName, TGeoMedium *medium,
   TGeoVolume *magF =
       gGeoManager->MakeArb8(arbName, medium, dZ, corners.data());
   magF->SetLineColor(color);
-  if (arbName.Contains("Absorb")) {
-      if (fWithConstAbsorberField) {
-          magF->SetField(magField);
-      }
-  } else if (fWithConstShieldField) {
+  if (fWithConstShieldField) {
       magF->SetField(magField);
   }
   tShield->AddNode(magF, 1, new TGeoTranslation(x_translation, y_translation,
 						z_translation));
 }
 
-void ShipMuonShield::CreateArb8(TString arbName, TGeoMedium *medium,
-          Double_t dZ, std::array<Double_t, 16> corners,
-          Int_t color, TGeoUniformMagField *magField,
-          TGeoVolume *tShield, Double_t x_translation,
-          Double_t y_translation,
-          Double_t z_translation,
-          Bool_t stepGeo) {
-  if (!stepGeo)
-  {
-    CreateArb8 (arbName, medium, dZ, corners, color, magField, tShield, x_translation, y_translation, z_translation);
-    return;
-  }
-  Double_t partLength = 0.5;
-  Int_t zParts = std::ceil(2.0*dZ/m/partLength);
-  Double_t finalCorners[zParts][16];
-  Double_t dxdy[4][2];
-  Double_t dZp = dZ/Double_t(zParts);
-
-  for (int i = 0; i < 4; ++i)
-  {
-    dxdy[i][0] = (corners[8+2*i] - corners[0+2*i])/Double_t(zParts);
-    dxdy[i][1] = (corners[9+2*i] - corners[1+2*i])/Double_t(zParts);
-  }
-
-  std::copy(corners.data() + 0,  corners.data() + 8, finalCorners[0]);
-
-  for (int i = 0; i < zParts; ++i)
-  {
-    for (int k = 0; k < 4; ++k)
-    {
-      finalCorners[i][8+2*k] = finalCorners[i][0+2*k] + dxdy[k][0];
-      finalCorners[i][9+2*k] = finalCorners[i][1+2*k] + dxdy[k][1];
-    }
-    if (i != zParts-1)
-    {
-      std::copy(finalCorners[i] + 8, finalCorners[i] + 16, finalCorners[i+1]);
-    }
-  }
-
-  for (int i = 0; i < zParts; ++i)
-  {
-    for (int k = 0; k < 4; ++k)
-    {
-      finalCorners[i][8+2*k] = finalCorners[i][0+2*k]  = (finalCorners[i][0+2*k] + finalCorners[i][8+2*k]) / 2.0;
-      finalCorners[i][9+2*k] = finalCorners[i][1+2*k]  = (finalCorners[i][9+2*k] + finalCorners[i][1+2*k]) / 2.0;
-    }
-  }
-
-  std::vector<TGeoVolume*> magF;
-
-  for (int i = 0; i < zParts; ++i)
-  {
-    magF.push_back(gGeoManager->MakeArb8(arbName + '_' + std::to_string(i), medium, dZp - 0.00001*m, finalCorners[i]));
-    magF[i]->SetLineColor(color);
-    if (fWithConstShieldField) {
-      magF[i]->SetField(magField);
-    }
-  }
-
-  for (int i = 0; i < zParts; ++i)
-  {
-    Double_t true_z_translation = z_translation + 2.0 * Double_t(i) * dZp - dZ + dZp;
-    tShield->AddNode(magF[i], 1, new TGeoTranslation(x_translation, y_translation, true_z_translation));
-  }
-}
-
 void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolume *tShield,TGeoUniformMagField *fields[4],FieldDirection fieldDirection,
-				  Double_t dX, Double_t dY, Double_t dX2, Double_t dY2, Double_t dZ,
+				  Double_t dX, Double_t dY, Double_t dX2, Double_t dY2,
+          Double_t ratio_yoke_1, Double_t ratio_yoke_2,
+          Double_t dY_yoke_1, Double_t dY_yoke_2,
+          Double_t dZ,
 				  Double_t middleGap,Double_t middleGap2,
-				  Double_t HmainSideMag, Double_t HmainSideMag2,
 				  Double_t gap,Double_t gap2, Double_t Z, Bool_t NotMagnet,
-          Bool_t stepGeo, Bool_t SC_key = false)
+          Bool_t SC_key = false)
   {
     Double_t coil_gap,coil_gap2;
     Int_t color[4] = {45,31,30,38};
-
-    if (NotMagnet) {
-       coil_gap = gap;
-       coil_gap2 = gap2;
-    } else if (fDesign > 7) {
-       // Assuming 0.5A/mm^2 and 10000At needed, about 200cm^2 gaps are necessary
-       // Current design safely above this. Will consult with MISiS to get a better minimum.
-       gap = std::ceil(std::max(100. / dY, gap));
-       gap2 = std::ceil(std::max(100. / dY2, gap2));
-       coil_gap = gap;
-       coil_gap2 = gap2;
-    } else {
-       coil_gap = std::max(20., gap);
-       coil_gap2 = std::max(20., gap2);
-       gap = std::max(2., gap);
-       gap2 = std::max(2., gap2);
-    }
+    gap = std::ceil(std::max(100. / dY, gap));
+    gap2 = std::ceil(std::max(100. / dY2, gap2));
+    coil_gap = gap;
+    coil_gap2 = gap2;
 
     Double_t anti_overlap = 0.1; // gap between fields in the
 						   // corners for mitred joints
@@ -282,133 +110,103 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
 						   // they touch each other)
 
     std::array<Double_t, 16> cornersMainL = {
-	middleGap, -(dY + dX - anti_overlap),
-	middleGap, dY + dX - anti_overlap,
-	dX + middleGap, dY - anti_overlap,
-	dX + middleGap, -(dY - anti_overlap),
-	middleGap2, -(dY2 + dX2 - anti_overlap),
-	middleGap2, dY2 + dX2 - anti_overlap,
-	dX2 + middleGap2, dY2 - anti_overlap,
-	dX2 + middleGap2, -(dY2 - anti_overlap)
-    };
-
-    std::array<Double_t, 16> cornersTL = {middleGap + dX,
-                                          dY,
-                                          middleGap,
-                                          dY + dX,
-                                          2 * dX + middleGap + coil_gap,
-                                          dY + dX,
-                                          dX + middleGap + coil_gap,
-                                          dY,
-                                          middleGap2 + dX2,
-                                          dY2,
-                                          middleGap2,
-                                          dY2 + dX2,
-                                          2 * dX2 + middleGap2 + coil_gap2,
-                                          dY2 + dX2,
-                                          dX2 + middleGap2 + coil_gap2,
-                                          dY2};
-
-    std::array<Double_t, 16> cornersMainSideL =
-      fDesign == 7 ?
-      std::array<Double_t, 16>{
-	dX + middleGap + gap, -HmainSideMag,
-	dX + middleGap + gap, HmainSideMag,
-	2 * dX + middleGap + gap, HmainSideMag,
-	2 * dX + middleGap + gap, -HmainSideMag,
-	dX2 + middleGap2 + gap2, -HmainSideMag2,
-	dX2 + middleGap2 + gap2, HmainSideMag2,
-	2 * dX2 + middleGap2 + gap2, HmainSideMag2,
-	2 * dX2 + middleGap2 + gap2, -HmainSideMag2
-      } :
-      std::array<Double_t, 16>{
-	dX + middleGap + gap, -(dY - anti_overlap),
-	dX + middleGap + gap, dY - anti_overlap,
-	2 * dX + middleGap + gap, dY + dX - anti_overlap,
-	2 * dX + middleGap + gap, -(dY + dX - anti_overlap),
-	dX2 + middleGap2 + gap2, -(dY2 - anti_overlap),
-	dX2 + middleGap2 + gap2, dY2 - anti_overlap,
-	2 * dX2 + middleGap2 + gap2, dY2 + dX2 - anti_overlap,
-	2 * dX2 + middleGap2 + gap2, -(dY2 + dX2 - anti_overlap)
-    };
-    // SC part
-  if(SC_key){
-
-    cornersMainL = {
-    middleGap, -(dY + 3*dX - anti_overlap),
-    middleGap, dY + 3*dX - anti_overlap,
-    dX + middleGap, dY - anti_overlap,
-    dX + middleGap, -(dY - anti_overlap),
-    middleGap2, -(dY2 + 3*dX2 - anti_overlap),
-    middleGap2, dY2 + 3*dX2 - anti_overlap,
-    dX2 + middleGap2, dY2 - anti_overlap,
-    dX2 + middleGap2, -(dY2 - anti_overlap)
+      middleGap,
+      -(dY +dY_yoke_1)- anti_overlap,
+      middleGap,
+      dY + dY_yoke_1- anti_overlap,
+      dX + middleGap,
+      dY- anti_overlap,
+      dX + middleGap,
+      -(dY- anti_overlap),
+      middleGap2,
+      -(dY2 + dY_yoke_2- anti_overlap), middleGap2,
+      dY2 + dY_yoke_2- anti_overlap,
+      dX2 + middleGap2,
+      dY2- anti_overlap,
+      dX2 + middleGap2,
+      -(dY2- anti_overlap)
       };
 
-      cornersTL = {middleGap + dX,
-                  dY,
-                  middleGap,
-                  dY + 3*dX,
-                  4 * dX + middleGap + coil_gap,
-                  dY + 3*dX,
-                  dX + middleGap + coil_gap,
-                  dY,
-                  middleGap2 + dX2,
-                  dY2,
-                  middleGap2,
-                  dY2 + 3*dX2,
-                  4 * dX2 + middleGap2 + coil_gap2,
-                  dY2 + 3*dX2,
-                  dX2 + middleGap2 + coil_gap2,
-                  dY2};
+      std::array<Double_t, 16> cornersTL = {
+        middleGap + dX,dY,
+        middleGap,
+        dY + dY_yoke_1,
+        dX + ratio_yoke_1*dX + middleGap + coil_gap,
+        dY + dY_yoke_1,
+        dX + middleGap + coil_gap,
+        dY,
+        middleGap2 + dX2,
+        dY2,
+        middleGap2,
+        dY2 + dY_yoke_2,
+        dX2 + ratio_yoke_2*dX2 + middleGap2 + coil_gap2,
+        dY2 + dY_yoke_2,
+        dX2 + middleGap2 + coil_gap2,
+        dY2
+      };
 
-      cornersMainSideL =
-        fDesign == 7 ?
-        std::array<Double_t, 16>{
-    dX + middleGap + gap, -HmainSideMag,
-    dX + middleGap + gap, HmainSideMag,
-    4 * dX + middleGap + gap, HmainSideMag,
-    4 * dX + middleGap + gap, -HmainSideMag,
-    dX2 + middleGap2 + gap2, -HmainSideMag2,
-    dX2 + middleGap2 + gap2, HmainSideMag2,
-    4 * dX2 + middleGap2 + gap2, HmainSideMag2,
-    4 * dX2 + middleGap2 + gap2, -HmainSideMag2
-        } :
-        std::array<Double_t, 16>{
-    dX + middleGap + gap, -(dY - anti_overlap),
-    dX + middleGap + gap, dY - anti_overlap,
-    4 * dX + middleGap + gap, dY + 3*dX - anti_overlap,
-    4 * dX + middleGap + gap, -(dY + 3*dX - anti_overlap),
-    dX2 + middleGap2 + gap2, -(dY2 - anti_overlap),
-    dX2 + middleGap2 + gap2, dY2 - anti_overlap,
-    4 * dX2 + middleGap2 + gap2, dY2 + 3*dX2 - anti_overlap,
-    4 * dX2 + middleGap2 + gap2, -(dY2 + 3*dX2 - anti_overlap)
-    };
-  }
-      // END of SC part
+      std::array<Double_t, 16> cornersMainSideL = {
+        dX + middleGap + gap,
+        -(dY),
+        dX + middleGap + gap,
+        dY,
+        dX + ratio_yoke_1*dX + middleGap + gap,
+        dY + dY_yoke_1,
+        dX + ratio_yoke_1*dX + middleGap + gap,
+        -(dY + dY_yoke_1),
+        dX2 + middleGap2 + gap2,
+        -(dY2),
+        dX2 + middleGap2 + gap2,
+        dY2,
+        dX2 + ratio_yoke_2*dX2 + middleGap2 + gap2,
+        dY2 + dY_yoke_2,
+        dX2 + ratio_yoke_2*dX2 + middleGap2 + gap2,
+        -(dY2 + dY_yoke_2)
+      };
+      // SC part
+    if(SC_key){
+      cornersMainL = {
+      middleGap, -(dY + 3*dX - anti_overlap),
+      middleGap, dY + 3*dX - anti_overlap,
+      dX + middleGap, dY - anti_overlap,
+      dX + middleGap, -(dY - anti_overlap),
+      middleGap2, -(dY2 + 3*dX2 - anti_overlap),
+      middleGap2, dY2 + 3*dX2 - anti_overlap,
+      dX2 + middleGap2, dY2 - anti_overlap,
+      dX2 + middleGap2, -(dY2 - anti_overlap)
+        };
+
+      cornersTL = {middleGap + dX,
+                    dY,
+                    middleGap,
+                    dY + 3*dX,
+                    4 * dX + middleGap + coil_gap,
+                    dY + 3*dX,
+                    dX + middleGap + coil_gap,
+                    dY,
+                    middleGap2 + dX2,
+                    dY2,
+                    middleGap2,
+                    dY2 + 3*dX2,
+                    4 * dX2 + middleGap2 + coil_gap2,
+                    dY2 + 3*dX2,
+                    dX2 + middleGap2 + coil_gap2,
+                    dY2};
+
+      cornersMainSideL ={
+      dX + middleGap + gap, -(dY - anti_overlap),
+      dX + middleGap + gap, dY - anti_overlap,
+      4 * dX + middleGap + gap, dY + 3*dX - anti_overlap,
+      4 * dX + middleGap + gap, -(dY + 3*dX - anti_overlap),
+      dX2 + middleGap2 + gap2, -(dY2 - anti_overlap),
+      dX2 + middleGap2 + gap2, dY2 - anti_overlap,
+      4 * dX2 + middleGap2 + gap2, dY2 + 3*dX2 - anti_overlap,
+      4 * dX2 + middleGap2 + gap2, -(dY2 + 3*dX2 - anti_overlap)
+      };
+    }
     std::array<Double_t, 16> cornersMainR, cornersCLBA,
        cornersMainSideR, cornersCLTA, cornersCRBA,
        cornersCRTA, cornersTR, cornersBL, cornersBR;
-
-    if (fDesign == 7) {
-       cornersCLBA = {dX + middleGap + gap,
-                      -HmainSideMag,
-                      2 * dX + middleGap + gap,
-                      -HmainSideMag,
-                      2 * dX + middleGap + coil_gap,
-                      -(dY + dX - anti_overlap),
-                      dX + middleGap + coil_gap,
-                      -(dY - anti_overlap),
-                      dX2 + middleGap2 + gap2,
-                      -HmainSideMag2,
-                      2 * dX2 + middleGap2 + gap2,
-                      -HmainSideMag2,
-                      2 * dX2 + middleGap2 + coil_gap2,
-                      -(dY2 + dX2 - anti_overlap),
-                      dX2 + middleGap2 + coil_gap2,
-                      -(dY2 - anti_overlap)};
-    }
-
     // Use symmetries to define remaining magnets
     for (int i = 0; i < 16; ++i) {
       cornersMainR[i] = -cornersMainL[i];
@@ -445,36 +243,24 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
     switch (fieldDirection){
 
     case FieldDirection::up:
-      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[0], fields[0], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[0], fields[0], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[1], fields[1], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[1], fields[1], tShield,  0, 0, Z, stepGeo);
-      if (fDesign == 7) {
-         CreateArb8(magnetName + str4, medium, dZ, cornersCLBA, color[1], fields[1], tShield, 0, 0, Z, stepGeo);
-         CreateArb8(magnetName + str5, medium, dZ, cornersCLTA, color[1], fields[1], tShield, 0, 0, Z, stepGeo);
-         CreateArb8(magnetName + str6, medium, dZ, cornersCRTA, color[1], fields[1], tShield, 0, 0, Z, stepGeo);
-         CreateArb8(magnetName + str7, medium, dZ, cornersCRBA, color[1], fields[1], tShield, 0, 0, Z, stepGeo);
-      }
-      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[3], fields[3], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[2], fields[2], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[2], fields[2], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[3], fields[3], tShield,  0, 0, Z, stepGeo);
+      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[3], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[2], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[2], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[3], fields[3], tShield,  0, 0, Z);
       break;
     case FieldDirection::down:
-      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[1], fields[1], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[1], fields[1], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[0], fields[0], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[0], fields[0], tShield,  0, 0, Z, stepGeo);
-      if (fDesign == 7) {
-         CreateArb8(magnetName + str4, medium, dZ, cornersCLBA, color[0], fields[0], tShield, 0, 0, Z, stepGeo);
-         CreateArb8(magnetName + str5, medium, dZ, cornersCLTA, color[0], fields[0], tShield, 0, 0, Z, stepGeo);
-         CreateArb8(magnetName + str6, medium, dZ, cornersCRTA, color[0], fields[0], tShield, 0, 0, Z, stepGeo);
-         CreateArb8(magnetName + str7, medium, dZ, cornersCRBA, color[0], fields[0], tShield, 0, 0, Z, stepGeo);
-      }
-      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[2], fields[2], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[3], fields[3], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[3], fields[3], tShield,  0, 0, Z, stepGeo);
-      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[2], fields[2], tShield,  0, 0, Z, stepGeo);
+      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[0], fields[0], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[2], fields[2], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str9, medium, dZ, cornersTR, color[3], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str10, medium, dZ, cornersBL, color[3], fields[3], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[2], fields[2], tShield,  0, 0, Z);
       break;
     }
   }
@@ -483,322 +269,72 @@ Int_t ShipMuonShield::Initialize(std::vector<TString> &magnetName,
 				std::vector<FieldDirection> &fieldDirection,
 				std::vector<Double_t> &dXIn, std::vector<Double_t> &dYIn,
 				std::vector<Double_t> &dXOut, std::vector<Double_t> &dYOut,
+        std::vector<Double_t> &ratio_yokesIn, std::vector<Double_t> &ratio_yokesOut,
+        std::vector<Double_t> &dY_yokeIn, std::vector<Double_t> &dY_yokeOut,
 				std::vector<Double_t> &dZ, std::vector<Double_t> &midGapIn,
 				std::vector<Double_t> &midGapOut,
-				std::vector<Double_t> &HmainSideMagIn,
-				std::vector<Double_t> &HmainSideMagOut,
+        std::vector<Double_t> &NI,
 				std::vector<Double_t> &gapIn, std::vector<Double_t> &gapOut,
 				std::vector<Double_t> &Z) {
-
-  const Int_t nMagnets = 9;
+  const Int_t nMagnets = 7;
+  LOG(INFO) << " Initialize the MS ";
   magnetName.reserve(nMagnets);
   fieldDirection.reserve(nMagnets);
   for (auto i :
        {&dXIn, &dXOut, &dYIn, &dYOut, &dZ, &midGapIn, &midGapOut,
-	&HmainSideMagIn, &HmainSideMagOut, &gapIn, &gapOut, &Z}) {
+	&ratio_yokesIn , &ratio_yokesOut, &dY_yokeIn, &dY_yokeOut, &NI, &gapIn, &gapOut, &Z}) {
     i->reserve(nMagnets);
   }
 
   Double_t zgap = 10 * cm;  // fixed distance between magnets in Z-axis
 
-  if (fDesign == 8) {
+  magnetName = {"MagnAbsorb", "Magn1", "Magn2", "Magn3",
+    "Magn4",       "Magn5",       "Magn6"};
 
-    magnetName = {"MagnAbsorb1", "MagnAbsorb2", "Magn1", "Magn2", "Magn3",
-		  "Magn4",       "Magn5",       "Magn6", "Magn7"};
+  fieldDirection = {
+FieldDirection::up,   FieldDirection::up,   FieldDirection::up,
+FieldDirection::up,   FieldDirection::up,   FieldDirection::down,
+FieldDirection::down, FieldDirection::down, FieldDirection::down,
+  };
 
-    fieldDirection = {
-	FieldDirection::up,   FieldDirection::up,   FieldDirection::up,
-	FieldDirection::up,   FieldDirection::up,   FieldDirection::down,
-	FieldDirection::down, FieldDirection::down, FieldDirection::down,
-    };
+  std::vector<Double_t> params;
+  params = shield_params;
 
-    std::vector<Double_t> params;
-    params = shield_params;
+  const int offset = nMagnets;
+  const int nParams = 13;
 
-    const int offset = 7;
 
-    dXIn[0] = 0.4 * m;
-    dXOut[0] = 0.40 * m;
-    gapIn[0] = 0.1 * mm;
-    dYIn[0] = 1.5 * m;
-    dYOut[0] = 1.5 * m;
-    gapOut[0] = 0.1 * mm;
-    dXIn[1] = 0.5 * m;
-    dXOut[1] = 0.5 * m;
-    gapIn[1] = 0.02 * m;
-    dYIn[1] = 1.19 * m;
-    dYOut[1] = 1.19 * m;
-    gapOut[1] = 0.02 * m;
-
-    for (Int_t i = 2; i < nMagnets - 1; ++i) {
-      dXIn[i] = params[offset + i * 6 + 1];
-      dXOut[i] = params[offset + i * 6 + 2];
-      dYIn[i] = params[offset + i * 6 + 3];
-      dYOut[i] = params[offset + i * 6 + 4];
-      gapIn[i] = params[offset + i * 6 + 5];
-      gapOut[i] = params[offset + i * 6 + 6];
-    }
-
-    dZ[0] = dZ1 - zgap / 2;
-    Z[0] = zEndOfAbsorb + dZ[0] + zgap;
-    dZ[1] = dZ2 - zgap / 2;
-    Z[1] = Z[0] + dZ[0] + dZ[1] + zgap;
-    dZ[2] = dZ3 - zgap / 2;
-    Z[2] = Z[1] + dZ[1] + dZ[2] + 2 * zgap;
-    dZ[3] = dZ4 - zgap / 2;
-    Z[3] = Z[2] + dZ[2] + dZ[3] + zgap;
-    dZ[4] = dZ5 - zgap / 2;
-    Z[4] = Z[3] + dZ[3] + dZ[4] + zgap;
-    dZ[5] = dZ6 - zgap / 2;
-    Z[5] = Z[4] + dZ[4] + dZ[5] + zgap;
-    dZ[6] = dZ7 - zgap / 2;
-    Z[6] = Z[5] + dZ[5] + dZ[6] + zgap;
-    dZ[7] = dZ8 - zgap / 2;
-    Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
-
-    dXIn[8] = dXOut[7];
-    dYIn[8] = dYOut[7];
-    dXOut[8] = dXIn[8];
-    dYOut[8] = dYIn[8];
-    gapIn[8] = gapOut[7];
-    gapOut[8] = gapIn[8];
-    dZ[8] = 0.1 * m;
-    Z[8] = Z[7] + dZ[7] + dZ[8];
-
-    for (int i = 0; i < nMagnets; ++i) {
-      midGapIn[i] = 0.;
-      midGapOut[i] = 0.;
-      HmainSideMagIn[i] = dYIn[i] / 2;
-      HmainSideMagOut[i] = dYOut[i] / 2;
-    }
-
-  } else if (fDesign == 9) {
-     magnetName = {"MagnAbsorb1", "MagnAbsorb2", "Magn1", "Magn2", "Magn3",
-       "Magn4", "Magn5", "Magn6", "Magn7"
-     };
-
-     fieldDirection = {
-        FieldDirection::up, FieldDirection::up, FieldDirection::up,
-	FieldDirection::up, FieldDirection::up, FieldDirection::down,
-	FieldDirection::down, FieldDirection::down, FieldDirection::down,
-     };
-
-     dXIn[0] = 0.4 * m;
-     dXOut[0] = 0.40 * m;
-     dYIn[0] = 1.5 * m;
-     dYOut[0] = 1.5 * m;
-     gapIn[0] = 0.1 * mm;
-     gapOut[0] = 0.1 * mm;
-     dZ[0] = dZ1 - zgap / 2;
-     Z[0] = zEndOfAbsorb + dZ[0] + zgap;
-
-     dXIn[1] = 0.5 * m;
-     dXOut[1] = 0.5 * m;
-     dYIn[1] = 1.3 * m;
-     dYOut[1] = 1.3 * m;
-     gapIn[1] = 0.02 * m;
-     gapOut[1] = 0.02 * m;
-     dZ[1] = dZ2 - zgap / 2;
-     Z[1] = Z[0] + dZ[0] + dZ[1] + zgap;
-
-     dXIn[2] = 0.72 * m;
-     dXOut[2] = 0.51 * m;
-     dYIn[2] = 0.29 * m;
-     dYOut[2] = 0.46 * m;
-     gapIn[2] = 0.10 * m;
-     gapOut[2] = 0.07 * m;
-     dZ[2] = dZ3 - zgap / 2;
-     Z[2] = Z[1] + dZ[1] + dZ[2] + 2 * zgap;
-
-     dXIn[3] = 0.54 * m;
-     dXOut[3] = 0.38 * m;
-     dYIn[3] = 0.46 * m;
-     dYOut[3] = 1.92 * m;
-     gapIn[3] = 0.14 * m;
-     gapOut[3] = 0.09 * m;
-     dZ[3] = dZ4 - zgap / 2;
-     Z[3] = Z[2] + dZ[2] + dZ[3] + zgap;
-
-     dXIn[4] = 0.10 * m;
-     dXOut[4] = 0.31 * m;
-     dYIn[4] = 0.35 * m;
-     dYOut[4] = 0.31 * m;
-     gapIn[4] = 0.51 * m;
-     gapOut[4] = 0.11 * m;
-     dZ[4] = dZ5 - zgap / 2;
-     Z[4] = Z[3] + dZ[3] + dZ[4] + zgap;
-
-     dXIn[5] = 0.03 * m;
-     dXOut[5] = 0.32 * m;
-     dYIn[5] = 0.54 * m;
-     dYOut[5] = 0.24 * m;
-     gapIn[5] = 0.08 * m;
-     gapOut[5] = 0.08 * m;
-     dZ[5] = dZ6 - zgap / 2;
-     Z[5] = Z[4] + dZ[4] + dZ[5] + zgap;
-
-     dXIn[6] = 0.22 * m;
-     dXOut[6] = 0.32 * m;
-     dYIn[6] = 2.09 * m;
-     dYOut[6] = 0.35 * m;
-     gapIn[6] = 0.08 * m;
-     gapOut[6] = 0.13 * m;
-     dZ[6] = dZ7 - zgap / 2;
-     Z[6] = Z[5] + dZ[5] + dZ[6] + zgap;
-
-     dXIn[7] = 0.33 * m;
-     dXOut[7] = 0.77 * m;
-     dYIn[7] = 0.85 * m;
-     dYOut[7] = 2.41 * m;
-     gapIn[7] = 0.09 * m;
-     gapOut[7] = 0.26 * m;
-     dZ[7] = dZ8 - zgap / 2;
-     Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
-
-     dXIn[8] = dXOut[7];
-     dYIn[8] = dYOut[7];
-     dXOut[8] = dXIn[8];
-     dYOut[8] = dYIn[8];
-     gapIn[8] = gapOut[7];
-     gapOut[8] = gapIn[8];
-     dZ[8] = 0.1 * m;
-     Z[8] = Z[7] + dZ[7] + dZ[8];
-
-     for (int i = 0; i < nMagnets; ++i) {
-        midGapIn[i] = 0.;
-        midGapOut[i] = 0.;
-        HmainSideMagIn[i] = dYIn[i] / 2;
-        HmainSideMagOut[i] = dYOut[i] / 2;
-     }
-
-  } else if (fDesign == 7) {
-  magnetName = {"MagnAbsorb1", "MagnAbsorb2", "Magn1", "Magn2", "Magn3",
-                "Magn4", "Magn5", "Magn6", "Magn7"};
-
-  fieldDirection[0] = FieldDirection::up;
-  dXIn[0]  = 0.4*m;			dYIn[0]	= 1.5*m;
-  dXOut[0] = 0.40*m;			dYOut[0]= 1.5*m;
-  gapIn[0] = 0.02 * m;			gapOut[0] = 0.02 * m;
-  dZ[0] = dZ1-zgap/2;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
-
-  fieldDirection[1] = FieldDirection::up;
-  dXIn[1]  = 0.8*m;			dYIn[1]	= 1.5*m;
-  dXOut[1] = 0.8*m;			dYOut[1]= 1.5*m;
-  gapIn[1] = 0.02*m;			gapOut[1] = 0.02*m;
-  dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
-
-  fieldDirection[2] = FieldDirection::up;
-  dXIn[2]  = 0.87*m;			dYIn[2]	= 0.35*m;
-  dXOut[2] = 0.65*m;			dYOut[2]= 1.21*m;
-  gapIn[2] = 0.11 * m;  		gapOut[2] = 0.065 * m;
-  dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2] + zgap;
-
-  fieldDirection[3] = FieldDirection::up;
-  dXIn[3]  = 0.65*m;			dYIn[3]	= 1.21*m;
-  dXOut[3] = 0.43*m;			dYOut[3]= 2.07*m;
-  gapIn[3] = 0.065 * m; 		gapOut[3] = 0.02 * m;
-  dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
-
-  fieldDirection[4] = FieldDirection::up;
-  dXIn[4]  = 0.06*m;			dYIn[4]	= 0.32*m;
-  dXOut[4] = 0.33*m;			dYOut[4]= 0.13*m;
-  gapIn[4] = 0.7*m;			gapOut[4] = 0.11*m;
-  dZ[4] = dZ5-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
-
-  fieldDirection[5] = FieldDirection::down;
-  dXIn[5]  = 0.05*m;			dYIn[5]	= 1.12*m;
-  dXOut[5] =0.16*m;			dYOut[5]= 0.05*m;
-  gapIn[5] = 0.04*m;			gapOut[5] = 0.02*m;
-  dZ[5] = dZ6-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
-
-  fieldDirection[6] = FieldDirection::down;
-  dXIn[6]  = 0.15*m;			dYIn[6]	= 2.35*m;
-  dXOut[6] = 0.34*m;			dYOut[6]= 0.32*m;
-  gapIn[6] = 0.05*m;			gapOut[6] = 0.08*m;
-  dZ[6] = dZ7-zgap/2;			Z[6] = Z[5] + dZ[5] + dZ[6]+zgap;
-
-  Double_t clip_width = 0.1*m; // clip field width by this width
-  fieldDirection[7] = FieldDirection::down;
-  dXIn[7]  = 0.31*m;			dYIn[7]	= 1.86*m;
-  dXOut[7] = 0.9*m - clip_width;	dYOut[7]= 3.1*m;
-  Double_t clip_len =
-       (dZ8-zgap/2) * (1 - (dXOut[7] - dXIn[7]) / (dXOut[7] + clip_width - dXIn[7]));
-  gapIn[7] = 0.02*m;			gapOut[7] = 0.55*m;
-  dZ[7] = dZ8 - clip_len - zgap / 2;	Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
-
-  fieldDirection[8] = FieldDirection::down;
-  dXIn[8]  = dXOut[7];			dYIn[8]	= dYOut[7];
-  dXOut[8] = dXOut[7];			dYOut[8]= dYOut[7];
-  gapIn[8] = 0.55*m;			gapOut[8] = 0.55*m;
-  dZ[8] = clip_len;			Z[8] = Z[7] + dZ[7] + dZ[8];
-
-  for (int i = 0; i < nMagnets; ++i) {
-    midGapIn[i] = 0.;
-    midGapOut[i] = 0.;
-    HmainSideMagIn[i] = dYIn[i] / 2;
-    HmainSideMagOut[i] = dYOut[i] / 2;
+  for (Int_t i = 0; i < nMagnets; ++i) {
+    dXIn[i] = params[offset + i * nParams + 0];
+    dXOut[i] = params[offset + i * nParams + 1];
+    dYIn[i] = params[offset + i * nParams + 2];
+    dYOut[i] = params[offset + i * nParams + 3];
+    gapIn[i] = params[offset + i * nParams + 4];
+    gapOut[i] = params[offset + i * nParams + 5];
+    ratio_yokesIn[i] = params[offset + i * nParams + 6];
+    ratio_yokesOut[i] = params[offset + i * nParams + 7];
+    dY_yokeIn[i] = params[offset + i * nParams + 8];
+    dY_yokeOut[i] = params[offset + i * nParams + 9];
+    midGapIn[i] = params[offset + i * nParams + 10];
+    midGapOut[i] = params[offset + i * nParams + 11];
+    NI[i] = params[offset + i * nParams + 12];
   }
 
-  } else {
+  dZ[0] = dZ1 - zgap / 2;
+  Z[0] = zEndOfAbsorb + dZ[0] + zgap;
+  dZ[1] = dZ2 - zgap / 2;
+  Z[1] = Z[0] + dZ[0] + dZ[1] + zgap;
+  dZ[2] = dZ3 - zgap / 2;
+  Z[2] = Z[1] + dZ[1] + dZ[2] + 2 * zgap;
+  dZ[3] = dZ4 - zgap / 2;
+  Z[3] = Z[2] + dZ[2] + dZ[3] + zgap;
+  dZ[4] = dZ5 - zgap / 2;
+  Z[4] = Z[3] + dZ[3] + dZ[4] + zgap;
+  dZ[5] = dZ6 - zgap / 2;
+  Z[5] = Z[4] + dZ[4] + dZ[5] + zgap;
+  dZ[6] = dZ7 - zgap / 2;
+  Z[6] = Z[5] + dZ[5] + dZ[6] + zgap;
 
-  magnetName = {"1", "2", "3", "4", "5", "6", "7"};
-
-  fieldDirection[0] = FieldDirection::up;
-  dXIn[0]  = 0.7*m;			dYIn[0]	= 1.*m;
-  dXOut[0] = 0.7*m;			dYOut[0]= 0.8158*m;
-  midGapIn[0] = 0; 			midGapOut[0] = 0;
-  HmainSideMagIn[0] = dYIn[0];  	HmainSideMagOut[0] = dYOut[0];
-  gapIn[0] = 20;			gapOut[0] = 20;
-  dZ[0] = dZ1-zgap;			Z[0] = zEndOfAbsorb + dZ[0]+zgap;
-
-  fieldDirection[1] = FieldDirection::up;
-  dXIn[1]  = 0.36*m;			dYIn[1]	= 0.8158*m;
-  dXOut[1] = 0.19*m;			dYOut[1]= 0.499*m;
-  midGapIn[1] = 0; 			midGapOut[1] = 0;
-  HmainSideMagIn[1] = dYIn[1]/2;  	HmainSideMagOut[1] = dYOut[1]/2;
-  gapIn[1] = 88;			gapOut[1] = 122;
-  dZ[1] = dZ2-zgap/2;			Z[1] = Z[0] + dZ[0] + dZ[1]+zgap;
-
-  fieldDirection[2] = FieldDirection::down;
-  dXIn[2]  = 0.075*m;			dYIn[2]	= 0.499*m;
-  dXOut[2] = 0.25*m;			dYOut[2]= 1.10162*m;
-  midGapIn[2] = 0; 			midGapOut[2] = 0;
-  HmainSideMagIn[2] = dYIn[2]/2;  	HmainSideMagOut[2] = dYOut[2]/2;
-  gapIn[2] = 0;				gapOut[2] = 0;
-  dZ[2] = dZ3-zgap/2;			Z[2] = Z[1] + dZ[1] + dZ[2]+zgap;
-
-  fieldDirection[3] = FieldDirection::down;
-  dXIn[3]  = 0.25*m;			dYIn[3]	= 1.10262*m;
-  dXOut[3] = 0.3*m;			dYOut[3]= 1.82697*m;
-  midGapIn[3] = 0; 			midGapOut[3] = 0;
-  HmainSideMagIn[3] = dXIn[3];  	HmainSideMagOut[3] = dXOut[3];
-  gapIn[3] = 0;				gapOut[3] = 25;
-  dZ[3] = dZ4-zgap/2;			Z[3] = Z[2] + dZ[2] + dZ[3]+zgap;
-
-  fieldDirection[4] = FieldDirection::down;
-  dXIn[4]  = 0.3*m;			dYIn[4]	= 1.82697*m;
-  dXOut[4] = 0.4*m;			dYOut[4]= 2.55131*m;
-  midGapIn[4] = 5; 			midGapOut[4] = 25;
-  HmainSideMagIn[4] = dXIn[4];  	HmainSideMagOut[4] = dXOut[4];
-  gapIn[4] = 20;			gapOut[4] = 20;
-  dZ[4] = dZ6-zgap/2;			Z[4] = Z[3] + dZ[3] + dZ[4]+zgap;
-
-  fieldDirection[5] = FieldDirection::down;
-  dXIn[5]  = 0.4*m;			dYIn[5]	= 2.55131*m;
-  dXOut[5] =0.4*m;			dYOut[5]= 3.27566*m;
-  midGapIn[5] = 25; 			midGapOut[5] = 65;
-  HmainSideMagIn[5] = dXIn[5];  	HmainSideMagOut[5] = dXOut[5];
-  gapIn[5] = 20;			gapOut[5] = 20;
-  dZ[5] = dZ7-zgap/2;			Z[5] = Z[4] + dZ[4] + dZ[5]+zgap;
-
-  fieldDirection[6] = FieldDirection::down;
-  dXIn[6]  = 0.4*m;			dYIn[6]	= 3.27566*m;
-  dXOut[6] = 0.75*m;			dYOut[6]= 4*m;
-  midGapIn[6] = 65; 		        midGapOut[6] = 75;
-  HmainSideMagIn[6] = dXIn[6];  	HmainSideMagOut[6] = dXOut[6];
-  gapIn[6] = 20;			gapOut[6] = 20;
-  dZ[6] = dZ8-zgap/2;			Z[6] = Z[5] + dZ[5] + dZ[6]+zgap;
-  }
   return nMagnets;
 }
 void ShipMuonShield::ConstructGeometry()
@@ -812,21 +348,11 @@ void ShipMuonShield::ConstructGeometry()
     InitMedium("Concrete");
     TGeoMedium *concrete  =gGeoManager->GetMedium("Concrete");
 
-    if (fDesign >= 7 && fDesign <= 9) {
-      Double_t ironField = fField*tesla;
-      TGeoUniformMagField *magFieldIron = new TGeoUniformMagField(0.,ironField,0.);
-      TGeoUniformMagField *RetField     = new TGeoUniformMagField(0.,-ironField,0.);
-      TGeoUniformMagField *ConRField    = new TGeoUniformMagField(-ironField,0.,0.);
-      TGeoUniformMagField *ConLField    = new TGeoUniformMagField(ironField,0.,0.);
-      TGeoUniformMagField *fields[4] = {magFieldIron,RetField,ConRField,ConLField};
-
       std::vector<TString> magnetName;
       std::vector<FieldDirection> fieldDirection;
-      std::vector<Double_t> dXIn, dYIn, dXOut, dYOut, dZf, midGapIn, midGapOut,
-	  HmainSideMagIn, HmainSideMagOut, gapIn, gapOut, Z;
-      const Int_t nMagnets = Initialize(magnetName, fieldDirection, dXIn, dYIn, dXOut, dYOut, dZf,
-		 midGapIn, midGapOut, HmainSideMagIn, HmainSideMagOut, gapIn,
-		 gapOut, Z);
+      std::vector<Double_t> dXIn, dYIn, dXOut, dYOut, dZf, midGapIn, midGapOut, ratio_yokesIn, ratio_yokesOut, dY_yokeIn, dY_yokeOut, gapIn, gapOut, NI, Z;
+      const Int_t nMagnets = Initialize(magnetName, fieldDirection, dXIn, dYIn, dXOut, dYOut, ratio_yokesIn, ratio_yokesOut,
+        dY_yokeIn, dY_yokeOut, dZf, midGapIn, midGapOut, NI, gapIn, gapOut, Z);
 
       // Create TCC8 tunnel around muon shield
       Double_t TCC8_length =  170 * m;
@@ -836,7 +362,7 @@ void ShipMuonShield::ConstructGeometry()
       Double_t TCC8_trench_length = 12 * m;
       Double_t zgap = 10 * cm;
       Double_t absorber_offset = zgap;
-      Double_t absorber_half_length = (dZf[0] + dZf[1]) + zgap / 2.;
+      Double_t absorber_half_length = (dZf[0]);
       Double_t z_transition = zEndOfAbsorb + 2 * absorber_half_length + absorber_offset + 14 * cm + TCC8_trench_length;
       auto *rock = new TGeoBBox("rock", 20 * m, 20 * m, TCC8_length / 2. + ECN3_length / 2. + 5 * m);
       auto *muon_shield_cavern = new TGeoBBox("muon_shield_cavern", 4.995 * m, 3.75 * m, TCC8_length / 2.);
@@ -860,58 +386,64 @@ void ShipMuonShield::ConstructGeometry()
       auto *target_pit_shift = new TGeoTranslation("target_pit_shift", 0 * m, -2.2 * m, zEndOfAbsorb - 2 * m - z_transition);
       target_pit_shift->RegisterYourself();
 
-        float mField = 1.6 * tesla;
-	TGeoUniformMagField *fieldsAbsorber[4] = {
-	    new TGeoUniformMagField(0., mField, 0.),
-	    new TGeoUniformMagField(0., -mField, 0.),
-	    new TGeoUniformMagField(-mField, 0., 0.),
-	    new TGeoUniformMagField(mField, 0., 0.)
-	};
 
-	for (Int_t nM = (fDesign == 7) ? 0 : 1; nM < 2; nM++) {
-	  CreateMagnet(magnetName[nM], iron, tShield, fieldsAbsorber,
-		       fieldDirection[nM], dXIn[nM], dYIn[nM], dXOut[nM],
-		       dYOut[nM], dZf[nM], midGapIn[nM], midGapOut[nM],
-		       HmainSideMagIn[nM], HmainSideMagOut[nM], gapIn[nM],
-		       gapOut[nM], Z[nM], true, false);
-	}
+      std::array<double, 7> fieldScale = {{1., 1., 1., 1., 1., 1., 1.}};
+      for (Int_t nM = 0; nM < (nMagnets); nM++) {
+        if (dZf[nM] < 1e-5){
+                    continue;
+                  }
 
+                  // Initialize the field
+                  Double_t ironField_s = fField * fieldScale[nM] * tesla;
+        // SC MAGNET
+        if (nM == 4  && fSC_mag) {
+              continue;
+            }
+            ironField_s = fField * fieldScale[nM] * tesla;
+            if (nM == 3 && fSC_mag) {
+                Double_t SC_FIELD = 5.1;
+                ironField_s = SC_FIELD * fieldScale[nM] * tesla;
+            }
+        if (nM == 0){
+          ironField_s = HA_field * fieldScale[nM] * tesla;
+        }
+        // END
+        TGeoUniformMagField *magFieldIron_s = new TGeoUniformMagField(0.,ironField_s,0.);
+        TGeoUniformMagField *RetField_s     = new TGeoUniformMagField(0.,-ironField_s,0.);
+        TGeoUniformMagField *ConRField_s    = new TGeoUniformMagField(-ironField_s,0.,0.);
+        TGeoUniformMagField *ConLField_s    = new TGeoUniformMagField(ironField_s,0.,0.);
+        TGeoUniformMagField *fields_s[4] = {magFieldIron_s,RetField_s,ConRField_s,ConLField_s};
+        // Create the magnet
+        CreateMagnet(magnetName[nM], iron, tShield, fields_s, fieldDirection[nM],
+          dXIn[nM], dYIn[nM], dXOut[nM], dYOut[nM],  ratio_yokesIn[nM], ratio_yokesOut[nM], dY_yokeIn[nM], dY_yokeOut[nM], dZf[nM],
+          midGapIn[nM], midGapOut[nM], gapIn[nM], gapOut[nM], Z[nM], nM==0, nM == 3 && fSC_mag);
+        }
+
+      // Place in origin of SHiP coordinate system as subnodes placed correctly
+      top->AddNode(tShield, 1);
+
+      // Create the cavern
       std::vector<TGeoTranslation*> mag_trans;
 
-      if (fDesign == 7) {
-         auto mag1 = new TGeoTranslation("mag1", 0, 0, -dZ2);
-         mag1->RegisterYourself();
-	 mag_trans.push_back(mag1);
-      }
-      auto mag2 = new TGeoTranslation("mag2", 0, 0, +dZ1);
+      auto mag2 = new TGeoTranslation("mag2", 0, 0, -0.001*m);
       mag2->RegisterYourself();
       mag_trans.push_back(mag2);
 
-      auto abs = new TGeoBBox("absorber",  4.995 * m -0.001*m, 3.75 * m -0.001*m, absorber_half_length - 0.001);
+      // Absorber
+
+      auto abs = new TGeoBBox("absorber",  4.995 * m -0.002*m, 3.75 * m, absorber_half_length - 0.001);
       auto *absorber_shift = new TGeoTranslation("absorber_shift", 1.435 * m, 2.05 * m, 0);
       absorber_shift->RegisterYourself();
 
-      const std::vector<TString> absorber_magnets =
-         (fDesign == 7) ? std::vector<TString>{"MagnAbsorb1", "MagnAbsorb2"} : std::vector<TString>{"MagnAbsorb2"};
-      const std::vector<TString> magnet_components = fDesign == 7 ? std::vector<TString>{
-	  "_MiddleMagL", "_MiddleMagR",  "_MagRetL",    "_MagRetR",
-	  "_MagCLB",     "_MagCLT",      "_MagCRT",     "_MagCRB",
-	  "_MagTopLeft", "_MagTopRight", "_MagBotLeft", "_MagBotRight",
-      }: std::vector<TString>{
-	  "_MiddleMagL", "_MiddleMagR",  "_MagRetL",    "_MagRetR",
-	  "_MagTopLeft", "_MagTopRight", "_MagBotLeft", "_MagBotRight",
-      };
+      const std::vector<TString> absorber_magnets = {"MagnAbsorb"};
+      const std::vector<TString> magnet_components = {
+        "_MiddleMagL", "_MiddleMagR",  "_MagRetL",    "_MagRetR",
+        "_MagTopLeft", "_MagTopRight", "_MagBotLeft", "_MagBotRight",
+    };
       TString absorber_magnet_components;
       for (auto &&magnet_component : magnet_components) {
 	// format: "-<magnetName>_<magnet_component>:<translation>"
-	absorber_magnet_components +=
-	    ("-" + absorber_magnets[0] + magnet_component + ":" +
-	     mag_trans[0]->GetName());
-	if (fDesign == 7) {
-	absorber_magnet_components +=
-	    ("-" + absorber_magnets[1] + magnet_component + ":" +
-	     mag_trans[1]->GetName());
-	}
+	absorber_magnet_components += ("-" + absorber_magnets[0] + magnet_component + ":" + mag_trans[0]->GetName());
       }
       TGeoCompositeShape *absorberShape = new TGeoCompositeShape(
 	  "Absorber", "absorber:absorber_shift" + absorber_magnet_components); // cutting out
@@ -934,106 +466,5 @@ void ShipMuonShield::ConstructGeometry()
       top->AddNode(Cavern, 1, new TGeoTranslation(0, 0, z_transition));
 
 
-      std::array<double, 9> fieldScale = {{1., 1., 1., 1., 1., 1., 1., 1., 1.}};
-      if (fWithCoMagnet > 0)
-      {
-        Double_t lengthSum = 0.;
-        for (int i = 2; i < 9; ++i)
-        {
-          lengthSum += dZf[i];
-        }
-        fieldScale.fill((fField * lengthSum -  2.2 * dZf[fWithCoMagnet])/fField/(lengthSum - dZf[fWithCoMagnet]));
-        fieldScale[0] = 1.;
-        fieldScale[1] = 1.;
-        try
-        {
-         fieldScale.at(fWithCoMagnet) = 2.2 / fField;
-        }
-        catch(const std::out_of_range& e)
-        {
-           Fatal( "ShipMuonShield", "Exception out of range for --coMuonShield occurred \n");
-        }
-      }
-      for (Int_t nM = 2; nM <= (nMagnets - 1); nM++) {
 
-          // SC MAGNET
-  if ((dZf[nM] < 1e-5 || nM == 4 ) && fSC_mag) {
-        continue;
-      }
-      Double_t ironField_s_SC = fField * fieldScale[nM] * tesla;
-      if (nM == 3 && fSC_mag) {
-          Double_t SC_FIELD = 5.1;
-          ironField_s_SC = SC_FIELD * fieldScale[nM] * tesla;
-      }
-  // END
-  Double_t ironField_s = fField * fieldScale[nM] * tesla;
-  TGeoUniformMagField *magFieldIron_s = new TGeoUniformMagField(0.,ironField_s_SC,0.);
-  TGeoUniformMagField *RetField_s     = new TGeoUniformMagField(0.,-ironField_s,0.);
-  TGeoUniformMagField *ConRField_s    = new TGeoUniformMagField(-ironField_s,0.,0.);
-  TGeoUniformMagField *ConLField_s    = new TGeoUniformMagField(ironField_s,0.,0.);
-  TGeoUniformMagField *fields_s[4] = {magFieldIron_s,RetField_s,ConRField_s,ConLField_s};
-  CreateMagnet(magnetName[nM], iron, tShield, fields_s, fieldDirection[nM],
-          dXIn[nM], dYIn[nM], dXOut[nM], dYOut[nM], dZf[nM],
-          midGapIn[nM], midGapOut[nM], HmainSideMagIn[nM],
-          HmainSideMagOut[nM], gapIn[nM], gapOut[nM], Z[nM], nM==8, fStepGeo, nM == 3 && fSC_mag);
-
-
-	if (nM==8 || !fSupport) continue;
-	Double_t dymax = std::max(dYIn[nM] + dXIn[nM], dYOut[nM] + dXOut[nM]);
-	Double_t dymin = std::min(dYIn[nM] + dXIn[nM], dYOut[nM] + dXOut[nM]);
-	Double_t slope =
-	    (dYIn[nM] + dXIn[nM] - dYOut[nM] - dXOut[nM]) / (2 * dZf[nM]);
-	Double_t w1 = 2 * dXIn[nM] + std::max(20., gapIn[nM]);
-	Double_t w2 = 2 * dXOut[nM] + std::max(20., gapOut[nM]);
-	Double_t anti_overlap = 0.1;
-	Double_t h1 = 0.5 * (dYIn[nM] + dXIn[nM] + anti_overlap - 10 * m + fFloor);
-	Double_t h2 = 0.5 * (dYOut[nM] + dXOut[nM] + anti_overlap - 10 * m + fFloor);
-	Double_t length = std::min(0.5 * m, std::abs(dZf[nM]/2. - 5 * cm));
-	std::array<Double_t, 16> verticesIn = {
-	    -w1, -h1,
-	    +w1, -h1,
-	    +w1, +h1,
-	    -w1, +h1,
-	    -w1, -h1 + slope * 2. * length,
-	    +w1, -h1 + slope * 2. * length,
-	    +w1, +h1,
-	    -w1, +h1,
-	};
-	std::array<Double_t, 16> verticesOut = {
-	    -w2, -h2 - slope * 2. * length,
-	    +w2, -h2 - slope * 2. * length,
-	    +w2, +h2,
-	    -w2, +h2,
-	    -w2, -h2,
-	    +w2, -h2,
-	    +w2, +h2,
-	    -w2, +h2,
-	};
-  if (!fStepGeo)
-  {
-
-
-  	TGeoVolume *pillar1 =
-  	    gGeoManager->MakeArb8(TString::Format("pillar_%d", 2 * nM - 1),
-  				  steel, length, verticesIn.data());
-  	TGeoVolume *pillar2 =
-  	    gGeoManager->MakeArb8(TString::Format("pillar_%d", 2 * nM), steel,
-  				  length, verticesOut.data());
-  	pillar1->SetLineColor(kGreen-5);
-  	pillar2->SetLineColor(kGreen-5);
-  	tShield->AddNode(pillar1, 1, new TGeoTranslation(
-  				     0, -0.5 * (dYIn[nM] + dXIn[nM] + 10 * m - fFloor),
-  				     Z[nM] - dZf[nM] + length));
-  	tShield->AddNode(pillar2, 1, new TGeoTranslation(
-  				     0, -0.5 * (dYOut[nM] + dXOut[nM] + 10 * m - fFloor),
-  				     Z[nM] + dZf[nM] - length));
-  }
-      }
-
-      // Place in origin of SHiP coordinate system as subnodes placed correctly
-      top->AddNode(tShield, 1);
-
-    } else {
-     Fatal("ShipMuonShield","Design %i does not match implemented designs",fDesign);
-    }
 }

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -20,39 +20,19 @@ class ShipMuonShield : public FairModule
 {
   public:
 
-   ShipMuonShield(const char* name, const Int_t Design=1,  const char* Title="ShipMuonShield",
-                               Double_t Z=0, Double_t L0=0, Double_t L1=0, Double_t L2=0, Double_t L3=0, Double_t L4=0, Double_t L5=0, Double_t L6=0,
-                               Double_t L7=0, Double_t L8=0,Double_t gap=0,Double_t LE=0,Double_t y=400, Double_t floor=500, Double_t field=1.7,
-                               const Int_t withCoMagnet=0, const Bool_t StepGeo=false,
-                               const Bool_t WithConstAbsorberField=true, const Bool_t WithConstShieldField=true);
-
-   ShipMuonShield(TString geofile, Double_t floor=500, const Int_t withCoMagnet=0, const Bool_t StepGeo=false,
-   const Bool_t WithConstAbsorberField=true, const Bool_t WithConstShieldField=true);
-   ShipMuonShield(TVectorT<Double_t> in_params,
-                  Double_t floor, const Int_t withCoMagnet, const Bool_t StepGeo, const Bool_t WithConstAbsorberField, const Bool_t WithConstShieldField, const Bool_t SC_key);
+   ShipMuonShield(std::vector<double> in_params,
+                  Double_t floor, const Bool_t WithConstShieldField, const Bool_t SC_key);
    ShipMuonShield();
    virtual ~ShipMuonShield();
    void ConstructGeometry();
    ClassDef(ShipMuonShield,4)
 
-  void SetSupports(Bool_t supports) {
-    fSupport = supports;
-    LOG(WARNING) <<"Setting supports to "<< (fSupport ? "true" : "false") << ". This will not have any effect if called after the geometry has been constructed.";
-  }
-
  protected:
 
-  Int_t  fDesign;       // design of muon shield, 1=passive, active = ...
-  TString fGeofile;
-  Double_t  fMuonShieldLength,fY,fField;
+  Double_t  fMuonShieldLength,fField, HA_field; // FIXME: HA_field to be removed in the next workshop meeting
   Double_t fFloor;
-  Bool_t fSupport;
-  Double_t  dZ0,dZ1,dZ2,dZ3,dZ4,dZ5,dZ6,dZ7,dZ8,dXgap,zEndOfAbsorb,mag4Gap,midGapOut7,midGapOut8;
+  Double_t  dZ0,dZ1,dZ2,dZ3,dZ4,dZ5,dZ6,dZ7,dXgap,zEndOfAbsorb;
   Int_t InitMedium(TString name);
-
-  Int_t fWithCoMagnet;
-  Bool_t fStepGeo;
-  Bool_t fWithConstAbsorberField;
   Bool_t fWithConstShieldField;
   Bool_t fSC_mag;
   std::vector<Double_t> shield_params;
@@ -63,36 +43,30 @@ class ShipMuonShield : public FairModule
 		  Double_t x_translation, Double_t y_translation,
 		  Double_t z_translation);
 
-    void CreateArb8(TString arbName, TGeoMedium *medium, Double_t dZ,
-      std::array<Double_t, 16> corners, Int_t color,
-      TGeoUniformMagField *magField, TGeoVolume *top,
-      Double_t x_translation, Double_t y_translation,
-      Double_t z_translation,
-      Bool_t stepGeo);
-
-  void CreateTube(TString tubeName, TGeoMedium *medium, Double_t dX,
-		  Double_t dY, Double_t dZ, Int_t color, TGeoVolume *top,
-		  Double_t x_translation, Double_t y_translation,
-		  Double_t z_translation);
 
   Int_t Initialize(std::vector<TString> &magnetName,
 		  std::vector<FieldDirection> &fieldDirection,
 		  std::vector<Double_t> &dXIn, std::vector<Double_t> &dYIn,
 		  std::vector<Double_t> &dXOut, std::vector<Double_t> &dYOut,
+      std::vector<Double_t> &ratio_yokesIn, std::vector<Double_t> &ratio_yokesOut,
+      std::vector<Double_t> &dY_yokeIn, std::vector<Double_t> &dY_yokeOut,
 		  std::vector<Double_t> &dZ, std::vector<Double_t> &midGapIn,
 		  std::vector<Double_t> &midGapOut,
-		  std::vector<Double_t> &HmainSideMagIn,
-		  std::vector<Double_t> &HmainSideMagOut,
+      std::vector<Double_t> &NI,
 		  std::vector<Double_t> &gapIn, std::vector<Double_t> &gapOut,
 		  std::vector<Double_t> &Z);
 
   void CreateMagnet(TString magnetName, TGeoMedium *medium, TGeoVolume *tShield,
 		    TGeoUniformMagField *fields[4],
-		    FieldDirection fieldDirection, Double_t dX, Double_t dY,
-		    Double_t dX2, Double_t dY2, Double_t dZ, Double_t middleGap,
-		    Double_t middleGap2, Double_t HmainSideMag,
-		    Double_t HmainSideMag2, Double_t gap, Double_t gap2,
-		    Double_t Z, Bool_t NotMagnet, Bool_t stepGeo,  Bool_t SC_key);
+		    FieldDirection fieldDirection,
+        Double_t dX, Double_t dY,
+		    Double_t dX2, Double_t dY2,
+        Double_t ratio_yoke_1, Double_t ratio_yoke_2,
+        Double_t dY_yoke_1, Double_t dY_yoke_2,
+        Double_t dZ,
+        Double_t middleGap, Double_t middleGap2,
+        Double_t gap, Double_t gap2,
+		    Double_t Z, Bool_t NotMagnet,  Bool_t SC_key);
 
 
 };

--- a/python/ShieldUtils.py
+++ b/python/ShieldUtils.py
@@ -1,7 +1,7 @@
 def find_shield_center(ship_geo):
     zEndOfAbsorb = ship_geo.muShield.z - ship_geo.muShield.length / 2;
-    dZ = [None] * 9
-    Z = [None] * 9
+    dZ = [None] * 7
+    Z = [None] * 7
     zgap = 10.
     dZ[0] = ship_geo.muShield.dZ1 - zgap / 2;
     Z[0] = zEndOfAbsorb + dZ[0] + zgap;
@@ -24,12 +24,7 @@ def find_shield_center(ship_geo):
     dZ[6] = ship_geo.muShield.dZ7 - zgap / 2;
     Z[6] = Z[5] + dZ[5] + dZ[6] + zgap;
 
-    dZ[7] = ship_geo.muShield.dZ8 - zgap / 2;
-    Z[7] = Z[6] + dZ[6] + dZ[7] + zgap;
 
-    dZ[8] = 10.;
-    Z[8] = Z[7] + dZ[7] + dZ[8];
-
-    shield_center = (Z[2] + Z[8] + dZ[8] - dZ[2]) / 2
-    shield_half_lenth = abs((Z[2] - dZ[2]) - (Z[8] + dZ[8])) / 2
+    shield_center = (Z[1] + Z[6] + dZ[6] - dZ[1]) / 2
+    shield_half_lenth = abs((Z[1] - dZ[1]) - (Z[6] + dZ[6])) / 2
     return shield_center, shield_half_lenth

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -319,29 +319,14 @@ def configure(run, ship_geo):
         cave.SetGeometryFileName("caveWithAir.geo")
     detectorList.append(cave)
 
-    if ship_geo.muShieldDesign in [
-        7,
-        8,
-        9,
-        10,
-    ]:  # magnetized hadron absorber defined in ShipMuonShield
-        TargetStation = ROOT.ShipTargetStation(
-            "TargetStation",
-            ship_geo.target.length,
-            ship_geo.target.z,
-            ship_geo.targetOpt,
-            ship_geo.target.sl,
-        )
-    else:
-        TargetStation = ROOT.ShipTargetStation(
-            "TargetStation",
-            ship_geo.target.length,
-            ship_geo.hadronAbsorber.length,
-            ship_geo.target.z,
-            ship_geo.hadronAbsorber.z,
-            ship_geo.targetOpt,
-            ship_geo.target.sl,
-        )
+    # magnetized hadron absorber defined in ShipMuonShield
+    TargetStation = ROOT.ShipTargetStation(
+        "TargetStation",
+        ship_geo.target.length,
+        ship_geo.target.z,
+        ship_geo.targetOpt,
+        ship_geo.target.sl,
+    )
 
     if ship_geo.targetOpt > 10:
         slices_length = ROOT.std.vector("float")()
@@ -352,44 +337,15 @@ def configure(run, ship_geo):
         TargetStation.SetLayerPosMat(ship_geo.target.xy, slices_length, slices_material)
     detectorList.append(TargetStation)
 
-    if ship_geo.muShieldDesign in [7, 9]:
-        MuonShield = ROOT.ShipMuonShield(
-            "MuonShield",
-            ship_geo.muShieldDesign,
-            "ShipMuonShield",
-            ship_geo.muShield.z,
-            ship_geo.muShield.dZ0,
-            ship_geo.muShield.dZ1,
-            ship_geo.muShield.dZ2,
-            ship_geo.muShield.dZ3,
-            ship_geo.muShield.dZ4,
-            ship_geo.muShield.dZ5,
-            ship_geo.muShield.dZ6,
-            ship_geo.muShield.dZ7,
-            ship_geo.muShield.dZ8,
-            ship_geo.muShield.dXgap,
-            ship_geo.muShield.LE,
-            ship_geo.Yheight * 4.0 / 10.0,
-            ship_geo.cave.floorHeightMuonShield,
-            ship_geo.muShield.Field,
-            ship_geo.muShieldWithCobaltMagnet,
-            ship_geo.muShieldStepGeo,
-            ship_geo.hadronAbsorber.WithConstField,
-            ship_geo.muShield.WithConstField,
-        )
-    elif ship_geo.muShieldDesign == 8:
-        in_params = ROOT.TVectorD(
-            len(ship_geo.muShield.params), array("d", ship_geo.muShield.params)
-        )
-        MuonShield = ROOT.ShipMuonShield(
-            in_params,
-            ship_geo.cave.floorHeightMuonShield,
-            ship_geo.muShieldWithCobaltMagnet,
-            ship_geo.muShieldStepGeo,
-            ship_geo.hadronAbsorber.WithConstField,
-            ship_geo.muShield.WithConstField,
-            ship_geo.SC_mag
-        )
+
+    in_params = list(ship_geo.muShield.params)
+
+    MuonShield = ROOT.ShipMuonShield(
+        in_params,
+        ship_geo.cave.floorHeightMuonShield,
+        ship_geo.muShield.WithConstField,
+        ship_geo.SC_mag
+    )
     detectorList.append(MuonShield)
 
     if not hasattr(ship_geo, "magnetDesign"):


### PR DESCRIPTION
Removed old option (7,9,10). Muonshield geometry is defined in geometry config.py and the SC is based on the choice made. Removed Cobalt option.