### PR TITLE
Added dump_event() function to analysis_toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ it in future.
 * **Corrections in MuonDIS simulation**
   The DIS interactions are now time-shifted to be consistent with the original incoming muon. Additionally, tracks from soft interactions of the original muon along with the muon's veto response are preserved (in muonDis.root) and included up to the DIS interaction point. To be noted that the muon veto points are manually added using add_muonresponse.py, which modifies the simulation file. This replaces the old method of "backward-travelling muon" to generate the incoming muon's veto response. All MuonDIS simulation scripts have been updated and consolidated within FairShip/muonDIS, ensuring consistency for new productions.
 * Added a custom CrossSection branch to the simulation file to save the DIS cross sections from muonDIS.
+* Added event_inspector class to experimental analysis_toolkit to streamline usage of helper functions; Added dump_event() as a start.
 
 ### Fixed
 

--- a/examples/analysis_example.py
+++ b/examples/analysis_example.py
@@ -22,6 +22,8 @@ def main():
     )
 
     selection = analysis_toolkit.selection_check(geo_file)
+    inspector = analysis_toolkit.event_inspector()
+
     hist_dict = {}
 
     ut.bookHist(hist_dict, "event_weight", "Event weight", 100, 100, 100)
@@ -74,6 +76,9 @@ def main():
         if len(event.Particles) == 0:
             continue
 
+        print(f"Event{event_nr}:")
+        inspector.dump_event(event, mom_threshold=0.5)  # in GeV
+
         event_weight = event.MCTrack[2].GetWeight()
 
         hist_dict["event_weight"].Fill(event_weight)
@@ -101,8 +106,6 @@ def main():
                 print(
                     f"Event:{event_nr} Candidate_index: {candidate_id_in_event} <--passes the pre-selection\n\n"
                 )
-            else:
-                print(f"Event:{event_nr} Candidate_index: {candidate_id_in_event} \n\n")
 
     ut.writeHists(hist_dict, "preselectionparameters.root")
 


### PR DESCRIPTION
This is a modified `dump_event()` function inspired by the `dump()` function in ShipAna.py.
Output for an event (produced using `analysis_example.py `:
![Screenshot from 2025-04-04 16-32-45](https://github.com/user-attachments/assets/52b8e256-c5ea-4589-a3cf-e43fbf38b975)
