### PR TITLE
Assume all tracks are muons during track fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ it in future.
 * feat(digi): Use STL vectors for SBT digitisation
 * Change max x of stereo hits to match straw length
 * Get rid of straw diameter dependency in scale factor
+* Assume all tracks are muons during track fit (avoid using MC truth)
 
 ### Removed
 

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -884,9 +884,9 @@ class ShipDigiReco:
 #
   for atrack in hitPosLists:
     if atrack < 0: continue # these are hits not assigned to MC track because low E cut
-    pdg    = self.sTree.MCTrack[atrack].GetPdgCode()
-    if not self.PDG.GetParticle(pdg): continue # unknown particle
-    # pdg = 13
+    # pdg    = self.sTree.MCTrack[atrack].GetPdgCode()
+    # if not self.PDG.GetParticle(pdg): continue # unknown particle
+    pdg = 13 # assume all tracks are muons
     meas = hitPosLists[atrack]
     detIDs = hit_detector_ids[atrack]
     nM = meas.size()

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -978,6 +978,7 @@ class ShipDigiReco:
       error = "Fit not converged"
       ut.reportError(error)
     nmeas = fitStatus.getNdf()
+    global_variables.h['nmeas'].Fill(nmeas)
     if nmeas > 0:
       chi2 = fitStatus.getChi2() / nmeas
       global_variables.h['chi2'].Fill(chi2)


### PR DESCRIPTION
The MC track matching for tracks from real pattern recognition doesn’t work. For simplicity, use muon as particle hypothesis during track fit. Use of PID information for hypothesis to be studied.