### PR TITLE
modified GetXYZ method on UBT Hit to work with scoring plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ it in future.
 * fix: don't use TFile's deprecated attribute syntax
 * fix(digi): Fix logic of SST digitisation (#662)
 * Fix double append of recognized stracks
+* Fix GetXYZ for UBT; adapted for the single scoring plane. 
 
 ### Changed
 

--- a/UpstreamTagger/UpstreamTaggerHit.cxx
+++ b/UpstreamTagger/UpstreamTaggerHit.cxx
@@ -113,10 +113,8 @@ void UpstreamTaggerHit::Dist(Float_t x, Float_t& lpos, Float_t& lneg){
 // ----------------------------------------------
 TVector3 UpstreamTaggerHit::GetXYZ()
 {
-    Double_t hit_final;
-    Int_t mod;
     TGeoNavigator* nav = gGeoManager->GetCurrentNavigator();
-    TGeoNode* node = GetNode(hit_final, mod);
+    TGeoNode* node = GetNode();
     auto shape =  dynamic_cast<TGeoBBox*>(node->GetVolume()->GetShape());
     Double_t origin[3] = {shape->GetOrigin()[0],shape->GetOrigin()[1],shape->GetOrigin()[2]};
     Double_t master[3] = {0,0,0};


### PR DESCRIPTION
This fix the GetXYZ method on UpstreamTaggerHit, based on the new geometry of UBT. There is no need of search for modules since now is a single volume. 
This fix issue #354 