### PR TITLE
Update tracker station z positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ it in future.
 * Change of UBT geometry, remove implementation of RPC and setting a new scoring plane of 4×6 m
 * Allow specifying spectrometer field map
 * Obtain tauMuDet z position from muonshield position and length, instead of chamber trackers
-* Update tracker station z positions (16 April 2025)
+* Update tracker station z positions, fix UBT, TimeDet & SplitCal position (s. integration layout EDMS 3287817 v1)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ it in future.
 * Change of UBT geometry, remove implementation of RPC and setting a new scoring plane of 4×6 m
 * Allow specifying spectrometer field map
 * Obtain tauMuDet z position from muonshield position and length, instead of chamber trackers
+* Update tracker station z positions (16 April 2025)
 
 ### Removed
 

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -128,7 +128,7 @@ with ConfigRegistry.register_config("basic") as c:
      c.chambers.Rmin = 245.*u.cm
      c.chambers.Rmax = 250.*u.cm
      # positions and lenghts of vacuum tube segments
-     zset = -25.40 * u.m #Relative position of UBT to decay vessel centre
+     zset=z4-4666.*u.cm-magnetIncrease-extraVesselLength
      c.Chamber1 = AttrDict(z=zset)
      zset=z4-2628.*u.cm-magnetIncrease-extraVesselLength/2.
      c.Chamber2 = AttrDict(z=zset)
@@ -440,4 +440,4 @@ with ConfigRegistry.register_config("basic") as c:
     c.UpstreamTagger.X_Strip = 229 * u.cm  - UBT_x_crop
     c.UpstreamTagger.X_Strip64 = 1.534 * u.cm
     c.UpstreamTagger.Y_Strip64 = 111 * u.cm
-    c.UpstreamTagger.Z_Position = c.tauMudet.zMudetC + (c.tauMudet.Ztot)/2 + 12.0*u.cm
+    c.UpstreamTagger.Z_Position = -25.40 * u.m #Relative position of UBT to decay vessel centre

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -112,7 +112,7 @@ with ConfigRegistry.register_config("basic") as c:
     magnetIncrease    = 100.*u.cm
     # make z coordinates for the decay volume and tracking stations relative to T4z
     # eventually, the only parameter which needs to be changed when the active shielding lenght changes.
-    c.z = 31.450 * u.m #Relative position of spectrometer magnet to decay vessel centre
+    c.z = 31.450 * u.m  # Relative position of spectrometer magnet to decay vessel centre
     if strawDesign != 4 and strawDesign != 10:
      print("this design ",strawDesign," is not supported, use strawDesign = 4 or 10")
      1/0
@@ -129,20 +129,20 @@ with ConfigRegistry.register_config("basic") as c:
      # positions and lenghts of vacuum tube segments
      zset = -4666. * u.cm - magnetIncrease - extraVesselLength
      c.Chamber1 = AttrDict(z=zset)
-     zset = -2628. * u.cm - magnetIncrease - extraVesselLength/2.
+     zset = -2628. * u.cm - magnetIncrease - extraVesselLength / 2.
      c.Chamber2 = AttrDict(z=zset)
      zset = -740. * u.cm - magnetIncrease
      c.Chamber3 = AttrDict(z=zset)
-     zset = -420. * u.cm - magnetIncrease/2.
+     zset = -420. * u.cm - magnetIncrease / 2.
      c.Chamber4 = AttrDict(z=zset)
      zset = -100. * u.cm
      c.Chamber5 = AttrDict(z=zset)
-     zset = 30. * u.cm + windowBulge/2.
+     zset = 30. * u.cm + windowBulge / 2.
      c.Chamber6 = AttrDict(z=zset)
 
      c.xMax = 2 * u.m  # max horizontal width at T4
-     TrGap = 2 * u.m #Distance between Tr1/2 and Tr3/4
-     TrMagGap = 3.5 * u.m #Distance from spectrometer magnet centre to the next tracking stations
+     TrGap = 2 * u.m  # Distance between Tr1/2 and Tr3/4
+     TrMagGap = 3.5 * u.m  # Distance from spectrometer magnet centre to the next tracking stations
      #
      z4 = c.z + TrMagGap + TrGap
      c.TrackStation4 = AttrDict(z=z4)
@@ -209,7 +209,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.TimeDet.DZ = (c.TimeDet.dzBarRow + c.TimeDet.dzBarCol + c.TimeDet.zBar) / 2
     c.TimeDet.DX = 225 * u.cm
     c.TimeDet.DY = 325 * u.cm
-    c.TimeDet.z = 37.800 * u.m - c.TimeDet.dzBarRow * 3 / 2 #Relative position of first layer of timing detector to decay vessel centre
+    c.TimeDet.z = 37.800 * u.m - c.TimeDet.dzBarRow * 3 / 2  # Relative position of first layer of timing detector to decay vessel centre
 
     if CaloDesign==0:
      c.HcalOption = 1
@@ -227,7 +227,7 @@ with ConfigRegistry.register_config("basic") as c:
      1/0
 
     c.SplitCal = AttrDict(z=0)
-    c.SplitCal.ZStart = 38.450 * u.m #Relative start z of split cal to decay vessel centre
+    c.SplitCal.ZStart = 38.450 * u.m  # Relative start z of split cal to decay vessel centre
     c.SplitCal.XMax = 480.*u.cm/2. #290.*u.cm  #half length
     c.SplitCal.YMax = 720. * u.cm / 2. #510.*u.cm * c.Yheight / (10.*u.m)   #half length
     c.SplitCal.Empty = 0*u.cm
@@ -257,13 +257,13 @@ with ConfigRegistry.register_config("basic") as c:
     c.SplitCal.StripHalfLength = 150*u.cm # c.SplitCal.YMax/c.SplitCal.NModulesInY
     c.SplitCal.SplitCalThickness=(c.SplitCal.FilterECALThickness_first-c.SplitCal.FilterECALThickness)+(c.SplitCal.FilterECALThickness+c.SplitCal.ActiveECALThickness)*c.SplitCal.nECALSamplings+c.SplitCal.BigGap
 
-    zecal = 38.450 * u.m #Relative start z of ECAL to decay vessel centre
+    zecal = 38.450 * u.m  # Relative start z of ECAL to decay vessel centre
     c.ecal = AttrDict(z=zecal)
     c.ecal.File = EcalGeoFile
     hcalThickness = 232*u.cm
     if  c.HcalOption == 2: hcalThickness = 110*u.cm  # to have same interaction length as before
     if not c.HcalOption < 0:
-     zhcal = 40.850 * u.m #Relative position of HCAL to decay vessel centre
+     zhcal = 40.850 * u.m  # Relative position of HCAL to decay vessel centre
      c.hcal = AttrDict(z=zhcal)
      c.hcal.hcalSpace = hcalThickness + 5.5*u.cm
      c.hcal.File  =  HcalGeoFile
@@ -441,4 +441,4 @@ with ConfigRegistry.register_config("basic") as c:
     c.UpstreamTagger.X_Strip = 229 * u.cm  - UBT_x_crop
     c.UpstreamTagger.X_Strip64 = 1.534 * u.cm
     c.UpstreamTagger.Y_Strip64 = 111 * u.cm
-    c.UpstreamTagger.Z_Position = -25.400 * u.m #Relative position of UBT to decay vessel centre
+    c.UpstreamTagger.Z_Position = -25.400 * u.m  # Relative position of UBT to decay vessel centre

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -112,7 +112,7 @@ with ConfigRegistry.register_config("basic") as c:
     magnetIncrease    = 100.*u.cm
     # make z coordinates for the decay volume and tracking stations relative to T4z
     # eventually, the only parameter which needs to be changed when the active shielding lenght changes.
-    c.z = 31.10 * u.m #Relative position of spectrometer magnet to decay vessel centre
+    c.z = 31.450 * u.m #Relative position of spectrometer magnet to decay vessel centre
     if strawDesign != 4 and strawDesign != 10:
      print("this design ",strawDesign," is not supported, use strawDesign = 4 or 10")
      1/0
@@ -209,7 +209,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.TimeDet.DZ = (c.TimeDet.dzBarRow + c.TimeDet.dzBarCol + c.TimeDet.zBar) / 2
     c.TimeDet.DX = 225 * u.cm
     c.TimeDet.DY = 325 * u.cm
-    c.TimeDet.z = 37.80 * u.m #Relative position of timing detector to decay vessel centre
+    c.TimeDet.z = 37.800 * u.m #Relative position of timing detector to decay vessel centre
 
     if CaloDesign==0:
      c.HcalOption = 1
@@ -227,7 +227,7 @@ with ConfigRegistry.register_config("basic") as c:
      1/0
 
     c.SplitCal = AttrDict(z=0)
-    c.SplitCal.ZStart = 38.45 * u.m #Relative start z of split cal to decay vessel centre
+    c.SplitCal.ZStart = 38.450 * u.m #Relative start z of split cal to decay vessel centre
     c.SplitCal.XMax = 480.*u.cm/2. #290.*u.cm  #half length
     c.SplitCal.YMax = 720. * u.cm / 2. #510.*u.cm * c.Yheight / (10.*u.m)   #half length
     c.SplitCal.Empty = 0*u.cm
@@ -257,12 +257,12 @@ with ConfigRegistry.register_config("basic") as c:
     c.SplitCal.StripHalfLength = 150*u.cm # c.SplitCal.YMax/c.SplitCal.NModulesInY
     c.SplitCal.SplitCalThickness=(c.SplitCal.FilterECALThickness_first-c.SplitCal.FilterECALThickness)+(c.SplitCal.FilterECALThickness+c.SplitCal.ActiveECALThickness)*c.SplitCal.nECALSamplings+c.SplitCal.BigGap
 
-    c.ecal = AttrDict(z=39.35*u.m) #Relative position of ECAL to decay vessel centre
+    c.ecal = AttrDict(z=39.350*u.m) #Relative position of ECAL to decay vessel centre
     c.ecal.File = EcalGeoFile
     hcalThickness = 232*u.cm
     if  c.HcalOption == 2: hcalThickness = 110*u.cm  # to have same interaction length as before
     if not c.HcalOption < 0:
-     c.hcal = AttrDict(z=40.85*u.m) #Relative position of HCAL to decay vessel centre
+     c.hcal = AttrDict(z=40.850*u.m) #Relative position of HCAL to decay vessel centre
      c.hcal.hcalSpace = hcalThickness + 5.5*u.cm
      c.hcal.File  =  HcalGeoFile
     else:
@@ -439,4 +439,4 @@ with ConfigRegistry.register_config("basic") as c:
     c.UpstreamTagger.X_Strip = 229 * u.cm  - UBT_x_crop
     c.UpstreamTagger.X_Strip64 = 1.534 * u.cm
     c.UpstreamTagger.Y_Strip64 = 111 * u.cm
-    c.UpstreamTagger.Z_Position = -25.40 * u.m #Relative position of UBT to decay vessel centre
+    c.UpstreamTagger.Z_Position = -25.400 * u.m #Relative position of UBT to decay vessel centre

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -113,7 +113,7 @@ with ConfigRegistry.register_config("basic") as c:
     # make z coordinates for the decay volume and tracking stations relative to T4z
     # eventually, the only parameter which needs to be changed when the active shielding lenght changes.
     c.z = 31.10 * u.m #Relative position of spectrometer magnet to decay vessel centre
-    z4 = 2582.75*u.cm + magnetIncrease + extraVesselLength
+    z4=2438.*u.cm+magnetIncrease+extraVesselLength #Cautious! This is an outdated z position of Tr4!
     if strawDesign != 4 and strawDesign != 10:
      print("this design ",strawDesign," is not supported, use strawDesign = 4 or 10")
      1/0

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -209,7 +209,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.TimeDet.DZ = (c.TimeDet.dzBarRow + c.TimeDet.dzBarCol + c.TimeDet.zBar) / 2
     c.TimeDet.DX = 225 * u.cm
     c.TimeDet.DY = 325 * u.cm
-    c.TimeDet.z = 37.800 * u.m #Relative position of timing detector to decay vessel centre
+    c.TimeDet.z = 37.800 * u.m - c.TimeDet.dzBarRow * 3 / 2 #Relative position of first layer of timing detector to decay vessel centre
 
     if CaloDesign==0:
      c.HcalOption = 1
@@ -257,12 +257,14 @@ with ConfigRegistry.register_config("basic") as c:
     c.SplitCal.StripHalfLength = 150*u.cm # c.SplitCal.YMax/c.SplitCal.NModulesInY
     c.SplitCal.SplitCalThickness=(c.SplitCal.FilterECALThickness_first-c.SplitCal.FilterECALThickness)+(c.SplitCal.FilterECALThickness+c.SplitCal.ActiveECALThickness)*c.SplitCal.nECALSamplings+c.SplitCal.BigGap
 
-    c.ecal = AttrDict(z=39.350*u.m) #Relative position of ECAL to decay vessel centre
+    zecal = 38.450 * u.m #Relative start z of ECAL to decay vessel centre
+    c.ecal = AttrDict(z=zecal)
     c.ecal.File = EcalGeoFile
     hcalThickness = 232*u.cm
     if  c.HcalOption == 2: hcalThickness = 110*u.cm  # to have same interaction length as before
     if not c.HcalOption < 0:
-     c.hcal = AttrDict(z=40.850*u.m) #Relative position of HCAL to decay vessel centre
+     zhcal = 40.850 * u.m #Relative position of HCAL to decay vessel centre
+     c.hcal = AttrDict(z=zhcal)
      c.hcal.hcalSpace = hcalThickness + 5.5*u.cm
      c.hcal.File  =  HcalGeoFile
     else:

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -112,7 +112,7 @@ with ConfigRegistry.register_config("basic") as c:
     magnetIncrease    = 100.*u.cm
     # make z coordinates for the decay volume and tracking stations relative to T4z
     # eventually, the only parameter which needs to be changed when the active shielding lenght changes.
-    z4=2438.*u.cm+magnetIncrease+extraVesselLength
+    z4 = 2582.75*u.cm + magnetIncrease + extraVesselLength
     if strawDesign != 4 and strawDesign != 10:
      print("this design ",strawDesign," is not supported, use strawDesign = 4 or 10")
      1/0
@@ -127,8 +127,8 @@ with ConfigRegistry.register_config("basic") as c:
      c.chambers.Rmin = 245.*u.cm
      c.chambers.Rmax = 250.*u.cm
      # positions and lenghts of vacuum tube segments
-     zset=z4-4666.*u.cm-magnetIncrease-extraVesselLength
-     c.Chamber1 = AttrDict(z=zset)
+     zset = z4 - 4810.75*u.cm - magnetIncrease - extraVesselLength
+     c.Chamber1 = AttrDict(z = zset)
      zset=z4-2628.*u.cm-magnetIncrease-extraVesselLength/2.
      c.Chamber2 = AttrDict(z=zset)
      zset=z4-740.*u.cm-magnetIncrease
@@ -142,13 +142,13 @@ with ConfigRegistry.register_config("basic") as c:
 
      c.xMax = 2 * u.m  # max horizontal width at T4
      #
-     c.TrackStation4 = AttrDict(z=z4)
-     zset=z4-200.*u.cm
-     c.TrackStation3 = AttrDict(z=zset)
-     zset=z4-640.*u.cm-magnetIncrease
-     c.TrackStation2 = AttrDict(z=zset)
-     zset=z4-840.*u.cm-magnetIncrease
-     c.TrackStation1 = AttrDict(z=zset)
+     c.TrackStation4 = AttrDict(z = z4)
+     zset = z4 - 200.*u.cm
+     c.TrackStation3 = AttrDict(z = zset)
+     zset = z4 - 800.*u.cm - magnetIncrease
+     c.TrackStation2 = AttrDict(z = zset)
+     zset = z4 - 1000.*u.cm - magnetIncrease
+     c.TrackStation1 = AttrDict(z = zset)
 
     c.z = c.TrackStation2.z + 0.5 * (c.TrackStation3.z - c.TrackStation2.z)
     c.scintillator = AttrDict(z=0*u.cm)

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -112,6 +112,7 @@ with ConfigRegistry.register_config("basic") as c:
     magnetIncrease    = 100.*u.cm
     # make z coordinates for the decay volume and tracking stations relative to T4z
     # eventually, the only parameter which needs to be changed when the active shielding lenght changes.
+    c.z = 31.10 * u.m #Relative position of spectrometer magnet to decay vessel centre
     z4 = 2582.75*u.cm + magnetIncrease + extraVesselLength
     if strawDesign != 4 and strawDesign != 10:
      print("this design ",strawDesign," is not supported, use strawDesign = 4 or 10")
@@ -127,8 +128,8 @@ with ConfigRegistry.register_config("basic") as c:
      c.chambers.Rmin = 245.*u.cm
      c.chambers.Rmax = 250.*u.cm
      # positions and lenghts of vacuum tube segments
-     zset = z4 - 4810.75*u.cm - magnetIncrease - extraVesselLength
-     c.Chamber1 = AttrDict(z = zset)
+     zset = -25.40 * u.m #Relative position of UBT to decay vessel centre
+     c.Chamber1 = AttrDict(z=zset)
      zset=z4-2628.*u.cm-magnetIncrease-extraVesselLength/2.
      c.Chamber2 = AttrDict(z=zset)
      zset=z4-740.*u.cm-magnetIncrease
@@ -141,16 +142,18 @@ with ConfigRegistry.register_config("basic") as c:
      c.Chamber6 = AttrDict(z=zset)
 
      c.xMax = 2 * u.m  # max horizontal width at T4
+     TrGap = 2 * u.m #Distance between Tr1/2 and Tr3/4
+     TrMagGap = 3.5 * u.m #Distance from spectrometer magnet centre to the next tracking stations
      #
-     c.TrackStation4 = AttrDict(z = z4)
-     zset = z4 - 200.*u.cm
-     c.TrackStation3 = AttrDict(z = zset)
-     zset = z4 - 800.*u.cm - magnetIncrease
-     c.TrackStation2 = AttrDict(z = zset)
-     zset = z4 - 1000.*u.cm - magnetIncrease
-     c.TrackStation1 = AttrDict(z = zset)
+     z4 = c.z + TrMagGap + TrGap
+     c.TrackStation4 = AttrDict(z=z4)
+     z3 = c.z + TrMagGap
+     c.TrackStation3 = AttrDict(z=z3)
+     z2 = c.z - TrMagGap
+     c.TrackStation2 = AttrDict(z=z2)
+     z1 = c.z - TrMagGap - TrGap
+     c.TrackStation1 = AttrDict(z=z1)
 
-    c.z = c.TrackStation2.z + 0.5 * (c.TrackStation3.z - c.TrackStation2.z)
     c.scintillator = AttrDict(z=0*u.cm)
     c.scintillator.Rmin = 251.*u.cm
     c.scintillator.Rmax = 260.*u.cm

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -113,7 +113,6 @@ with ConfigRegistry.register_config("basic") as c:
     # make z coordinates for the decay volume and tracking stations relative to T4z
     # eventually, the only parameter which needs to be changed when the active shielding lenght changes.
     c.z = 31.10 * u.m #Relative position of spectrometer magnet to decay vessel centre
-    z4=2438.*u.cm+magnetIncrease+extraVesselLength #Cautious! This is an outdated z position of Tr4!
     if strawDesign != 4 and strawDesign != 10:
      print("this design ",strawDesign," is not supported, use strawDesign = 4 or 10")
      1/0
@@ -128,17 +127,17 @@ with ConfigRegistry.register_config("basic") as c:
      c.chambers.Rmin = 245.*u.cm
      c.chambers.Rmax = 250.*u.cm
      # positions and lenghts of vacuum tube segments
-     zset=z4-4666.*u.cm-magnetIncrease-extraVesselLength
+     zset = -4666. * u.cm - magnetIncrease - extraVesselLength
      c.Chamber1 = AttrDict(z=zset)
-     zset=z4-2628.*u.cm-magnetIncrease-extraVesselLength/2.
+     zset = -2628. * u.cm - magnetIncrease - extraVesselLength/2.
      c.Chamber2 = AttrDict(z=zset)
-     zset=z4-740.*u.cm-magnetIncrease
+     zset = -740. * u.cm - magnetIncrease
      c.Chamber3 = AttrDict(z=zset)
-     zset=z4-420.*u.cm-magnetIncrease/2.
+     zset = -420. * u.cm - magnetIncrease/2.
      c.Chamber4 = AttrDict(z=zset)
-     zset=z4-100.*u.cm
+     zset = -100. * u.cm
      c.Chamber5 = AttrDict(z=zset)
-     zset=z4+30.*u.cm+windowBulge/2.
+     zset = 30. * u.cm + windowBulge/2.
      c.Chamber6 = AttrDict(z=zset)
 
      c.xMax = 2 * u.m  # max horizontal width at T4
@@ -210,7 +209,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.TimeDet.DZ = (c.TimeDet.dzBarRow + c.TimeDet.dzBarCol + c.TimeDet.zBar) / 2
     c.TimeDet.DX = 225 * u.cm
     c.TimeDet.DY = 325 * u.cm
-    c.TimeDet.z = c.Chamber6.z + c.chambers.Tub6length + c.TimeDet.DZ + 1*u.cm # safety margin
+    c.TimeDet.z = 37.80 * u.m #Relative position of timing detector to decay vessel centre
 
     if CaloDesign==0:
      c.HcalOption = 1
@@ -228,7 +227,7 @@ with ConfigRegistry.register_config("basic") as c:
      1/0
 
     c.SplitCal = AttrDict(z=0)
-    c.SplitCal.ZStart = c.TimeDet.z + c.TimeDet.DZ + 5*u.cm
+    c.SplitCal.ZStart = 38.45 * u.m #Relative start z of split cal to decay vessel centre
     c.SplitCal.XMax = 480.*u.cm/2. #290.*u.cm  #half length
     c.SplitCal.YMax = 720. * u.cm / 2. #510.*u.cm * c.Yheight / (10.*u.m)   #half length
     c.SplitCal.Empty = 0*u.cm
@@ -258,12 +257,12 @@ with ConfigRegistry.register_config("basic") as c:
     c.SplitCal.StripHalfLength = 150*u.cm # c.SplitCal.YMax/c.SplitCal.NModulesInY
     c.SplitCal.SplitCalThickness=(c.SplitCal.FilterECALThickness_first-c.SplitCal.FilterECALThickness)+(c.SplitCal.FilterECALThickness+c.SplitCal.ActiveECALThickness)*c.SplitCal.nECALSamplings+c.SplitCal.BigGap
 
-    c.ecal  =  AttrDict(z = c.TimeDet.z + c.TimeDet.DZ  + 5*u.cm)  #
+    c.ecal = AttrDict(z=39.35*u.m) #Relative position of ECAL to decay vessel centre
     c.ecal.File = EcalGeoFile
     hcalThickness = 232*u.cm
     if  c.HcalOption == 2: hcalThickness = 110*u.cm  # to have same interaction length as before
     if not c.HcalOption < 0:
-     c.hcal =  AttrDict(z=c.ecal.z + hcalThickness/2. + 45.*u.cm  )
+     c.hcal = AttrDict(z=40.85*u.m) #Relative position of HCAL to decay vessel centre
      c.hcal.hcalSpace = hcalThickness + 5.5*u.cm
      c.hcal.File  =  HcalGeoFile
     else:


### PR DESCRIPTION
S. integration layout [EDMS 3287817 v1](https://edms.cern.ch/document/3287817/1.0)

Update tracker station z positions according to the following:
- Distance between Tr1/2 as well as Tr3/4 stays at 2 m.
- Distance from the magnet to Tr2 and to Tr3, respectively, is 3.5 m (midpoint).

Relative position of the magnet to the decay volume centre (z = 0) is adjusted (31.450 m) to avoid overlap.

Decoupling UBT from z position of Tr4 is done by defining directly the z of UBT (= −25.400 m).

Fixing timing detector (z = 37.800 m) and split cal (z_start = 38.450 m) to their permanent position