### PR TITLE
Remove Tracker Dependences from TauMuDet Position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ it in future.
 * Assume all tracks are muons during track fit (avoid using MC truth)
 * Change of UBT geometry, remove implementation of RPC and setting a new scoring plane of 4×6 m
 * Allow specifying spectrometer field map
+* Obtain tauMuDet z position from muonshield position and length, instead of chamber trackers
 
 ### Removed
 

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -403,7 +403,7 @@ with ConfigRegistry.register_config("basic") as c:
     #CAMM - For Nu tau detector, keep only these parameters which are used by others...
     c.tauMudet = AttrDict(z=0*u.cm)
     c.tauMudet.Ztot = 3 * u.m #space allocated to Muon spectrometer
-    c.tauMudet.zMudetC = c.Chamber1.z -c.chambers.Tub1length - c.tauMudet.Ztot/2 -31*u.cm
+    c.tauMudet.zMudetC = c.muShield.z + c.muShield.length/2. - c.tauMudet.Ztot/2. - 70 * u.cm
 
 
     #Upstream Tagger


### PR DESCRIPTION
Hello, 

This small change is related to the discussion in #707. In particular, this part:

From @olantwin: The SND should not need to know anything about the trackers. The only relevant info should be the muon shield position and length.

Best Regards,
Antonio