### PR TITLE
Include FairLogger in strawtubes

### DIFF
--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -15,6 +15,7 @@
 #include "FairGeoBuilder.h"
 #include "FairRun.h"
 #include "FairRuntimeDb.h"
+#include "FairLogger.h"
 #include "ShipDetectorList.h"
 #include "ShipStack.h"
 

--- a/strawtubes/strawtubesHit.cxx
+++ b/strawtubes/strawtubesHit.cxx
@@ -3,6 +3,7 @@
 #include "TVector3.h"
 #include "FairRun.h"
 #include "FairRunSim.h"
+#include "FairLogger.h"
 #include "TMath.h"
 #include "TRandom1.h"
 #include "TRandom3.h"


### PR DESCRIPTION
With #715 merged, I missed the inclusion of FairLogger required for using LOG.