### PR TITLE
Emulsion target decoding function edited to return a tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ it in future.
 * Removed old stuff legacy in `shipMuonShield.cxx` (like LE and fFloor)
 * Event Display: Don't try to recreate geometry config
 * Geometry: Make the tungsten target the default (Jun25 config)
+* Change EmulsionTarget detID decode function to tuple output
 
 ### Removed
 

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -48,6 +48,7 @@
 
 #include <iosfwd>     // for ostream
 #include <iostream>   // for operator<<, basic_ostream,etc
+#include <tuple>
 #include <stddef.h>   // for NULL
 #include <string.h>
 
@@ -534,13 +535,15 @@ Bool_t Target::ProcessHits(FairVolume* vol)
     return kTRUE;
 }
 
-void Target::DecodeBrickID(Int_t detID, Int_t& NWall, Int_t& NRow, Int_t& NColumn, Int_t& NPlate, Bool_t& EmTop)
+std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID)
 {
-    NWall = detID / 1E7;
-    NRow = (detID - NWall * 1E7) / 1E6;
-    NColumn = (detID - NWall * 1E7 - NRow * 1E6) / 1E4;
-    NPlate = (detID - NWall * 1E7 - NRow * 1E6 - NColumn * 1E4 - 1E3) / 1E1;
-    EmTop = (detID - NWall * 1E7 - NRow * 1E6 - NColumn * 1E4 - 1E3 - NPlate * 1E1) / 1E0;
+    Int_t NWall = detID / 1E7;
+    Int_t NRow = (detID - NWall * 1E7) / 1E6;
+    Int_t NColumn = (detID - NWall * 1E7 - NRow * 1E6) / 1E4;
+    Int_t NPlate = (detID - NWall * 1E7 - NRow * 1E6 - NColumn * 1E4 - 1E3) / 1E1;
+    Bool_t EmTop = (detID - NWall * 1E7 - NRow * 1E6 - NColumn * 1E4 - 1E3 - NPlate * 1E1) / 1E0;
+
+    return std::make_tuple(NWall, NRow, NColumn, NPlate, EmTop);
 }
 
 void Target::EndOfEvent()

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -537,19 +537,19 @@ Bool_t Target::ProcessHits(FairVolume* vol)
 
 std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID)
 {
-    auto divt_E7 = std::div(detID,1E7);
+    auto divt_E7 = std::div(detID, 1E7);
 
     Int_t NWall = divt_E7.quot;
-    auto divt_E6 = std::div(divt_E7.rem,1E6);
-    
-    Int_t NRow =  divt_E6.quot;
+    auto divt_E6 = std::div(divt_E7.rem, 1E6);
+
+    Int_t NRow = divt_E6.quot;
     auto divt_E4 = std::div(divt_E6.rem, 1E4);
 
     Int_t NColumn = divt_E4.quot;
     auto divt_E1 = std::div(divt_E4.rem - int(1E3), 1E1);
 
     Int_t NPlate = divt_E1.quot;
-    Bool_t EmTop = (std::div(divt_E1.rem,1E0)).quot;
+    Bool_t EmTop = (std::div(divt_E1.rem, 1E0)).quot;
 
     return std::make_tuple(NWall, NRow, NColumn, NPlate, EmTop);
 }

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -48,9 +48,9 @@
 
 #include <iosfwd>     // for ostream
 #include <iostream>   // for operator<<, basic_ostream,etc
-#include <tuple>
 #include <stddef.h>   // for NULL
 #include <string.h>
+#include <tuple>
 
 using std::cout;
 using std::endl;

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -537,12 +537,19 @@ Bool_t Target::ProcessHits(FairVolume* vol)
 
 std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID)
 {
+    auto divt_E7 = std::div(detID,1E7);
 
-    Int_t NWall = detID / 1E7;
-    Int_t NRow = (detID % int(1E7)) / 1E6;
-    Int_t NColumn = (detID % int(1E6)) / 1E4;
-    Int_t NPlate = (detID % int(1E4) - 1E3) / 1E1;
-    Bool_t EmTop = (detID % int(1E1)) / 1E0;
+    Int_t NWall = divt_E7.quot;
+    auto divt_E6 = std::div(divt_E7.rem,1E6);
+    
+    Int_t NRow =  divt_E6.quot;
+    auto divt_E4 = std::div(divt_E6.rem, 1E4);
+
+    Int_t NColumn = divt_E4.quot;
+    auto divt_E1 = std::div(divt_E4.rem - int(1E3), 1E1);
+
+    Int_t NPlate = divt_E1.quot;
+    Bool_t EmTop = (std::div(divt_E1.rem,1E0)).quot;
 
     return std::make_tuple(NWall, NRow, NColumn, NPlate, EmTop);
 }

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -537,11 +537,12 @@ Bool_t Target::ProcessHits(FairVolume* vol)
 
 std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID)
 {
+
     Int_t NWall = detID / 1E7;
-    Int_t NRow = (detID - NWall * 1E7) / 1E6;
-    Int_t NColumn = (detID - NWall * 1E7 - NRow * 1E6) / 1E4;
-    Int_t NPlate = (detID - NWall * 1E7 - NRow * 1E6 - NColumn * 1E4 - 1E3) / 1E1;
-    Bool_t EmTop = (detID - NWall * 1E7 - NRow * 1E6 - NColumn * 1E4 - 1E3 - NPlate * 1E1) / 1E0;
+    Int_t NRow = (detID % int(1E7)) / 1E6;
+    Int_t NColumn = (detID % int(1E6)) / 1E4;
+    Int_t NPlate = (detID % int(1E4) - 1E3) / 1E1;
+    Bool_t EmTop = (detID % int(1E1)) / 1E0;
 
     return std::make_tuple(NWall, NRow, NColumn, NPlate, EmTop);
 }

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -501,7 +501,7 @@ Bool_t Target::ProcessHits(FairVolume* vol)
             // cout << i << "   " << motherV[i] << "    name = " << mumname << endl;
         }
 
-        detID = (NWall + 1) * 1E7 + (NRow + 1) * 1E6 + (NColumn + 1) * 1E4 + 1E3 + (NPlate + 1) * 1E1 + EmTop * 1;
+        detID = (NWall + 1) * 1E7 + (NRow + 1) * 1E6 + (NColumn + 1) * 1E4 + (NPlate + 1) * 1E1 + EmTop;
 
         fVolumeID = detID;
 
@@ -537,7 +537,16 @@ Bool_t Target::ProcessHits(FairVolume* vol)
 
 std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID)
 {
-    auto divt_E7 = std::div(detID, 1E7);
+    //! Decode detectorID into a struct with info about the film position in the target:
+    /*
+     \param detID detectorID for the TargetPoint
+     \return a struct providing the wall, row, column and plate number (starting from 1),
+        as well as a boolean for top/bottom emulsion layer.
+        Examples:
+         11010031 -> Wall 1, Row 1, Column 1, Plate 3, true;
+         31010150 -> Wall 3, Row 1, Column 1, Plate 15, false;
+    */
+    auto divt_E7 = std::div(detID,1E7);
 
     Int_t NWall = divt_E7.quot;
     auto divt_E6 = std::div(divt_E7.rem, 1E6);
@@ -546,10 +555,10 @@ std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID
     auto divt_E4 = std::div(divt_E6.rem, 1E4);
 
     Int_t NColumn = divt_E4.quot;
-    auto divt_E1 = std::div(divt_E4.rem - int(1E3), 1E1);
+    auto divt_E1 = std::div(divt_E4.rem, 1E1);
 
     Int_t NPlate = divt_E1.quot;
-    Bool_t EmTop = (std::div(divt_E1.rem, 1E0)).quot;
+    Bool_t EmTop = static_cast<Bool_t> (divt_E1.rem);
 
     return std::make_tuple(NWall, NRow, NColumn, NPlate, EmTop);
 }

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -546,7 +546,7 @@ std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID
          11010031 -> Wall 1, Row 1, Column 1, Plate 3, true;
          31010150 -> Wall 3, Row 1, Column 1, Plate 15, false;
     */
-    auto divt_E7 = std::div(detID,1E7);
+    auto divt_E7 = std::div(detID, 1E7);
 
     Int_t NWall = divt_E7.quot;
     auto divt_E6 = std::div(divt_E7.rem, 1E6);
@@ -558,7 +558,7 @@ std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> Target::DecodeBrickID(Int_t detID
     auto divt_E1 = std::div(divt_E4.rem, 1E1);
 
     Int_t NPlate = divt_E1.quot;
-    Bool_t EmTop = static_cast<Bool_t> (divt_E1.rem);
+    Bool_t EmTop = static_cast<Bool_t>(divt_E1.rem);
 
     return std::make_tuple(NWall, NRow, NColumn, NPlate, EmTop);
 }

--- a/SND/EmulsionTarget/Target.h
+++ b/SND/EmulsionTarget/Target.h
@@ -74,7 +74,7 @@ class Target : public FairDetector
     void SetBaseDimension(Double_t X, Double_t Y, Double_t Z);
     void SetPillarDimension(Double_t X, Double_t Y, Double_t Z);
 
-    std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> DecodeBrickID(Int_t detID);
+    static std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> DecodeBrickID(Int_t detID);
 
     void SetHpTParam(Int_t n, Double_t dd, Double_t DZ);   // other detector's parameters (needed for positioning)
 

--- a/SND/EmulsionTarget/Target.h
+++ b/SND/EmulsionTarget/Target.h
@@ -16,6 +16,7 @@
 #include "TVector3.h"
 
 #include <string>   // for string
+#include <tuple>
 
 class TargetPoint;
 class FairVolume;
@@ -73,7 +74,7 @@ class Target : public FairDetector
     void SetBaseDimension(Double_t X, Double_t Y, Double_t Z);
     void SetPillarDimension(Double_t X, Double_t Y, Double_t Z);
 
-    void DecodeBrickID(Int_t detID, Int_t& NWall, Int_t& NRow, Int_t& NColumn, Int_t& NPlate, Bool_t& EmTop);
+    std::tuple<Int_t, Int_t, Int_t, Int_t, Bool_t> DecodeBrickID(Int_t detID);
 
     void SetHpTParam(Int_t n, Double_t dd, Double_t DZ);   // other detector's parameters (needed for positioning)
 


### PR DESCRIPTION
Dear all,

This small pull request is related to #791.
It simplifies the function, which now only requires the detectorID as argument and does not require argument mutation.
It returns a std::tuple.

Best Regards,
Antonio