### PR TITLE
SND implementation into Muon Shield

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
-          python $FAIRSHIP/macro/run_simScript.py --test --${{ matrix.vessel_option }} --noSND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml
+          python $FAIRSHIP/macro/run_simScript.py --test --${{ matrix.vessel_option }} --SND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml
 
       - name: Run Reco
         run: |
@@ -154,7 +154,7 @@ jobs:
         run: |
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
-          python $FAIRSHIP/macro/run_simScript.py --test -n 0 --debug 2 --${{ matrix.vessel_option }} --noSND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml | tee log
+          python $FAIRSHIP/macro/run_simScript.py --test -n 0 --debug 2 --${{ matrix.vessel_option }} --SND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml | tee log
           ! grep ovlp log
 
       - name: Geo information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ it in future.
 * SND/EmulsionTarget folder, with the Target and TargetTracker classes from nutaudet
 * Added fibre structure for MTC and digitization. Fibre <-> SiPM mapping is done in ```SND/MTC/MTCDetector.cxx```, can be extracted and tested in ```python/SciFiMapping.py```, that is subsequently used in ```python/shipDigiReco.py```
 * Implement proximity shielding design from 26/06/2025 by G. Humphreys
-
+* Added the hole for SND in the Muon Shield, that is created automatically if SND key is enabled (works so far for SND_design == 2)
 ### Fixed
 
 * chore: Fix file endings

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -68,10 +68,10 @@ Int_t ShipMuonShield::InitMedium(TString name)
 }
 
 
-void ShipMuonShield::SetSNDSpace(const Bool_t hole, Double_t hole_dx, Double_t hole_dy)
+void ShipMuonShield::SetSNDSpace(Bool_t hole, Double_t hole_dx, Double_t hole_dy)
 {
   snd_hole = hole;
-  snd_hole_dx = hole_dx / 2.;
+  snd_hole_dx = hole_dx / 2.; // since the hole is cut in 2 halves, we need to divide the width by 2
   snd_hole_dy = hole_dy;
 }
 
@@ -85,7 +85,7 @@ void ShipMuonShield::CreateArb8(TString                         arbName,
                                 Double_t                        x_translation,
                                 Double_t                        y_translation,
                                 Double_t                        z_translation,
-                                const Bool_t                          snd_key) {
+                                Bool_t                          snd_key) {
   TGeoVolume* magVol = nullptr;
 
   if (!snd_key) {
@@ -95,7 +95,7 @@ void ShipMuonShield::CreateArb8(TString                         arbName,
                                    dZ,
                                    corners.data());
   }
-  else {
+  else{
     // 1) create the raw Arb8 volume (registers a shape named "<arbName>_shape")
     TString  shapeName = arbName + "_shape";
     gGeoManager->MakeArb8(shapeName,
@@ -104,11 +104,12 @@ void ShipMuonShield::CreateArb8(TString                         arbName,
                          corners.data());
 
     // 2) create the void‐box volume (registers a shape named "<arbName>_void")
+    constexpr double eps = 0.01; // antioverlap
     TString voidName = arbName + "_void";
     gGeoManager->MakeBox(voidName,
                          medium,
-                         snd_hole_dx,
-                         snd_hole_dy,
+                         snd_hole_dx - eps,
+                         snd_hole_dy - eps,
                          dZ);
 
     // 3) figure out which way to shift the box on X

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -84,18 +84,10 @@ void ShipMuonShield::CreateArb8(TString                         arbName,
                                 TGeoVolume*                     tShield,
                                 Double_t                        x_translation,
                                 Double_t                        y_translation,
-                                Double_t                        z_translation,
-                                Bool_t                          snd_key) {
+                                Double_t                        z_translation) {
   TGeoVolume* magVol = nullptr;
 
-  if (!snd_key) {
-    // — original uncut magnet —
-    magVol = gGeoManager->MakeArb8(arbName,
-                                   medium,
-                                   dZ,
-                                   corners.data());
-  }
-  else{
+  if (snd_hole && (arbName == "Magn6_MiddleMagL" || arbName == "Magn6_MiddleMagR")){
     // 1) create the raw Arb8 volume (registers a shape named "<arbName>_shape")
     TString  shapeName = arbName + "_shape";
     gGeoManager->MakeArb8(shapeName,
@@ -105,11 +97,13 @@ void ShipMuonShield::CreateArb8(TString                         arbName,
 
     // 2) create the void‐box volume (registers a shape named "<arbName>_void")
     constexpr double eps = 0.01; // antioverlap
+    snd_hole_dx = snd_hole_dx - eps;
+    snd_hole_dy = snd_hole_dy - eps;
     TString voidName = arbName + "_void";
     gGeoManager->MakeBox(voidName,
                          medium,
-                         snd_hole_dx - eps,
-                         snd_hole_dy - eps,
+                         snd_hole_dx,
+                         snd_hole_dy,
                          dZ);
 
     // 3) figure out which way to shift the box on X
@@ -135,6 +129,14 @@ void ShipMuonShield::CreateArb8(TString                         arbName,
 
     // 6) wrap the composite in a volume
     magVol = new TGeoVolume(arbName, compShape, medium);
+  }
+
+  else {
+    // — original uncut magnet —
+    magVol = gGeoManager->MakeArb8(arbName,
+                                   medium,
+                                   dZ,
+                                   corners.data());
   }
 
   magVol->SetLineColor(color);
@@ -312,14 +314,8 @@ void ShipMuonShield::CreateMagnet(TString magnetName,TGeoMedium* medium,TGeoVolu
       CreateArb8(magnetName + str11, medium, dZ, cornersBR, color[3], fields[3], tShield,  0, 0, Z);
       break;
     case FieldDirection::down:
-      if(magnetName == "Magn6" && snd_hole){
-        CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[1], fields[1], tShield,  0, 0, Z, true);
-        CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[1], fields[1], tShield,  0, 0, Z, true);
-      }
-      else{
-        CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[1], fields[1], tShield,  0, 0, Z);
-        CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[1], fields[1], tShield,  0, 0, Z);
-      }
+      CreateArb8(magnetName + str1L, medium, dZ, cornersMainL, color[1], fields[1], tShield,  0, 0, Z);
+      CreateArb8(magnetName + str1R, medium, dZ, cornersMainR, color[1], fields[1], tShield,  0, 0, Z);
       CreateArb8(magnetName + str2, medium, dZ, cornersMainSideL, color[0], fields[0], tShield,  0, 0, Z);
       CreateArb8(magnetName + str3, medium, dZ, cornersMainSideR, color[0], fields[0], tShield,  0, 0, Z);
       CreateArb8(magnetName + str8, medium, dZ, cornersTL, color[2], fields[2], tShield,  0, 0, Z);

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -23,7 +23,7 @@ class ShipMuonShield : public FairModule
     ShipMuonShield();
     virtual ~ShipMuonShield();
     void ConstructGeometry();
-
+    void SetSNDSpace(const Bool_t hole, Double_t hole_dx, Double_t hole_dy);
   protected:
     Double_t fMuonShieldHalfLength;   // FIXME: HA_field to be removed in the next workshop meeting
     Double_t dZ0, dZ1, dZ2, dZ3, dZ4, dZ5, dZ6, dZ7, dXgap, z_end_of_proximity_shielding;
@@ -31,6 +31,8 @@ class ShipMuonShield : public FairModule
     Bool_t fWithConstShieldField;
     Bool_t fSC_mag;
     std::vector<Double_t> shield_params;
+    Bool_t snd_hole;
+    Double_t snd_hole_dx = 0., snd_hole_dy = 0.;
 
     void CreateArb8(TString arbName,
                     TGeoMedium* medium,
@@ -41,7 +43,8 @@ class ShipMuonShield : public FairModule
                     TGeoVolume* top,
                     Double_t x_translation,
                     Double_t y_translation,
-                    Double_t z_translation);
+                    Double_t z_translation,
+                    const Bool_t snd_key = false);
 
     Int_t Initialize(std::vector<TString>& magnetName,
                      std::vector<FieldDirection>& fieldDirection,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -43,8 +43,7 @@ class ShipMuonShield : public FairModule
                     TGeoVolume* top,
                     Double_t x_translation,
                     Double_t y_translation,
-                    Double_t z_translation,
-                    Bool_t snd_key = false);
+                    Double_t z_translation);
 
     Int_t Initialize(std::vector<TString>& magnetName,
                      std::vector<FieldDirection>& fieldDirection,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -23,7 +23,7 @@ class ShipMuonShield : public FairModule
     ShipMuonShield();
     virtual ~ShipMuonShield();
     void ConstructGeometry();
-    void SetSNDSpace(const Bool_t hole, Double_t hole_dx, Double_t hole_dy);
+    void SetSNDSpace(Bool_t hole, Double_t hole_dx, Double_t hole_dy);
   protected:
     Double_t fMuonShieldHalfLength;   // FIXME: HA_field to be removed in the next workshop meeting
     Double_t dZ0, dZ1, dZ2, dZ3, dZ4, dZ5, dZ6, dZ7, dXgap, z_end_of_proximity_shielding;
@@ -44,7 +44,7 @@ class ShipMuonShield : public FairModule
                     Double_t x_translation,
                     Double_t y_translation,
                     Double_t z_translation,
-                    const Bool_t snd_key = false);
+                    Bool_t snd_key = false);
 
     Int_t Initialize(std::vector<TString>& magnetName,
                      std::vector<FieldDirection>& fieldDirection,


### PR DESCRIPTION
Implementation of the SND Hole into Muon Shield:

1) For the last magnet the modified ```Arb8``` geo object is created: ```CreateArb8``` method is modified accordingly.
2) The SND parameters are set via a new method ```SetSNDSpace``` that is called in ```python/shipDet_conf.py``` script. The dimensions of the hole are (width + 5 cm, height + 5 cm) of MTC. This approach can also be used for the old version of SND.
3) To read .yaml file with MTC parameters only once, I placed the initialization of SND earlier than Muon Shield (hope it is okay).

In the end, such kind of implementation does not conflict with any public method or the constructor of Muon Shield class. @antonioiuliano2 and @Gfrisella, please propose changes, if something looks ugly :)

P.S. Sorry in advance for style errors, CI in my fork launches for ages (and i'm not sure if it even works then).