### PR TITLE
Remove hadron absorber from fixed target

### DIFF
--- a/muonShieldOptimization/run_fixedTarget.py
+++ b/muonShieldOptimization/run_fixedTarget.py
@@ -178,9 +178,7 @@ run.AddModule(cave)
 
 TargetStation = ROOT.ShipTargetStation("TargetStation",
                                        ship_geo.target.length,
-                                       ship_geo.hadronAbsorber.length,
                                        ship_geo.target.z,
-                                       ship_geo.hadronAbsorber.z,
                                        ship_geo.targetVersion,
                                        ship_geo.target.nS)
 

--- a/passive/ShipTargetStation.cxx
+++ b/passive/ShipTargetStation.cxx
@@ -21,8 +21,9 @@ using ShipUnit::mm;
 
 ShipTargetStation::~ShipTargetStation() {}
 ShipTargetStation::ShipTargetStation()
-    : FairModule("ShipTargetStation", "")
-{}
+  : FairModule("ShipTargetStation", "")
+{
+}
 
 ShipTargetStation::ShipTargetStation(const char* name,
                                      const Double_t tl,
@@ -32,10 +33,10 @@ ShipTargetStation::ShipTargetStation(const char* name,
                                      const char* Title)
     : FairModule(name, Title)
 {
-    fTargetLength = tl;
-    fTargetZ = tz;
-    fTV = tV;
-    fnS = nS;
+  fTargetLength    = tl;
+  fTargetZ         = tz;
+  fTV = tV;
+  fnS = nS;
 }
 
 // -----   Private method InitMedium
@@ -111,97 +112,34 @@ void ShipTargetStation::ConstructGeometry()
             material = tungsten;
         };
 
-        target = gGeoManager->MakeTube(nmi, material, 0., fDiameter / 2., fL.at(i) / 2.);
-        if (fM.at(i) == "molybdenum") {
-            target->SetLineColor(28);
-        } else {
-            target->SetLineColor(38);
-        };   // silver/blue
-        tTarget->AddNode(target, 1, new TGeoTranslation(0, 0, zPos + fL.at(i) / 2.));
-        if (i < slots) {
-            slit = gGeoManager->MakeTube(sm, cooler, 0., fDiameter / 2., fG.at(i) / 2.);
-            slit->SetLineColor(7);   // cyan
-            tTarget->AddNode(slit, 1, new TGeoTranslation(0, 0, zPos + fL.at(i) + fG.at(i) / 2.));
-            zPos += fL.at(i) + fG.at(i);
-        } else {
-            zPos += fL.at(i);
-        }
-    }   // loop on layers
+    // put iron shielding around target
+    if (fTV > 10) {
+        Float_t xTot = 400. / 2.;   // all in cm
+        Float_t yTot = 400. / 2.;
+        Float_t spaceTopBot = 10.;
+        Float_t spaceSide = 5.;
+        TGeoVolume* moreShieldingTopBot =
+            gGeoManager->MakeBox("moreShieldingTopBot", iron, xTot, yTot / 2., fTargetLength / 2.);
+        moreShieldingTopBot->SetLineColor(33);
+        tTarget->AddNode(moreShieldingTopBot,
+                         1,
+                         new TGeoTranslation(0., fDiameter / 2. + spaceTopBot + yTot / 2., fTargetLength / 2.));
+        tTarget->AddNode(moreShieldingTopBot,
+                         2,
+                         new TGeoTranslation(0., -fDiameter / 2. - spaceTopBot - yTot / 2., fTargetLength / 2.));
+        TGeoVolume* moreShieldingSide = gGeoManager->MakeBox(
+            "moreShieldingSide", iron, xTot / 2., (fDiameter + 1.9 * spaceTopBot) / 2., fTargetLength / 2.);
+        moreShieldingSide->SetLineColor(33);
+        tTarget->AddNode(
+            moreShieldingSide, 1, new TGeoTranslation(fDiameter / 2. + spaceSide + xTot / 2., 0., fTargetLength / 2.));
+        tTarget->AddNode(
+            moreShieldingSide, 2, new TGeoTranslation(-fDiameter / 2. - spaceSide - xTot / 2., 0., fTargetLength / 2.));
+    } else {
+        TGeoVolume* moreShielding = gGeoManager->MakeTube("MoreShielding", iron, 30, 400, fTargetLength / 2.);
+        moreShielding->SetLineColor(43);   //
+        tTarget->AddNode(moreShielding, 1, new TGeoTranslation(0, 0, fTargetLength / 2.));
+    }
+    top->AddNode(tTarget, 1, new TGeoTranslation(0, 0, fTargetZ - fTargetLength / 2.));
 
-    // Proximity shielding
-
-    double start_of_target = fTargetZ - fTargetLength / 2.;
-    fTargetLength = 1586.4 * mm;  // Make shielding independent of actual target length
-    double shielding_width = 1600 * mm;
-    double shielding_length = 3000 * mm;
-    double proximity_shielding_height = 1126 * mm;
-    double proximity_shielding_thickness = 250 * mm;
-    double proximity_shielding_thickness_front = 550 * mm;
-    double proximity_shielding_hole_diameter = 200 * mm;
-    double proximity_shielding_hole_height = 735 * mm;
-    double proximity_shielding_distance_after_target = 96.1 * mm;
-    double shielding_position = start_of_target + fTargetLength + proximity_shielding_distance_after_target
-                                             + proximity_shielding_thickness - shielding_length / 2;
-    auto proximity_shielding_envelope = new TGeoBBox("proximity_shielding_envelope",
-                                                     shielding_width / 2,
-                                                     proximity_shielding_height / 2,
-                                                     shielding_length / 2);
-    auto proximity_shielding_inner = new TGeoBBox(
-        "proximity_shielding_inner",
-        shielding_width / 2 - proximity_shielding_thickness,
-        proximity_shielding_height / 2,
-        (shielding_length - (proximity_shielding_thickness_front + proximity_shielding_thickness)) / 2);
-    auto proximity_shielding_hole = new TGeoTube(
-        "proximity_shielding_hole", 0, proximity_shielding_hole_diameter / 2, proximity_shielding_thickness_front / 2);
-    auto proximity_shielding_inner_shift = new TGeoTranslation(
-        "proximity_shielding_inner_shift", 0, 0, (proximity_shielding_thickness_front - proximity_shielding_thickness) / 2);
-    proximity_shielding_inner_shift->RegisterYourself();
-    auto proximity_shielding_hole_shift =
-        new TGeoTranslation("proximity_shielding_hole_shift",
-                            0,
-                            proximity_shielding_hole_height - proximity_shielding_height / 2,
-                            -shielding_length / 2 + proximity_shielding_thickness_front / 2);
-    proximity_shielding_hole_shift->RegisterYourself();
-    auto proximity_shielding_shape =
-        new TGeoCompositeShape("proximity_shielding_shape",
-                               "proximity_shielding_envelope"
-                               "- proximity_shielding_inner:proximity_shielding_inner_shift"
-                               "- proximity_shielding_hole:proximity_shielding_hole_shift");
-    auto proximity_shielding = new TGeoVolume("proximity_shielding", proximity_shielding_shape, copper);
-    auto proximity_shielding_centre =
-        new TGeoTranslation(
-            0., -(proximity_shielding_hole_height - proximity_shielding_height / 2), shielding_position);
-
-    top->AddNode(proximity_shielding, 1, proximity_shielding_centre);
-
-    // Iron shielding
-    double top_shielding_height = 600 * mm;
-    double bottom_shielding_height = 545 * mm;
-    auto top_shielding = gGeoManager->MakeBox(
-        "top_shielding", iron, shielding_width / 2, top_shielding_height / 2, shielding_length / 2);
-    top->AddNode(
-        top_shielding,
-        1,
-        new TGeoTranslation(0.,
-                            top_shielding_height / 2 + proximity_shielding_height - proximity_shielding_hole_height,
-                            shielding_position));
-    auto bottom_shielding = gGeoManager->MakeBox(
-        "bottom_shielding", iron, shielding_width / 2, bottom_shielding_height / 2, shielding_length / 2);
-    top->AddNode(bottom_shielding,
-                 1,
-                 new TGeoTranslation(
-                     0., -bottom_shielding_height / 2 - proximity_shielding_hole_height, shielding_position));
-    double pedestal_length = 2170 * mm;
-    double pedestal_width = 1070 * mm;
-    double pedestal_height = 150 * mm;
-    auto shielding_pedestal =
-        gGeoManager->MakeBox("shielding_pedestal", iron, pedestal_width / 2, pedestal_height / 2, pedestal_length / 2);
-    top->AddNode(
-        shielding_pedestal,
-        1,
-        new TGeoTranslation(0.,
-                            pedestal_height / 2 - proximity_shielding_hole_height,
-                            shielding_position - shielding_length / 2 + 565 * mm + pedestal_length / 2));
-
-    top->AddNode(tTarget, 1, new TGeoTranslation(0, 0, start_of_target));
+    cout << "target at " << fTargetZ / 100. << "m " << endl;
 }

--- a/passive/ShipTargetStation.cxx
+++ b/passive/ShipTargetStation.cxx
@@ -21,9 +21,8 @@ using ShipUnit::mm;
 
 ShipTargetStation::~ShipTargetStation() {}
 ShipTargetStation::ShipTargetStation()
-  : FairModule("ShipTargetStation", "")
-{
-}
+    : FairModule("ShipTargetStation", "")
+{}
 
 ShipTargetStation::ShipTargetStation(const char* name,
                                      const Double_t tl,
@@ -33,10 +32,10 @@ ShipTargetStation::ShipTargetStation(const char* name,
                                      const char* Title)
     : FairModule(name, Title)
 {
-  fTargetLength    = tl;
-  fTargetZ         = tz;
-  fTV = tV;
-  fnS = nS;
+    fTargetLength = tl;
+    fTargetZ = tz;
+    fTV = tV;
+    fnS = nS;
 }
 
 // -----   Private method InitMedium
@@ -112,34 +111,97 @@ void ShipTargetStation::ConstructGeometry()
             material = tungsten;
         };
 
-    // put iron shielding around target
-    if (fTV > 10) {
-        Float_t xTot = 400. / 2.;   // all in cm
-        Float_t yTot = 400. / 2.;
-        Float_t spaceTopBot = 10.;
-        Float_t spaceSide = 5.;
-        TGeoVolume* moreShieldingTopBot =
-            gGeoManager->MakeBox("moreShieldingTopBot", iron, xTot, yTot / 2., fTargetLength / 2.);
-        moreShieldingTopBot->SetLineColor(33);
-        tTarget->AddNode(moreShieldingTopBot,
-                         1,
-                         new TGeoTranslation(0., fDiameter / 2. + spaceTopBot + yTot / 2., fTargetLength / 2.));
-        tTarget->AddNode(moreShieldingTopBot,
-                         2,
-                         new TGeoTranslation(0., -fDiameter / 2. - spaceTopBot - yTot / 2., fTargetLength / 2.));
-        TGeoVolume* moreShieldingSide = gGeoManager->MakeBox(
-            "moreShieldingSide", iron, xTot / 2., (fDiameter + 1.9 * spaceTopBot) / 2., fTargetLength / 2.);
-        moreShieldingSide->SetLineColor(33);
-        tTarget->AddNode(
-            moreShieldingSide, 1, new TGeoTranslation(fDiameter / 2. + spaceSide + xTot / 2., 0., fTargetLength / 2.));
-        tTarget->AddNode(
-            moreShieldingSide, 2, new TGeoTranslation(-fDiameter / 2. - spaceSide - xTot / 2., 0., fTargetLength / 2.));
-    } else {
-        TGeoVolume* moreShielding = gGeoManager->MakeTube("MoreShielding", iron, 30, 400, fTargetLength / 2.);
-        moreShielding->SetLineColor(43);   //
-        tTarget->AddNode(moreShielding, 1, new TGeoTranslation(0, 0, fTargetLength / 2.));
-    }
-    top->AddNode(tTarget, 1, new TGeoTranslation(0, 0, fTargetZ - fTargetLength / 2.));
+        target = gGeoManager->MakeTube(nmi, material, 0., fDiameter / 2., fL.at(i) / 2.);
+        if (fM.at(i) == "molybdenum") {
+            target->SetLineColor(28);
+        } else {
+            target->SetLineColor(38);
+        };   // silver/blue
+        tTarget->AddNode(target, 1, new TGeoTranslation(0, 0, zPos + fL.at(i) / 2.));
+        if (i < slots) {
+            slit = gGeoManager->MakeTube(sm, cooler, 0., fDiameter / 2., fG.at(i) / 2.);
+            slit->SetLineColor(7);   // cyan
+            tTarget->AddNode(slit, 1, new TGeoTranslation(0, 0, zPos + fL.at(i) + fG.at(i) / 2.));
+            zPos += fL.at(i) + fG.at(i);
+        } else {
+            zPos += fL.at(i);
+        }
+    }   // loop on layers
 
-    cout << "target at " << fTargetZ / 100. << "m " << endl;
+    // Proximity shielding
+
+    double start_of_target = fTargetZ - fTargetLength / 2.;
+    fTargetLength = 1586.4 * mm;  // Make shielding independent of actual target length
+    double shielding_width = 1600 * mm;
+    double shielding_length = 3000 * mm;
+    double proximity_shielding_height = 1126 * mm;
+    double proximity_shielding_thickness = 250 * mm;
+    double proximity_shielding_thickness_front = 550 * mm;
+    double proximity_shielding_hole_diameter = 200 * mm;
+    double proximity_shielding_hole_height = 735 * mm;
+    double proximity_shielding_distance_after_target = 96.1 * mm;
+    double shielding_position = start_of_target + fTargetLength + proximity_shielding_distance_after_target
+                                             + proximity_shielding_thickness - shielding_length / 2;
+    auto proximity_shielding_envelope = new TGeoBBox("proximity_shielding_envelope",
+                                                     shielding_width / 2,
+                                                     proximity_shielding_height / 2,
+                                                     shielding_length / 2);
+    auto proximity_shielding_inner = new TGeoBBox(
+        "proximity_shielding_inner",
+        shielding_width / 2 - proximity_shielding_thickness,
+        proximity_shielding_height / 2,
+        (shielding_length - (proximity_shielding_thickness_front + proximity_shielding_thickness)) / 2);
+    auto proximity_shielding_hole = new TGeoTube(
+        "proximity_shielding_hole", 0, proximity_shielding_hole_diameter / 2, proximity_shielding_thickness_front / 2);
+    auto proximity_shielding_inner_shift = new TGeoTranslation(
+        "proximity_shielding_inner_shift", 0, 0, (proximity_shielding_thickness_front - proximity_shielding_thickness) / 2);
+    proximity_shielding_inner_shift->RegisterYourself();
+    auto proximity_shielding_hole_shift =
+        new TGeoTranslation("proximity_shielding_hole_shift",
+                            0,
+                            proximity_shielding_hole_height - proximity_shielding_height / 2,
+                            -shielding_length / 2 + proximity_shielding_thickness_front / 2);
+    proximity_shielding_hole_shift->RegisterYourself();
+    auto proximity_shielding_shape =
+        new TGeoCompositeShape("proximity_shielding_shape",
+                               "proximity_shielding_envelope"
+                               "- proximity_shielding_inner:proximity_shielding_inner_shift"
+                               "- proximity_shielding_hole:proximity_shielding_hole_shift");
+    auto proximity_shielding = new TGeoVolume("proximity_shielding", proximity_shielding_shape, copper);
+    auto proximity_shielding_centre =
+        new TGeoTranslation(
+            0., -(proximity_shielding_hole_height - proximity_shielding_height / 2), shielding_position);
+
+    top->AddNode(proximity_shielding, 1, proximity_shielding_centre);
+
+    // Iron shielding
+    double top_shielding_height = 600 * mm;
+    double bottom_shielding_height = 545 * mm;
+    auto top_shielding = gGeoManager->MakeBox(
+        "top_shielding", iron, shielding_width / 2, top_shielding_height / 2, shielding_length / 2);
+    top->AddNode(
+        top_shielding,
+        1,
+        new TGeoTranslation(0.,
+                            top_shielding_height / 2 + proximity_shielding_height - proximity_shielding_hole_height,
+                            shielding_position));
+    auto bottom_shielding = gGeoManager->MakeBox(
+        "bottom_shielding", iron, shielding_width / 2, bottom_shielding_height / 2, shielding_length / 2);
+    top->AddNode(bottom_shielding,
+                 1,
+                 new TGeoTranslation(
+                     0., -bottom_shielding_height / 2 - proximity_shielding_hole_height, shielding_position));
+    double pedestal_length = 2170 * mm;
+    double pedestal_width = 1070 * mm;
+    double pedestal_height = 150 * mm;
+    auto shielding_pedestal =
+        gGeoManager->MakeBox("shielding_pedestal", iron, pedestal_width / 2, pedestal_height / 2, pedestal_length / 2);
+    top->AddNode(
+        shielding_pedestal,
+        1,
+        new TGeoTranslation(0.,
+                            pedestal_height / 2 - proximity_shielding_hole_height,
+                            shielding_position - shielding_length / 2 + 565 * mm + pedestal_length / 2));
+
+    top->AddNode(tTarget, 1, new TGeoTranslation(0, 0, start_of_target));
 }


### PR DESCRIPTION
Aim is to remove outdated hadron absorber from `FixedTarget` code. At the same time, files which define hadron absorber in `FixedTarget` are updated. 
Notes:
- `run_fixedTarget` was updated but is not in a running state (it isn't in a running state in the master version either) -- this is addressed separately in PR 730
- `run_simPgun` could not run with just the changes to the `FixedTarget` so a series of changes were added to make it run. In particular `ship_geo` was defined and `Veto` and `Muon` needed additional dimension/position information.