### PR TITLE
Improve target definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,16 @@ it in future.
 + makeCascade: Added new default target, moved to argparse
 * run_simScript.py: use options directly internally instead of using intermediate variables
 * Update spectrometer yoke pit size according to EDMS no. 3309666
+* feat: Improve FixedTargetGenerator geometry handling
+  - Replace fragile hardcoded TGeo navigation paths with geometry constants from `ship_geo.target`
+  - Add `SetTargetCoordinates()` method to accept geometry-based start/end z-coordinates from `run_simScript.py`
+  - Use robust `ship_geo.target.z0` and `ship_geo.target.length` instead of brittle `"cave_1/target_vacuum_box_1/TargetArea_1/HeVolume_1"` path
+  - Maintain backward compatibility with legacy TGeo navigation as fallback
+* feat: Improve Pythia8Generator geometry handling
+  - Apply same geometry robustness improvements as FixedTargetGenerator
+  - Replace fragile `"volTarget_1"` TGeo navigation with geometry constants from `ship_geo.target`
+  - Add `SetTargetCoordinates()` method for robust geometry-based target configuration
+  - Maintain backward compatibility with legacy TGeo navigation as fallback
 
 ### Removed
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -347,7 +347,8 @@ if options.pythia8:
    primGen.SmearVertexXY(True)
   P8gen = ROOT.Pythia8Generator()
   P8gen.UseExternalFile(inputFile, options.firstEvent)
-  P8gen.SetTarget("volTarget_1",0.,0.) # will distribute PV inside target, beam offset x=y=0.
+  # Use geometry constants instead of fragile TGeo navigation
+  P8gen.SetTargetCoordinates(ship_geo.target.z0, ship_geo.target.z0 + ship_geo.target.length)
 # pion on proton 500GeV
 # P8gen.SetMom(500.*u.GeV)
 # P8gen.SetId(-211)
@@ -355,7 +356,8 @@ if options.pythia8:
 if options.fixedTarget:
  P8gen = ROOT.FixedTargetGenerator()
  P8gen.SetZoffset(options.z_offset*u.mm)
- P8gen.SetTarget("cave_1/target_vacuum_box_1/TargetArea_1/HeVolume_1", 0. ,0.)
+ # Use geometry constants instead of fragile TGeo navigation
+ P8gen.SetTargetCoordinates(ship_geo.target.z0, ship_geo.target.z0 + ship_geo.target.length)
  P8gen.SetMom(400.*u.GeV)
  P8gen.SetEnergyCut(0.)
  P8gen.SetHeartBeat(100000)

--- a/muonShieldOptimization/run_fixedTarget.py
+++ b/muonShieldOptimization/run_fixedTarget.py
@@ -190,7 +190,8 @@ run.AddModule(sensPlane)
 primGen = ROOT.FairPrimaryGenerator()
 P8gen = ROOT.FixedTargetGenerator()
 P8gen.SetZoffset(args.z_offset*u.mm)
-P8gen.SetTarget("cave_1/target_vacuum_box_1/TargetArea_1/HeVolume_1", 0., 0.)  # will distribute PV inside target, beam offset x=y=0.
+# Use geometry constants instead of fragile TGeo navigation
+P8gen.SetTargetCoordinates(ship_geo.target.z0, ship_geo.target.z0 + ship_geo.target.length)
 P8gen.SetMom(400.*u.GeV)
 P8gen.SetEnergyCut(args.ecut*u.GeV)
 P8gen.SetDebug(args.debug)

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -49,6 +49,7 @@ FixedTargetGenerator::FixedTargetGenerator()
   nrpotspill = 5.E13; // nr of protons / spill
   setByHand = kFALSE;
   Debug = kFALSE;
+  targetFromGeometry = kFALSE;
   Option = "Primary";
   wspill = 1.; // event weight == 1 for primary events
   heartbeat = 1000;
@@ -223,7 +224,21 @@ Bool_t FixedTargetGenerator::Init()
     evtgenN = new EvtGenDecays(fPythiaN, DecayFile.Data(), ParticleFile.Data(),myEvtGenPtr);
    }
   }
-  if (targetName!=""){
+  if (targetFromGeometry) {
+   // Use geometry-based coordinates passed from run_simScript.py
+   fMaterialInvestigator = new GenieGenerator();
+   start[0]=xOff;
+   start[1]=yOff;
+   start[2] = startZ + zOff;
+   end[0]=xOff;
+   end[1]=yOff;
+   end[2]=endZ;
+   LOG(INFO) << "FixedTargetGenerator: Using geometry-based target coordinates startZ=" << startZ << " endZ=" << endZ;
+   //find maximum interaction length
+   bparam = fMaterialInvestigator->MeanMaterialBudget(start, end, mparam);
+   maxCrossSection =  mparam[9];
+  } else if (targetName!=""){
+   // Fallback to fragile TGeo navigation for backward compatibility
    fMaterialInvestigator = new GenieGenerator();
    TGeoNavigator* nav = gGeoManager->GetCurrentNavigator();
    if (nav->CheckPath(targetName)) {

--- a/shipgen/FixedTargetGenerator.h
+++ b/shipgen/FixedTargetGenerator.h
@@ -35,6 +35,12 @@ class FixedTargetGenerator : public FairGenerator
   void UseRandom3() { fUseRandom1 = kFALSE; fUseRandom3 = kTRUE; };
   void SetTarget(TString s, Double_t x,Double_t y ) { targetName = s; xOff=x; yOff=y; };
   void SetZoffset(Double_t z) { zOff = z; };
+  void SetTargetCoordinates(Double_t start_z, Double_t end_z)
+  {
+      startZ = start_z;
+      endZ = end_z;
+      targetFromGeometry = true;
+  };
   void SetBoost(Double_t f) { fBoost  = f; }  // boost factor for rare di-muon decays
   void SetG4only() { G4only  = true; }  // only run Geant4, no pythia primary interaction
   void SetTauOnly() { tauOnly  = true; }  // only have Ds decay to tau
@@ -83,6 +89,7 @@ class FixedTargetGenerator : public FairGenerator
   Double_t mparam[10];
   Double_t startZ;
   Double_t endZ;
+  Bool_t targetFromGeometry;   // flag to indicate coordinates set from geometry
   Double_t maxCrossSection;
   TFile* fin;//!
   TNtuple* nTree;//!

--- a/shipgen/Pythia8Generator.cxx
+++ b/shipgen/Pythia8Generator.cxx
@@ -26,6 +26,7 @@ Pythia8Generator::Pythia8Generator()
   fInputFile  = NULL;
   targetName = "";
   xOff=0; yOff=0;
+  targetFromGeometry = kFALSE;
   fPythia =  new Pythia8::Pythia();
 }
 // -------------------------------------------------------------------------
@@ -94,7 +95,21 @@ Bool_t Pythia8Generator::Init()
    fPythia->settings.parm("Beams:eB", 0.);     // codespell:ignore parm
   }
   fPythia->init();
-  if (targetName!=""){
+  if (targetFromGeometry) {
+   // Use geometry-based coordinates passed from run_simScript.py
+   fMaterialInvestigator = new GenieGenerator();
+   start[0]=xOff;
+   start[1]=yOff;
+   start[2]=startZ;
+   end[0]=xOff;
+   end[1]=yOff;
+   end[2]=endZ;
+   LOG(info) << "Pythia8Generator: Using geometry-based target coordinates startZ=" << startZ << " endZ=" << endZ;
+   //find maximum interaction length
+   bparam = fMaterialInvestigator->MeanMaterialBudget(start, end, mparam);
+   maxCrossSection =  mparam[9];
+  } else if (targetName!=""){
+   // Fallback to fragile TGeo navigation for backward compatibility
    fMaterialInvestigator = new GenieGenerator();
    TGeoVolume* top = gGeoManager->GetTopVolume();
    TGeoNode* target = top->FindNode(targetName);

--- a/shipgen/Pythia8Generator.h
+++ b/shipgen/Pythia8Generator.h
@@ -34,6 +34,12 @@ class Pythia8Generator : public FairGenerator
   void UseExternalFile(const char* x, Int_t i){ fextFile   = x; firstEvent=i; };
   void SetfFDs(Double_t z) { fFDs = z; };
   void SetTarget(TString s, Double_t x,Double_t y ) { targetName = s; xOff=x; yOff=y; };
+  void SetTargetCoordinates(Double_t start_z, Double_t end_z)
+  {
+      startZ = start_z;
+      endZ = end_z;
+      targetFromGeometry = true;
+  };
   Int_t nrOfRetries(){ return fnRetries; };
 
  private:
@@ -67,6 +73,7 @@ class Pythia8Generator : public FairGenerator
   Double_t mparam[10];
   Double_t startZ;
   Double_t endZ;
+  Bool_t targetFromGeometry;   // flag to indicate coordinates set from geometry
   Double_t maxCrossSection;
 };
 


### PR DESCRIPTION
Take start/end z positions from geometry config instead of calculating them from the TGeo nodes for the FixedTargetGenerator and Pythia8Generator.

Both run_simScript.py and run_fixedTarget.py have been updated. The old method remains available, but is discouraged.

Fixes #831.