### PR TITLE
fix(ecal/hcal): include missing headers

### DIFF
--- a/ecal/ecalAnalysisSimple.h
+++ b/ecal/ecalAnalysisSimple.h
@@ -4,10 +4,10 @@
 #include "FairTask.h"
 
 #include "TString.h"
+#include "TTree.h"
 
 #include <list>
 
-class TTree;
 class ecalStructure;
 class TClonesArray;
 

--- a/hcal/hcalAnalysisSimple.h
+++ b/hcal/hcalAnalysisSimple.h
@@ -4,10 +4,10 @@
 #include "FairTask.h"
 
 #include "TString.h"
+#include "TTree.h"
 
 #include <list>
 
-class TTree;
 class hcalStructure;
 class TClonesArray;
 


### PR DESCRIPTION
@matclim How is the removal of HCAL/ECAL progressing? All this old code only causes problems.