### PR TITLE
fix!(run_simScript.py): Use debug flag to set verbosity

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
-          python $FAIRSHIP/macro/run_simScript.py --test --${{ matrix.vessel_option }} --SND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml
+          python $FAIRSHIP/macro/run_simScript.py --test --debug 2 --${{ matrix.vessel_option }} --SND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml
 
       - name: Overlap check
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ it in future.
   - The geometry configuration and detector setup (`geometry/geometry_config.py`, `python/shipDet_conf.py`) have been updated to instantiate all requested SND detectors.
   - This enables running with multiple SND subdetectors simultaneously and is future-proof for additional SND designs.
 * Add support for Pythia 8.3xx. 8.2xx is still supported via preprocessor macros for the time being.
+* Add dedicated --print-fields and --check-overlaps flags to run_simScript.py to use these debug tools.
 
 ### Fixed
 
@@ -125,6 +126,7 @@ it in future.
   - Add `SetTargetCoordinates()` method for robust geometry-based target configuration
   - Maintain backward compatibility with legacy TGeo navigation as fallback
 - The decorators from decorators.py now need to be applied explicitly using the new `apply_decorators` function.
+- The --debug flag to run_simScript.py now controls the severity that FairLogger logs.
 
 ### Removed
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -143,7 +143,9 @@ parser.add_argument("--dry-run", dest="dryrun", help="stop after initialize", ac
 parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajectories", action="store_true")
 parser.add_argument("--shieldName", help="The name of the muon shield in the database to use.", default="New_HA_Design", choices=["New_HA_Design", "warm_opt"])
 parser.add_argument("--MesonMother", dest="MM", help="Choose DP production meson source: pi0, eta, omega, eta1, eta11", default='pi0')
-parser.add_argument("--debug", help="1: print weights and field 2: make overlap check", default=0, type=int, choices=range(0,3))
+parser.add_argument("--debug", help="Control FairLogger verbosity: 0=info (default), 1=+debug, 2=+debug1, 3=+debug2", default=0, type=int, choices=range(0,4))
+parser.add_argument("--print-fields", help="Print VMC fields and weights information", action="store_true")
+parser.add_argument("--check-overlaps", help="Perform geometry overlap checking", action="store_true")
 parser.add_argument("--field_map", default=None, help="Specify spectrometer field map.")
 parser.add_argument("--z-offset", dest="z_offset", help="z-offset for the FixedTargetGenerator [mm]", default=-84., type=float)
 parser.add_argument(
@@ -237,6 +239,16 @@ if (options.ntuple or options.muonback) and defaultInputFile :
   sys.exit()
 ROOT.gRandom.SetSeed(options.theSeed)  # this should be propagated via ROOT to Pythia8 and Geant4VMC
 shipRoot_conf.configure(0)     # load basic libraries, prepare atexit for python
+
+# Configure FairLogger verbosity based on debug level
+if options.debug == 0:
+    ROOT.FairLogger.GetLogger().SetConsoleSeverity("info")
+elif options.debug == 1:
+    ROOT.FairLogger.GetLogger().SetConsoleSeverity("debug")
+elif options.debug == 2:
+    ROOT.FairLogger.GetLogger().SetConsoleSeverity("debug1")
+elif options.debug == 3:
+    ROOT.FairLogger.GetLogger().SetConsoleSeverity("debug2")
 ship_geo = ConfigRegistry.loadpy(
      "$FAIRSHIP/geometry/geometry_config.py",
      Yheight=options.dy,
@@ -559,7 +571,7 @@ if hasattr(ship_geo.Bfield,"fieldMap"):
      fieldMaker = geomGeant4.addVMCFields(ship_geo, verbose=True)
 
 # Print VMC fields and associated geometry objects
-if options.debug == 1:
+if options.print_fields:
  geomGeant4.printVMCFields()
  geomGeant4.printWeightsandFields(onlyWithField = True,\
              exclude=['DecayVolume','Tr1','Tr2','Tr3','Tr4','Veto','Ecal','Hcal','MuonDetector','SplitCal'])
@@ -584,7 +596,7 @@ import saveBasicParameters
 saveBasicParameters.execute(f"{options.outputDir}/geofile_full.{tag}.root",ship_geo)
 
 # checking for overlaps
-if options.debug == 2:
+if options.check_overlaps:
  ROOT.gROOT.SetWebDisplay("off")  # Workaround for https://github.com/root-project/root/issues/18881
  fGeo = ROOT.gGeoManager
  fGeo.SetNmeshPoints(10000)


### PR DESCRIPTION
- The --debug flag now controls which severity FairLogger will print to console
- The --print-fields and --check-overlaps flags have been added to access the debug tools previously controlled using the --debug flag.

Fixes #858.