### PR TITLE
chore: Remove isort in favor of ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,12 +40,6 @@ repos:
   hooks:
     - id: codespell
       exclude: muon|ecal|hcal
-- repo: https://github.com/pycqa/isort
-  rev: 7.0.0
-  hooks:
-    - id: isort
-      args: [--profile=black]
-      name: isort (python)
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.21.0
   hooks:
@@ -74,6 +68,6 @@ repos:
 
 ci:
   autofix_prs: true
-  skip: [ruff-check, isort]
+  skip: [ruff-check]
   autoupdate_commit_msg: "chore(deps): update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"


### PR DESCRIPTION
Ruff already handles import sorting (enabled in .ruff.toml). Removing the redundant isort hook.