### PR TITLE
fix: resolve CMake policy warnings and build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
 
 foreach(p CMP0028 # double colon for imported and alias targets
           CMP0074 # use _ROOT env variables
+          CMP0144 # use <PACKAGENAME>_ROOT variables
+          CMP0167 # FindBoost module removed
 )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/SND/EmulsionTarget/CMakeLists.txt
+++ b/SND/EmulsionTarget/CMakeLists.txt
@@ -17,7 +17,6 @@ link_directories(${LINK_DIRECTORIES})
 
 set(SRCS Target.cxx TargetPoint.cxx TargetTracker.cxx TTPoint.cxx)
 
-set(HEADERS)
 set(LINKDEF EmulsionTargetLinkDef.h)
 set(LIBRARY_NAME EmulsionTarget)
 set(DEPENDENCIES

--- a/SND/MTC/CMakeLists.txt
+++ b/SND/MTC/CMakeLists.txt
@@ -16,7 +16,6 @@ link_directories(${LINK_DIRECTORIES})
 
 set(SRCS MTCDetector.cxx MtcDetPoint.cxx MtcDetHit.cxx)
 
-set(HEADERS)
 set(LINKDEF MTCDetectorLinkDef.h)
 set(LIBRARY_NAME MTCDetector)
 set(DEPENDENCIES

--- a/UpstreamTagger/CMakeLists.txt
+++ b/UpstreamTagger/CMakeLists.txt
@@ -15,7 +15,6 @@ link_directories(${LINK_DIRECTORIES})
 
 set(SRCS UpstreamTagger.cxx UpstreamTaggerPoint.cxx UpstreamTaggerHit.cxx)
 
-set(HEADERS)
 set(LINKDEF LinkDef.h)
 set(LIBRARY_NAME UpstreamTagger)
 set(DEPENDENCIES Base ShipData FairLogger::FairLogger)

--- a/cmake/modules/ShipMacros.cmake
+++ b/cmake/modules/ShipMacros.cmake
@@ -77,15 +77,13 @@ macro(GENERATE_LIBRARY)
       endforeach()
 
       # Use FairRoot's dictionary generation macro
-      # FairRoot v18.8.2 uses ROOT_GENERATE_DICTIONARY() with no parameters
-      # (it reads variables from parent scope: LINKDEF, DICTIONARY, LIBRARY_NAME, HDRS, etc.)
-      # FairRoot v19+ uses fairroot_generate_dictionary() with parameters
-      if(COMMAND fairroot_generate_dictionary)
-        # FairRoot v19+
-        fairroot_generate_dictionary(${DictName} ${HDRS} LINKDEF ${Int_LINKDEF})
+      # Both FairRoot v18.8.2 and v19+ use macros with no parameters
+      # They read variables from parent scope: LINKDEF, DICTIONARY, LIBRARY_NAME, HDRS, etc.
+      if(COMMAND FAIRROOT_GENERATE_DICTIONARY)
+        # FairRoot v19+ - call without parameters
+        FAIRROOT_GENERATE_DICTIONARY()
       else()
         # FairRoot v18.8.2 - call ROOT_GENERATE_DICTIONARY without parameters
-        # It will use the variables we've already set (LINKDEF, DICTIONARY, LIBRARY_NAME, HDRS)
         ROOT_GENERATE_DICTIONARY()
       endif()
 

--- a/muonShieldOptimization/CMakeLists.txt
+++ b/muonShieldOptimization/CMakeLists.txt
@@ -20,7 +20,6 @@ link_directories(${LINK_DIRECTORIES})
 
 set(SRCS exitHadronAbsorber.cxx pyFairModule.cxx simpleTarget.cxx)
 
-set(HEADERS)
 set(LINKDEF LinkDef.h)
 set(LIBRARY_NAME ShipMuonShieldBackground)
 set(DEPENDENCIES

--- a/passive/CMakeLists.txt
+++ b/passive/CMakeLists.txt
@@ -23,7 +23,6 @@ set(SRCS
     ShipTAUMagneticSpectrometer.cxx
     ShipGoliath.cxx)
 
-set(HEADERS)
 set(LINKDEF LinkDef.h)
 set(LIBRARY_NAME ShipPassive)
 set(DEPENDENCIES

--- a/shipdata/CMakeLists.txt
+++ b/shipdata/CMakeLists.txt
@@ -17,7 +17,6 @@ link_directories(${LINK_DIRECTORIES})
 set(SRCS ShipHit.cxx ShipStack.cxx ShipMCTrack.cxx ShipParticle.cxx
          TrackInfo.cxx)
 
-set(HEADERS)
 set(LINKDEF LinkDef.h)
 set(LIBRARY_NAME ShipData)
 set(DEPENDENCIES Base EG Physics Core genfit2 FairLogger::FairLogger)


### PR DESCRIPTION
Fixes CMake configuration issues causing build failures.

- Add CMP0144 and CMP0167 policies to suppress warnings
- Remove empty HEADERS declarations causing dictionary generation failures  
- Fix FAIRROOT_GENERATE_DICTIONARY() invocation in ShipMacros.cmake

Tested successful build with FairRoot v19.0.0 and CMake 3.26+