### PR TITLE
fix(ci): Add tomli dependency for codespell to read pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
   hooks:
     - id: codespell
       exclude: muon|ecal|hcal
+      additional_dependencies: [tomli]
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.21.0
   hooks:


### PR DESCRIPTION
I think this might be the reason you wanted to ignore CHANGELOG.md, @eduard322 