### PR TITLE
refactor(digi): make BaseDetector an abstract base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ it in future.
 
 * Rename MtcDetPoint and MtcDetHit classes to MTCDetPoint and MTCDetHit for consistency with detector naming conventions
 * Refactor digitisation to use detector classes for MTC, muon, time and SBT detectors
+* Make BaseDetector an abstract base class to enforce interface contract
 * Don't special case EOS paths (fix #566)
 * Setting up the Muon shield geometry by ROOT files is completely replaced with the temporary solution of dict in the `geometry/geometry_config.py`.
 * Set up of the shield name is now done using the `--shieldName` flag instead of `--scName`.

--- a/python/BaseDetector.py
+++ b/python/BaseDetector.py
@@ -1,8 +1,9 @@
+from abc import ABC, abstractmethod
+
 import ROOT
-import global_variables
 
 
-class BaseDetector:
+class BaseDetector(ABC):
     def __init__(
         self,
         name,
@@ -46,8 +47,13 @@ class BaseDetector:
         if self.mcBranch:
             self.mcBranch.Fill()
 
+    @abstractmethod
     def digitize(self):
-        # This needs to be defined in the individual detector classes
+        """Digitize detector hits.
+
+        This method must be implemented by all detector subclasses to convert
+        MC hits into digitized detector responses.
+        """
         pass
 
     def process(self):


### PR DESCRIPTION
Make BaseDetector an abstract base class to enforce the interface contract.

- Convert `BaseDetector` to inherit from `ABC` (Abstract Base Class)
- Mark `digitize()` method as `@abstractmethod`
- Add docstring to `digitize()` explaining the required implementation
- Remove unused `global_variables` import (auto-fixed by ruff)

All existing detector classes (MTCDetector, SBTDetector, muonDetector, timeDetector) already implement `digitize()`, so this change is backwards compatible.