### PR TITLE
Make TTree branch split level configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ it in future.
 
 ### Fixed
 
+* fix(digi): Make TTree branch split level configurable in BaseDetector, set splitLevel=1 for MTC
 * chore: Fix file endings
 * chore: trim trailing whitespace
 * Fix mismatch dimension cavern ECN3 TCC8

--- a/python/BaseDetector.py
+++ b/python/BaseDetector.py
@@ -12,6 +12,7 @@ class BaseDetector(ABC):
         branchName=None,
         mcBranchType=None,
         mcBranchName=None,
+        splitLevel=-1,
     ):
         self.name = name
         self.intree = intree
@@ -21,17 +22,21 @@ class BaseDetector(ABC):
         self.mcBranch = None
         if mcBranchName:
             self.MCdet = ROOT.std.vector("std::vector< int >")()
-            self.mcBranch = self.intree.Branch(mcBranchName, self.MCdet, 32000, -1)
+            self.mcBranch = self.intree.Branch(
+                mcBranchName, self.MCdet, 32000, splitLevel
+            )
 
         if "std.vector" in branchType:
             self.det = self.det()
             self.isVector = True
         if branchName:
             self.branch = self.intree.Branch(
-                f"Digi_{branchName}Hits", self.det, 32000, -1
+                f"Digi_{branchName}Hits", self.det, 32000, splitLevel
             )
         else:
-            self.branch = self.intree.Branch(f"Digi_{name}Hits", self.det, 32000, -1)
+            self.branch = self.intree.Branch(
+                f"Digi_{name}Hits", self.det, 32000, splitLevel
+            )
 
     def delete(self):
         if self.isVector:

--- a/python/detectors/MTCDetector.py
+++ b/python/detectors/MTCDetector.py
@@ -4,7 +4,7 @@ from BaseDetector import BaseDetector
 
 class MTCDetector(BaseDetector):
     def __init__(self, name, intree, branchType = 'TClonesArray', branchName = None):
-        super().__init__(name, intree, branchType, branchName)
+        super().__init__(name, intree, branchType, branchName, splitLevel=1)
 
     def digitize(self):
         """Digitize SND/MTC MC hits.


### PR DESCRIPTION
Add splitLevel parameter to BaseDetector to allow subclasses to configure TTree branch split level. Set splitLevel=1 for MTC and default to -1 for other detectors.

Related to #889