### PR TITLE
chore: add CODEOWNERS entries for Python detector classes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,11 @@
 # that system.
 
 veto/* @kathalbrecht  # Katharina Albrecht (HU Berlin)
+python/detectors/SBTDetector.py @kathalbrecht  # Katharina Albrecht (HU Berlin)
 
 SND/* @antonioiuliano2  # Antonio Iuliano (INFN Napoli)
+SND/MTC/* @eduard322  # Eduard Ursov (HU Berlin)
+python/detectors/MTCDetector.py @eduard322
 
 passive/ShipMuonShield.* @Gfrisella  # Guglielmo Frisella (U Zürich)
 


### PR DESCRIPTION
Ensure Python detector classes have the same code owners as their C++ counterparts for consistency. Set Eduard Ursov as owner for MTC detector.