### PR TITLE
refactor: remove unused CaloDesign parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,8 @@ it in future.
 * Remove target versions older than CDR
 * Remove hadron absorber in ShipTargetStation.cxx
 * Remove old ecal and hcal in all of FairSHiP, affected files are notably the entire ecal and hcal directories as well as macro/run_anaEcal.py and python/shipPid.py. geometry/geometry_config.py, muonShieldOptimization/ana_ShipMuon.py, macro/ShipReco.py, macro/ShipAna.py, python/shipStrawTracking.py and python/shipPid.py.
+* Remove unused CaloDesign parameter from geometry configuration (only splitCal supported after ECAL/HCAL removal)
+
 ## 25.01
 
 ### Added

--- a/geometry/geometry_config.py
+++ b/geometry/geometry_config.py
@@ -231,8 +231,6 @@ if "TARGET_YAML" not in globals():
     TARGET_YAML = os.path.expandvars("$FAIRSHIP/geometry/target_config_old.yaml")
 if "strawDesign" not in globals():
     strawDesign = 10
-if "CaloDesign" not in globals():
-    CaloDesign = 0
 if "Yheight" not in globals():
     Yheight = 10.0
 if "shieldName" not in globals():

--- a/macro/create_field_perturbation.py
+++ b/macro/create_field_perturbation.py
@@ -9,7 +9,7 @@ import ShieldUtils
 from argparse import ArgumentParser
 
 
-globalDesigns = {'dy': 10., 'dv': 6, 'ds': 9, 'nud': 3, 'caloDesign': 3, 'strawDesign': 10}
+globalDesigns = {'dy': 10., 'dv': 6, 'ds': 9, 'nud': 3, 'strawDesign': 10}
 
 def create_csv_field_map(options):
     r.gErrorIgnoreLevel = r.kWarning
@@ -20,7 +20,6 @@ def create_csv_field_map(options):
         Yheight=globalDesigns["dy"],
         tankDesign=globalDesigns["dv"],
         nuTauTargetDesign=globalDesigns["nud"],
-        CaloDesign=globalDesigns["caloDesign"],
         strawDesign=globalDesigns["strawDesign"],
         muShieldDesign=options.ds,
         muShieldStepGeo=options.muShieldStepGeo,

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -39,13 +39,11 @@ defaultInputFile = True
 globalDesigns = {
      '2023' : {
           'dy' : 6.,
-          'caloDesign' : 3,
           'strawDesign' : 10
      },
      '2025' : {
           'dy' : 6.,
           'ds' : 8,
-          'caloDesign' : 2,
           'strawDesign' : 10
      },
 }
@@ -141,11 +139,6 @@ group.add_argument("-f", dest="inputFile", help="Input file if not default file"
 parser.add_argument("-g", dest="geofile", help="geofile for muon shield geometry, for experts only", default=None)
 parser.add_argument("-o", "--output", dest="outputDir", help="Output directory",  default=".")
 parser.add_argument("-Y", dest="dy", help="max height of vacuum tank", default=globalDesigns[default]['dy'])
-parser.add_argument("--caloDesign",
-                    help="0=ECAL/HCAL TP 2=splitCal  3=ECAL/ passive HCAL",
-                    default=globalDesigns[default]['caloDesign'],
-                    type=int,
-                    choices=[0,2,3])
 parser.add_argument("--strawDesign",
                     help="Tracker station frame material: 4=aluminium; 10=steel (default)",
                     default=globalDesigns[default]['strawDesign'],
@@ -266,7 +259,6 @@ elif options.debug == 3:
 ship_geo = ConfigRegistry.loadpy(
      "$FAIRSHIP/geometry/geometry_config.py",
      Yheight=options.dy,
-     CaloDesign=options.caloDesign,
      strawDesign=options.strawDesign,
      muShieldGeo=options.geofile,
      shieldName=options.shieldName,

--- a/python/TTCluster.py
+++ b/python/TTCluster.py
@@ -175,17 +175,16 @@ CDF_ly_params = {
 #####  LOAD THE TARGET TRACKER GEOMETRY  #########
 ##################################################
 
-design2018 = {'dy': 10.,'dv': 6,'ds': 9,'nud': 3,'caloDesign': 3,'strawDesign': 10}
+design2018 = {'dy': 10.,'dv': 6,'ds': 9,'nud': 3,'strawDesign': 10}
 dy = design2018['dy']
 dv = design2018['dv']
 ds = design2018['ds']
 nud = design2018['nud']
-caloDesign = design2018['caloDesign']
 strawDesign = design2018['strawDesign']
 geofile = None
 
 ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/geometry_config.py", Yheight=dy,
-	tankDesign=dv, muShieldDesign=ds, nuTauTargetDesign=nud, CaloDesign=caloDesign,
+	tankDesign=dv, muShieldDesign=ds, nuTauTargetDesign=nud,
 	strawDesign=strawDesign, muShieldGeo=geofile)
 
 n_hor_planes = ship_geo.NuTauTT.n_hor_planes # 11


### PR DESCRIPTION
After the ECAL/HCAL removal in commit 2b10248, only the splitCal design remains supported (HcalOption=-1, EcalOption=2). The CaloDesign parameter was kept in the API but completely unused.

This commit removes CaloDesign from:
- geometry_config.py: removed default value
- run_simScript.py: removed from globalDesigns, argparse, and function call
- create_field_perturbation.py: removed from globalDesigns and function call
- TTCluster.py: removed from design2018 dict and function call