### PR TITLE
refactor: remove globalDesigns dictionary, use inline defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ it in future.
 * Remove target versions older than CDR
 * Remove hadron absorber in ShipTargetStation.cxx
 * Remove old ecal and hcal in all of FairSHiP, affected files are notably the entire ecal and hcal directories as well as macro/run_anaEcal.py and python/shipPid.py. geometry/geometry_config.py, muonShieldOptimization/ana_ShipMuon.py, macro/ShipReco.py, macro/ShipAna.py, python/shipStrawTracking.py and python/shipPid.py.
+* Remove globalDesigns dictionary from run_simScript.py and create_field_perturbation.py, use inline defaults instead
 * Remove unused CaloDesign parameter from geometry configuration (only splitCal supported after ECAL/HCAL removal)
 
 ## 25.01

--- a/macro/create_field_perturbation.py
+++ b/macro/create_field_perturbation.py
@@ -9,15 +9,13 @@ import ShieldUtils
 from argparse import ArgumentParser
 
 
-globalDesigns = {'dy': 10., 'dv': 6, 'ds': 9, 'nud': 3, 'strawDesign': 10}
-
 def create_csv_field_map(options):
     r.gErrorIgnoreLevel = r.kWarning
     r.gSystem.Load('libpythia8')
 
     ship_geo = geometry_config.create_config(
-        Yheight=globalDesigns["dy"],
-        strawDesign=globalDesigns["strawDesign"],
+        Yheight=10.0,
+        strawDesign=10,
         muShieldGeo=options.geofile,
         shieldName=getattr(options, 'shieldName', 'warm_opt'))
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -36,19 +36,6 @@ HNL          = True
 inputFile    = "$EOSSHIP/eos/experiment/ship/data/Charm/Cascade-parp16-MSTP82-1-MSEL4-978Bpot.root"
 defaultInputFile = True
 
-globalDesigns = {
-     '2023' : {
-          'dy' : 6.,
-          'strawDesign' : 10
-     },
-     '2025' : {
-          'dy' : 6.,
-          'ds' : 8,
-          'strawDesign' : 10
-     },
-}
-default = '2025'
-
 parser = ArgumentParser()
 group = parser.add_mutually_exclusive_group()
 
@@ -138,10 +125,10 @@ parser.add_argument("-S", "--sameSeed",dest="sameSeed",  help="can be set to an 
 group.add_argument("-f", dest="inputFile", help="Input file if not default file", default=False)
 parser.add_argument("-g", dest="geofile", help="geofile for muon shield geometry, for experts only", default=None)
 parser.add_argument("-o", "--output", dest="outputDir", help="Output directory",  default=".")
-parser.add_argument("-Y", dest="dy", help="max height of vacuum tank", default=globalDesigns[default]['dy'])
+parser.add_argument("-Y", dest="dy", help="max height of vacuum tank", default=6.0, type=float)
 parser.add_argument("--strawDesign",
                     help="Tracker station frame material: 4=aluminium; 10=steel (default)",
-                    default=globalDesigns[default]['strawDesign'],
+                    default=10,
                     type=int,
                     choices=[4,10])
 parser.add_argument("-F", dest="deepCopy", help="default = False: copy only stable particles to stack, except for HNL events", action="store_true")


### PR DESCRIPTION
The globalDesigns dictionary was unnecessary indirection. Both 2023 and 2025 designs had identical values (dy=6.0, strawDesign=10), with only an unused 'ds' difference.

Simplified by using inline defaults directly in argparse.

Changes:
- run_simScript.py: Remove globalDesigns dict, set defaults to dy=6.0, strawDesign=10
- create_field_perturbation.py: Remove globalDesigns dict, use inline values (dy=10.0 for expert script)
- Both scripts now have explicit, clear defaults without dictionary lookup