### PR TITLE
fix: SiliconTarget detector ID and placement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ it in future.
 * Fix refactoring issue that broke MTC digitization
 * Fix the condition in the sipm channel <-> fiber mapping that stopped looping over channels because of the distance between a fiber and a channel. Setting a flexible condition that depends on the aggregated channel size.
 * Add flags for `python/ScifiMapping.py`
+* Fixed SiliconTarget detector identifier.
 
 ### Changed
 
@@ -179,6 +180,7 @@ it in future.
   - Automatic format detection: new code reads both JSON (new format) and pickle (legacy format) files without user intervention
 * Change the logic of SiPM channel encoding in MTC. Now the number of SiPM is 1 and has a number of channels that fits the width of the plane. If the number of channels exceeds 1000, iterating a SiPM digit to 1 and distributing channels among new number of SiPMs.
 * Set default parameters of MTC to 60x60 cm^2 and 4 aggregated channels according to Sep 2025 CM.
+* Placement of SiliconTarget has been shifted by 10 cm to bring the final layer to within 10 cm of the MTC.
 
 ### Removed
 

--- a/SND/SiliconTarget/SiliconTarget.cxx
+++ b/SND/SiliconTarget/SiliconTarget.cxx
@@ -242,6 +242,12 @@ Bool_t SiliconTarget::ProcessHits(FairVolume* vol)
         Double_t ymean = (fPos.Y() + Pos.Y()) / 2.;
         Double_t zmean = (fPos.Z() + Pos.Z()) / 2.;
 
+        Int_t strip_id = 0;
+        Int_t sensor_id = 0;
+        gMC->CurrentVolID(strip_id);
+        gMC->CurrentVolOffID(1, sensor_id);
+        fVolumeID = (sensor_id << 12) + strip_id;
+
         AddHit(fTrackID,
                fVolumeID,
                TVector3(xmean, ymean, zmean),

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -155,9 +155,9 @@ def configure_snd_siliconTarget(yaml_file, ship_geo):
     # Initialize detector
     if ship_geo.SiliconTarget_geo.zPosition == "auto":
         # Get the the center of the next to last magnet (temporary placement)
-        # Offset placement of detector by 130 cm, magnet is 2* 212.54 cm,
-        # 120 layers at 132 cm will fit.
-        ship_geo.SiliconTarget_geo.zPosition = find_shield_center(ship_geo)[2][-2] + 130
+        # Offset placement of detector by 140 cm, magnet is 2* 212.54 cm,
+        # 120 layers at 132 cm will fit, with 140 cm offset final layer within 10 cm of MTC.
+        ship_geo.SiliconTarget_geo.zPosition = find_shield_center(ship_geo)[2][-2] + 140
         print("SiliconTarget zPosition set to ", ship_geo.SiliconTarget_geo.zPosition)
     SiliconTarget = ROOT.SiliconTarget("SiliconTarget", ROOT.kTRUE)
     SiliconTarget.SetSiliconTargetParameters(


### PR DESCRIPTION
Detector ID now properly set for SiliconTargetPoints, previously defaulted to -1.
Position of detector moved forwards by 10 cm to bring it closer to the first MTC Iron layer (now ~9.6 cm separation from final silicon plane).