### PR TITLE
Remove StopTrack from sens plane

### DIFF
--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -83,7 +83,9 @@ Bool_t  exitHadronAbsorber::ProcessHits(FairVolume* vol)
       }
     }
   }
-  // gMC->StopTrack();
+  if ((!fCylindricalPlane) && fzPos > 1E8) {
+    gMC->StopTrack();
+  }
   return kTRUE;
 }
 


### PR DESCRIPTION
StopTrack leads to unwanted behaviour when the sensitive plane is not at the end of the decay volume. 
I am not sure if it is better to leave it by default, and add an option to not use, or remove it at all times