### PR TITLE
refactor(digi): use maximum branch splitting instead of no splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ it in future.
 * Integrate splitcal cluster reconstruction into splitcalDetector class
 * refactor(splitcal): Use value storage for both hits and clusters instead of pointer storage
 * refactor(splitcal): Replace TVector3 with std::array and hit pointers with indices in splitcalCluster for RNtuple compatibility
+* refactor(digi): Use maximum splitting (99) for vector branches instead of no splitting (-1)
 * Don't special case EOS paths (fix #566)
 * Setting up the Muon shield geometry by ROOT files is completely replaced with the temporary solution of dict in the `geometry/geometry_config.py`.
 * Set up of the shield name is now done using the `--shieldName` flag instead of `--scName`.

--- a/python/BaseDetector.py
+++ b/python/BaseDetector.py
@@ -1,9 +1,13 @@
+"""Base class for detector digitisation."""
+
 from abc import ABC, abstractmethod
 
 import ROOT
 
 
 class BaseDetector(ABC):
+    """Abstract base class for detector digitisation."""
+
     def __init__(
         self,
         name,
@@ -12,8 +16,9 @@ class BaseDetector(ABC):
         branchName=None,
         mcBranchType=None,
         mcBranchName=None,
-        splitLevel=-1,
+        splitLevel=99,
     ):
+        """Initialise detector digitisation."""
         self.name = name
         self.intree = intree
         self.isVector = False
@@ -39,6 +44,7 @@ class BaseDetector(ABC):
             )
 
     def delete(self):
+        """Clear detector containers."""
         if self.isVector:
             self.det.clear()
         else:
@@ -48,6 +54,7 @@ class BaseDetector(ABC):
             self.MCdet.clear()
 
     def fill(self):
+        """Fill TTree branches."""
         self.branch.Fill()
         if self.mcBranch:
             self.mcBranch.Fill()
@@ -62,6 +69,7 @@ class BaseDetector(ABC):
         pass
 
     def process(self):
+        """Process one event: delete, digitise, and fill."""
         self.delete()
         self.digitize()
         self.fill()

--- a/python/detectors/splitcalDetector.py
+++ b/python/detectors/splitcalDetector.py
@@ -10,7 +10,7 @@ class splitcalDetector(BaseDetector):
 
         # Clusters use value storage
         self.reco = ROOT.std.vector("splitcalCluster")()
-        self.recoBranch = self.intree.Branch("Reco_SplitcalClusters", self.reco, 32000, -1)
+        self.recoBranch = self.intree.Branch("Reco_SplitcalClusters", self.reco)
 
     def delete(self):
         # Override to also clear reconstruction branch


### PR DESCRIPTION
Change default split level from -1 (no splitting) to 99 (maximum splitting) for better I/O performance when reading individual data members.

Changes:
- BaseDetector: default splitLevel from -1 to 99
- splitcalDetector: remove explicit -1 from cluster branch creation
- Add docstrings to BaseDetector for linting compliance

Maximum splitting allows ROOT to create sub-branches for each data member, enabling efficient partial reads without loading entire objects.