### PR TITLE
docs(reco): document why genfit::Track requires pointer storage

### DIFF
--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -61,6 +61,8 @@ class ShipDigiReco:
   self.header  = ROOT.FairEventHeader()
   self.eventHeader  = self.sTree.Branch("ShipEventHeader",self.header,32000,-1)
 # fitted tracks
+  # Must use pointer storage: genfit::Track has circular references with TrackPoint
+  # requiring stable memory addresses (value storage would invalidate back-pointers on vector resize)
   self.fGenFitArray = ROOT.std.vector("genfit::Track*")()
   self.fitTrack2MC  = ROOT.std.vector('int')()
   self.goodTracksVect  = ROOT.std.vector('int')()


### PR DESCRIPTION
Add comment explaining that genfit::Track has circular references with TrackPoint (Track owns TrackPoints, TrackPoints have transient back-pointers to Track). This requires stable memory addresses, making value storage incompatible as vector resizes would invalidate the back-pointers.

This is a fundamental design constraint in GenFit that cannot be worked around without changes to GenFit itself.