### PR TITLE
Add extra sensitive plane after target

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
-          python $FAIRSHIP/muonShieldOptimization/run_fixedTarget.py -n 10 -e 10.0 -r 1
+          python $FAIRSHIP/macro/run_fixedTarget.py -n 10 -e 10.0 -r 1
 
       - name: Upload .root artifacts
         uses: actions/upload-artifact@v4

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -80,7 +80,6 @@ ap.add_argument('--TARGET_YAML', dest='TARGET_YAML', help='File for target confi
 
 ap.add_argument('--AddCylindricalSensPlane', action='store_true', help="Whether or not to add cylindrical sensitive plane around the target. False by default.")
 ap.add_argument('--AddPostTargetSensPlane', action='store_true', help="Whether or not to add sensitive plane after the target. False by default.")
-ap.add_argument('--SaveOnlyChargedParticlesInTargetPlane', action='store_true', help="Whether or not to save only the charged particles at the post-target sensitive plane. False by default.")
 
 args = ap.parse_args()
 if args.debug:
@@ -176,10 +175,7 @@ if args.AddPostTargetSensPlane:
     # by default, if the z-position is not set, the positioning is behind the hadron abosorber and the tracks are stopped when they hit the sens plane
     # if the z-position is set and has a reasonable value (below 1E8), then the tracks are not stopped and continue to the last plane after the hadron absorber
     sensPlanePostT.SetZposition(ship_geo.target.length + 7.6*u.cm + 300*u.mm)  # target length + vessel shift + shielding length
-    sensPlanePostT.SetPositionFromCave()  # position set from the cave to avoid extrusions since the plane is larger than the target vacuum box
-
-    if args.SaveOnlyChargedParticlesInTargetPlane:
-        sensPlanePostT.SetSaveOnlyChargedParticlesInTargetPlane()
+    sensPlanePostT.SetUseCaveCoordinates()  # position set from the cave to avoid extrusions since the plane is larger than the target vacuum box
 
     if args.storeOnlyMuons:
         sensPlanePostT.SetOnlyMuons()

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -51,8 +51,7 @@ exitHadronAbsorber::exitHadronAbsorber()
     fzPos(3E8),
     withNtuple(kFALSE),
     fCylindricalPlane(kFALSE),
-    fSaveOnlyChargedParticlesInTargetPlane(kFALSE),
-    fSetPosFromCave(kFALSE),
+    fUseCaveCoordinates(kFALSE),
     fexitHadronAbsorberPointCollection(new TClonesArray("vetoPoint"))
 {}
 
@@ -71,10 +70,8 @@ Bool_t  exitHadronAbsorber::ProcessHits(FairVolume* vol)
     fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
     TParticle* p  = gMC->GetStack()->GetCurrentTrack();
     Int_t pdgCode = p->GetPdgCode();
-    TDatabasePDG* PDG = TDatabasePDG::Instance();
-    Double_t charge = PDG->GetParticle(pdgCode)->Charge();
     gMC->TrackMomentum(fMom);
-    if (!(fOnlyMuons && TMath::Abs(pdgCode)!=13) && !(fSaveOnlyChargedParticlesInTargetPlane && TMath::Abs(charge)>0.1)){
+    if (!(fOnlyMuons && TMath::Abs(pdgCode)!=13)){
      fTime   = gMC->TrackTime() * 1.0e09;
      fLength = gMC->TrackLength();
      gMC->TrackPosition(fPos);
@@ -253,7 +250,7 @@ void exitHadronAbsorber::ConstructGeometry()
      TGeoVolume *sensPlane = gGeoManager->MakeBox(shapename_prefix+fVetoName+"_box",vac,3.56*m-1.*mm,1.7*m-1.*mm,1.*mm);
      std::cout << this->GetName() << ", ConstructGeometry(): Created Box with dimensions: 3.56*m-1.*mm,1.7*m-1.*mm,1.*mm" << std::endl;
 
-     if (!fSetPosFromCave) {
+     if (!fUseCaveCoordinates) {
         nav->cd("/MuonShieldArea_1/");
      } else {
         Double_t local[3]  = {0, 0, zLoc};

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -76,8 +76,7 @@ class exitHadronAbsorber: public FairDetector
     inline void SetZposition(Float_t x){fzPos=x;}
     inline void SetVetoPointName(TString nam){fVetoName=nam;}
     inline void SetCylindricalPlane(){fCylindricalPlane=kTRUE;}
-    inline void SetSaveOnlyChargedParticlesInTargetPlane(){fSaveOnlyChargedParticlesInTargetPlane=kTRUE;}
-    inline void SetPositionFromCave(){fSetPosFromCave=kTRUE;}
+    inline void SetUseCaveCoordinates(){fUseCaveCoordinates=kTRUE;}
 
   private:
 
@@ -100,8 +99,7 @@ class exitHadronAbsorber: public FairDetector
     Bool_t fSkipNeutrinos;  //! flag if neutrinos should be ignored
     TString fVetoName; //name to save veto collection
     Bool_t fCylindricalPlane;  //! flag if the sensPlane to be created should be cylindrical (by default it is not)
-    Bool_t fSaveOnlyChargedParticlesInTargetPlane;  //! flag if only charged particles should be saved in the plane
-    Bool_t fSetPosFromCave;  //! set position from cave rather than from muon sheild, default is false
+    Bool_t fUseCaveCoordinates;  //! set position from cave rather than from muon shield, default is false
 
     TFile* fout; //!
     TClonesArray* fElectrons; //!


### PR DESCRIPTION
Added sensitive plane after the target.

- The dimensions are the same as the ones for the plane post muon shield. This plane had to be defined from `cave` given otherwise there would have been extrusions, with z location at `target length + vessel shift + shielding length`.
- Everything is saved by default, but an option is added in the `exitHadronAbsorber` to save only charged particles if need be.