### PR TITLE
refactor: use friend trees for reconstruction output

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -108,13 +108,13 @@ jobs:
         run: |
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
-          python $FAIRSHIP/macro/ShipAna.py -f ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root
+          python $FAIRSHIP/macro/ShipAna.py -f ship.conical.Pythia8-TGeant4.root -r ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root
 
       - name: Run examples
         run: |
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
-          python $FAIRSHIP/examples/analysis_example.py
+          python $FAIRSHIP/examples/analysis_example.py -f ship.conical.Pythia8-TGeant4.root -r ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root
 
       - name: Upload .root artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -149,11 +149,15 @@ python $FAIRSHIP/macro/ShipReco.py -f ship.conical.Pythia8-TGeant4.root -g geofi
 >> [...]
 >> finished writing tree
 >> Exit normally
+>> (This creates ship.conical.Pythia8-TGeant4_rec.root with digitisation and reconstruction data)
 
-python -i $FAIRSHIP/macro/ShipAna.py -f ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root
+python -i $FAIRSHIP/macro/ShipAna.py -f ship.conical.Pythia8-TGeant4.root -r ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root
 >> finished making plots
 >> Exit normally
 ```
+
+**Note**: ShipReco now creates a separate reconstruction file (`*_rec.root`) containing only digitisation and reconstruction branches. The original simulation file is not modified. ShipAna uses both files via ROOT's friend tree mechanism to access both MC truth and reconstruction data.
+
 Alternatively, you can make use of the experimental `analysis_toolkit` to run a simple pre-selection check on the events. An example script can be found in `$FAIRSHIP/examples/analysis_example.py`.
 
 Simulate MC signal events with EventCalc:
@@ -169,7 +173,7 @@ python $FAIRSHIP/macro/run_simScript.py --evtcalc -n 1 -o test_folder -f test_fo
 Run the event display:
 
 ```bash
-python -i $FAIRSHIP/macro/eventDisplay.py -f ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root
+python -i $FAIRSHIP/macro/eventDisplay.py -f ship.conical.Pythia8-TGeant4.root -r ship.conical.Pythia8-TGeant4_rec.root -g geofile_full.conical.Pythia8-TGeant4.root
 // use SHiP Event Display GUI
 Use quit() or Ctrl-D (i.e. EOF) to exit
 ```

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -63,7 +63,10 @@ transparentMaterials = {
 parser = ArgumentParser()
 
 parser.add_argument(
-    "-f", "--inputFile", dest="InputFile", help="Input file", required=True
+    "-f", "--inputFile", dest="InputFile", help="Input file (MC simulation)", required=True
+)
+parser.add_argument(
+    "-r", "--recoFile", dest="recoFile", help="Reconstruction file (will be used as friend tree)", required=False
 )
 parser.add_argument(
     "-g", "--geoFile", dest="geoFile", help="ROOT geofile", required=True
@@ -102,6 +105,15 @@ parser.add_argument(
 options = parser.parse_args()
 if options.InputFile.find("_D") > 0:
     withGeo = True
+
+# Determine reconstruction file
+if not options.recoFile:
+    # Default: replace .root with _rec.root, or if already _rec.root use as-is
+    if options.InputFile.find('_rec.root') > 0:
+        options.recoFile = options.InputFile
+        options.InputFile = options.InputFile.replace('_rec.root', '.root')
+    else:
+        options.recoFile = options.InputFile.replace('.root', '_rec.root')
 
 
 def printMCTrack(n, MCTrack):
@@ -1183,6 +1195,8 @@ if options.geoFile:
     fRun.SetGeomFile(options.geoFile)
 
 inFile = ROOT.FairFileSource(options.InputFile)
+# Add reconstruction file as friend tree
+inFile.AddFriend(options.recoFile)
 fRun.SetSource(inFile)
 if options.OutputFile is None:
     options.OutputFile = ROOT.TMemFile("event_display_output", "recreate")

--- a/python/BaseDetector.py
+++ b/python/BaseDetector.py
@@ -16,25 +16,28 @@ class BaseDetector(ABC):
         mcBranchType=None,
         mcBranchName=None,
         splitLevel=99,
+        outtree=None,
     ):
         """Initialise detector digitisation."""
         self.name = name
         self.intree = intree
+        # If outtree provided, use it for output; else intree for compatibility
+        self.outtree = outtree if outtree is not None else intree
         self.det = ROOT.std.vector(f"{name}Hit")()
         self.MCdet = None
         self.mcBranch = None
         if mcBranchName:
             self.MCdet = ROOT.std.vector("std::vector< int >")()
-            self.mcBranch = self.intree.Branch(
+            self.mcBranch = self.outtree.Branch(
                 mcBranchName, self.MCdet, 32000, splitLevel
             )
 
         if branchName:
-            self.branch = self.intree.Branch(
+            self.branch = self.outtree.Branch(
                 f"Digi_{branchName}Hits", self.det, 32000, splitLevel
             )
         else:
-            self.branch = self.intree.Branch(
+            self.branch = self.outtree.Branch(
                 f"Digi_{name}Hits", self.det, 32000, splitLevel
             )
 

--- a/python/detectors/MTCDetector.py
+++ b/python/detectors/MTCDetector.py
@@ -5,8 +5,8 @@ from BaseDetector import BaseDetector
 
 
 class MTCDetector(BaseDetector):
-    def __init__(self, name, intree, branchName=None):
-        super().__init__(name, intree, branchName)
+    def __init__(self, name, intree, branchName=None, outtree=None):
+        super().__init__(name, intree, branchName, outtree=outtree)
         # add MTC module to the list of globals to use it later in the MTCDetHit class. Consistent with SND@LHC approach.
         # make SiPM to fibre mapping
         if intree.GetBranch("MTCDetPoint"):

--- a/python/detectors/SBTDetector.py
+++ b/python/detectors/SBTDetector.py
@@ -10,8 +10,16 @@ class SBTDetector(BaseDetector):
         branchName=None,
         mcBranchType=None,
         mcBranchName="digiSBT2MC",
+        outtree=None,
     ):
-        super().__init__(name, intree, branchName, mcBranchType, mcBranchName)
+        super().__init__(
+            name,
+            intree,
+            branchName,
+            mcBranchType,
+            mcBranchName,
+            outtree=outtree,
+        )
 
     def digitize(self):
         """Digitize Surrounding Background Tagger MC hits.

--- a/python/detectors/UpstreamTaggerDetector.py
+++ b/python/detectors/UpstreamTaggerDetector.py
@@ -4,8 +4,8 @@ from BaseDetector import BaseDetector
 
 
 class UpstreamTaggerDetector(BaseDetector):
-    def __init__(self, name, intree):
-        super().__init__(name, intree)
+    def __init__(self, name, intree, outtree=None):
+        super().__init__(name, intree, outtree=outtree)
 
     def digitize(self):
         ship_geo = global_variables.ShipGeo

--- a/python/detectors/muonDetector.py
+++ b/python/detectors/muonDetector.py
@@ -3,8 +3,8 @@ from BaseDetector import BaseDetector
 
 
 class muonDetector(BaseDetector):
-    def __init__(self, name, intree):
-        super().__init__(name, intree)
+    def __init__(self, name, intree, outtree=None):
+        super().__init__(name, intree, outtree=outtree)
 
     def digitize(self):
         """Digitize muon detector MC hits.

--- a/python/detectors/splitcalDetector.py
+++ b/python/detectors/splitcalDetector.py
@@ -5,13 +5,15 @@ from BaseDetector import BaseDetector
 
 
 class splitcalDetector(BaseDetector):
-    def __init__(self, name, intree):
+    def __init__(self, name, intree, outtree=None):
         # Initialize base class for digitized hits
-        super().__init__(name, intree, "Splitcal")
+        super().__init__(name, intree, "Splitcal", outtree=outtree)
 
         # Clusters use value storage
         self.reco = ROOT.std.vector("splitcalCluster")()
-        self.recoBranch = self.intree.Branch("Reco_SplitcalClusters", self.reco)
+        # Use outtree if provided, otherwise intree (backward compatibility)
+        tree_for_output = self.outtree if outtree is not None else intree
+        self.recoBranch = tree_for_output.Branch("Reco_SplitcalClusters", self.reco)
 
     def delete(self):
         # Override to also clear reconstruction branch

--- a/python/detectors/strawtubesDetector.py
+++ b/python/detectors/strawtubesDetector.py
@@ -5,11 +5,12 @@ from BaseDetector import BaseDetector
 
 
 class strawtubesDetector(BaseDetector):
-    def __init__(self, name, intree):
-        super().__init__(name, intree)
+    def __init__(self, name, intree, outtree=None):
+        super().__init__(name, intree, outtree=outtree)
 
     def digitize(self):
         """Digitize strawtube MC hits.
+
         The earliest hit per straw will be marked valid, all later ones invalid.
         """
         earliest_per_det_id = {}
@@ -83,8 +84,6 @@ class strawtubesDetector(BaseDetector):
                 continue
             detID = aDigi.GetDetectorID()
             global_variables.modules["strawtubes"].StrawEndPoints(detID, start, stop)
-            # distance to wire
-            delt1 = (start[2] - z1) / u.speedOfLight
             p = self.intree.strawtubesPoint[key]
             # use true t0  construction:
             #     fdigi = t0 + p->GetTime() + t_drift + ( stop[0]-p->GetX() )/ speedOfLight;

--- a/python/detectors/timeDetector.py
+++ b/python/detectors/timeDetector.py
@@ -3,8 +3,8 @@ from BaseDetector import BaseDetector
 
 
 class timeDetector(BaseDetector):
-    def __init__(self, name, intree):
-        super().__init__(name, intree)
+    def __init__(self, name, intree, outtree=None):
+        super().__init__(name, intree, outtree=outtree)
 
     def digitize(self):
         """Digitize timing detector MC hits.

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -10,8 +10,9 @@ from array import array
 
 class Task:
  "initialize"
- def __init__(self,hp,sTree):
+ def __init__(self,hp,sTree,mcTree=None):
   self.sTree = sTree
+  self.mcTree = mcTree if mcTree is not None else sTree
   self.fPartArray = ROOT.std.vector("ShipParticle")()
   if not self.sTree.GetBranch("Particles"):
       self.Particles = self.sTree.Branch("Particles", self.fPartArray)
@@ -139,9 +140,9 @@ class Task:
      #print "     ",mctrack.GetStartX(),mctrack.GetStartY(),mctrack.GetStartZ()
 #   HNL true
      if  self.sTree.GetBranch("fitTrack2MC"):
-      mctrack = self.sTree.MCTrack[self.sTree.fitTrack2MC[t1]]
-      mctrack2 = self.sTree.MCTrack[self.sTree.fitTrack2MC[t2]]
-      mcHNL = self.sTree.MCTrack[mctrack.GetMotherId()]
+      mctrack = self.mcTree.MCTrack[self.sTree.fitTrack2MC[t1]]
+      mctrack2 = self.mcTree.MCTrack[self.sTree.fitTrack2MC[t2]]
+      mcHNL = self.mcTree.MCTrack[mctrack.GetMotherId()]
       #print "true vtx: ",mctrack.GetStartX(),mctrack.GetStartY(),mctrack.GetStartZ()
       #print "reco vtx: ",HNLPos[0],HNLPos[1],HNLPos[2]
       #self.h['Vzpull'].Fill( (mctrack.GetStartZ()-HNLPos[2])/ROOT.TMath.Sqrt(covX[2][2]) )


### PR DESCRIPTION
ShipReco now writes a separate output file with only digitisation and
reconstruction branches instead of copying and modifying the input file.
The reconstruction file uses a new TTree named 'ship_reco_sim' which can
be added as a friend to the MC simulation tree 'cbmsim'.

Changes:
- ShipReco: remove file copying logic, pass both input and output files
  to ShipDigiReco constructor, add recoTree.Fill() after each event
- shipDigiReco: open input file read-only, create new output file with
  ship_reco_sim tree, close both files on finish
- BaseDetector: add outtree parameter to support separate input/output
  trees whilst maintaining backward compatibility
- All detector classes: accept and forward outtree parameter to base class
- ShipAna: add -r/--recoFile option with auto-detection, use AddFriend
  to combine MC and reco trees
- analysis_example: add --simfile and --recofile options, use AddFriend
- eventDisplay: add -r/--recoFile option with auto-detection, use
  FairFileSource.AddFriend for compatibility with FairRoot event manager
- CI: update workflow to use new friend tree mechanism
- README: document new workflow and friend tree usage

Benefits:
- Input simulation files remain unmodified (important for archived data)
- Smaller reconstruction files (no duplicated MC data)
- Can re-run reconstruction independently without re-digitising
- Clear separation between MC truth and reconstruction data