### PR TITLE
refactor: remove BOOST serialisation and modernise data classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,9 +194,18 @@ it in future.
 * Change the logic of SiPM channel encoding in MTC. Now the number of SiPM is 1 and has a number of channels that fits the width of the plane. If the number of channels exceeds 1000, iterating a SiPM digit to 1 and distributing channels among new number of SiPMs.
 * Set default parameters of MTC to 60x60 cm^2 and 4 aggregated channels according to Sep 2025 CM.
 * Placement of SiliconTarget has been shifted by 10 cm to bring the final layer to within 10 cm of the MTC.
+* Modernise data classes by removing obsolete BOOST serialisation (Tracklet, vetoHitOnTrack, ShipHit, TrackInfo)
+  - Replace BOOST serialisation with native ROOT 6 serialisation
+  - Modernise Tracklet constructor to accept `std::vector<unsigned int>` indices
+  - Update vetoHitOnTrack to use parameterised constructor in Python code
+  - Add const correctness to TrackInfo accessor methods
+  - Update Python code in shipDigiReco.py to use modern constructors
+  - Bump ClassDef versions to 2 for schema evolution
+  - Add TrackInfo to RNTuple I/O test suite
 
 ### Removed
 
+* Remove BOOST dependency from CMake build system - no longer required as ROOT 6 provides native serialisation
 * Remove Goliath magnet geometry and field implementation (ShipGoliath, ShipGoliathField, and associated field maps)
 * fix: Remove unused, unrunnable shipPatRec_prev.py
 * feat(geometry): Dropped support for old geometries without DecayVolumeMedium explicitly set(pre 24.11 release case).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
 foreach(p CMP0028 # double colon for imported and alias targets
           CMP0074 # use _ROOT env variables
           CMP0144 # use <PACKAGENAME>_ROOT variables
-          CMP0167 # FindBoost module removed
 )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)
@@ -143,19 +142,9 @@ find_package2(PUBLIC FairLogger REQUIRED)
 find_package2(PUBLIC VMC REQUIRED)
 find_package(genfit2 REQUIRED)
 
-if(DEFINED ${BOOST_ROOT})
-  set(Boost_NO_SYSTEM_PATHS TRUE)
-  set(Boost_NO_BOOST_CMAKE TRUE)
-endif(DEFINED ${BOOST_ROOT})
-# set(Boost_DEBUG TRUE)
-if(DEFINED ${BOOST_ROOT})
-  set(BOOST_ROOT $ENV{BOOST_ROOT})
-endif(DEFINED ${BOOST_ROOT})
 if(DEFINED $ENV{GSL_ROOT})
   set(GSL_DIR $ENV{GSL_ROOT})
 endif(DEFINED $ENV{GSL_ROOT})
-
-find_package(Boost 1.70 REQUIRED)
 
 # set a variable which should be used in all CMakeLists.txt Defines all basic
 # include directories from fairbase

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -339,11 +339,10 @@ class ShipDigiReco:
     frac, tmax = self.fracMCsame(track_ids)
     self.fitTrack2MC.push_back(tmax)
     # Save hits indexes of the the fitted tracks
-    aTracklet = ROOT.Tracklet()
-    aTracklet.setType(1)
-    listOfHits = aTracklet.getList()
+    indices = ROOT.std.vector('unsigned int')()
     for index in listOfIndices[atrack]:
-      listOfHits.push_back(index)
+      indices.push_back(index)
+    aTracklet = ROOT.Tracklet(1, indices)
     self.fTrackletsArray.push_back(aTracklet)
   self.Tracklets.Fill()
   self.fitTracks.Fill()
@@ -371,7 +370,7 @@ class ShipDigiReco:
 
  def findVetoHitOnTrack(self,track):
    distMin = 99999.
-   vetoHitOnTrack = ROOT.vetoHitOnTrack()
+   hitID = -1
    xx  = track.getFittedState()
    rep   = ROOT.genfit.RKTrackRep(xx.getPDG())
    state = ROOT.genfit.StateOnPlane(rep)
@@ -389,9 +388,8 @@ class ShipDigiReco:
      dist = (rep.getPos(state) - vetoHitPos).Mag()
      if dist < distMin:
        distMin = dist
-       vetoHitOnTrack.SetDist(distMin)
-       vetoHitOnTrack.SetHitID(i)
-   return vetoHitOnTrack
+       hitID = i
+   return ROOT.vetoHitOnTrack(hitID, distMin)
 
  def linkVetoOnTracks(self):
    self.vetoHitOnTrackArray.clear()

--- a/shipdata/ShipHit.h
+++ b/shipdata/ShipHit.h
@@ -6,11 +6,6 @@
 #include "Rtypes.h"                     // for Double_t, Int_t, Double32_t, etc
 #include "TVector3.h"                   // for TVector3
 
-#ifndef __CINT__
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
-#endif //__CINT__
-
 /**
  * copied from FairRoot FairHit and simplified
  */
@@ -41,23 +36,11 @@ class ShipHit : public TObject
     /*** Output to screen */
     virtual void Print(const Option_t* opt ="") const {;}
 
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int version)
-    {
-        ar& boost::serialization::base_object<TObject>(*this);
-        ar& fDetectorID;
-        ar& fdigi;
-    }
-
   protected:
-#ifndef __CINT__ // for BOOST serialization
-    friend class boost::serialization::access;
-#endif  // for BOOST serialization
-
     Float_t fdigi;   ///< digitized detector hit
     Int_t   fDetectorID;     ///< Detector unique identifier
 
-    ClassDef(ShipHit,1);
+    ClassDef(ShipHit,2);
 };
 
 #endif  // SHIPDATA_SHIPHIT_H_

--- a/shipdata/TrackInfo.h
+++ b/shipdata/TrackInfo.h
@@ -6,11 +6,7 @@
 #include "Rtypes.h"                     // for Double_t, Int_t, Double32_t, etc
 #include "TVector.h"                   // for TVector
 #include "Track.h"
-
-#ifndef __CINT__
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
-#endif //__CINT__
+#include <vector>
 
 class TrackInfo : public TObject
 {
@@ -29,32 +25,19 @@ class TrackInfo : public TObject
     virtual ~TrackInfo();
 
     /** Accessors **/
-    unsigned int N(){return fDetIDs.size();}
-    unsigned int detId(Int_t n){return fDetIDs[n];}
-    float wL(Int_t n){return fWL[n];}
-    float wR(Int_t n){return fWR[n];}
+    unsigned int N() const {return fDetIDs.size();}
+    unsigned int detId(Int_t n) const {return fDetIDs[n];}
+    float wL(Int_t n) const {return fWL[n];}
+    float wR(Int_t n) const {return fWR[n];}
 
     /*** Output to screen */
     virtual void Print(const Option_t* opt ="") const {;}
 
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int version)
-    {
-        ar& boost::serialization::base_object<TObject>(*this);
-        ar& fDetIDs;
-        ar& fWL;
-        ar& fWR;
-    }
-
   protected:
-#ifndef __CINT__ // for BOOST serialization
-    friend class boost::serialization::access;
-#endif  // for BOOST serialization
-
     std::vector<unsigned int> fDetIDs;   ///< array of measurements
     std::vector<float> fWL;
     std::vector<float> fWR;
-    ClassDef(TrackInfo,1);
+    ClassDef(TrackInfo,2);
 };
 
 #endif  // SHIPDATA_TRACKINFO_H_

--- a/strawtubes/Tracklet.cxx
+++ b/strawtubes/Tracklet.cxx
@@ -1,4 +1,5 @@
 #include "Tracklet.h"
+#include "strawtubesHit.h"
 #include "strawtubesPoint.h"
 #include <unordered_map>
 #include <iostream>
@@ -7,17 +8,31 @@ using std::cout;
 using std::endl;
 
 // -----   Default constructor   -------------------------------------------
-Tracklet::Tracklet()
-
+Tracklet::Tracklet() : flag(0)
 {
- flag = 0;
 }
 
-Tracklet::Tracklet(Int_t fl, std::vector<unsigned int>  aT)
+// -----   Constructor with indices   -------------------------------------------
+Tracklet::Tracklet(Int_t fl, const std::vector<unsigned int>& indices)
+    : flag(fl), aTracklet(indices)
 {
- flag = fl;
- aTracklet = aT;
+}
 
+// -----   Constructor with hits   -------------------------------------------
+Tracklet::Tracklet(Int_t fl, const std::vector<strawtubesHit>& hits,
+                   const std::vector<strawtubesHit>& container)
+    : flag(fl)
+{
+    aTracklet.reserve(hits.size());
+    for (const auto& hit : hits) {
+        // Find index of hit in container by comparing addresses
+        for (size_t i = 0; i < container.size(); ++i) {
+            if (&container[i] == &hit) {
+                aTracklet.push_back(static_cast<unsigned int>(i));
+                break;
+            }
+        }
+    }
 }
 
 // -----   Destructor   ----------------------------------------------------

--- a/strawtubes/Tracklet.h
+++ b/strawtubes/Tracklet.h
@@ -4,12 +4,11 @@
 #include "TClonesArray.h"
 
 #include <stddef.h>
+#include <vector>
 #include "Rtypes.h"                     // for Double_t, Int_t, Double32_t, etc
 
-#ifndef __CINT__
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
-#endif  // __CINT__
+class strawtubesHit;
+
 /**
  *@author Thomas Ruf
  **
@@ -23,34 +22,29 @@ class Tracklet: public TObject
   public:
     /** Default constructor **/
     Tracklet();
-    /** Constructor with arguments **/
-    Tracklet(Int_t f, std::vector<unsigned int>  aT);
 
-/** Destructor **/
+    /** Constructor with hit indices **/
+    Tracklet(Int_t f, const std::vector<unsigned int>& indices);
+
+    /** Constructor with hits (extracts indices from container) **/
+    Tracklet(Int_t f, const std::vector<strawtubesHit>& hits, const std::vector<strawtubesHit>& container);
+
+    /** Destructor **/
     virtual ~Tracklet();
 
     std::vector<unsigned int>* getList(){return &aTracklet;}
-    Int_t getType(){return flag;}
+    const std::vector<unsigned int>& getIndices() const {return aTracklet;}
+    Int_t getType() const {return flag;}
     void setType(Int_t f){flag=f;}
     Int_t link2MCTrack(TClonesArray* strawPoints, Float_t min);   // give back MCTrack ID with max matched strawtubesHits
+
     /*** Output to screen */
     virtual void Print(const Option_t* opt ="") const {;}
 
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int version)
-    {
-        ar& boost::serialization::base_object<TObject>(*this);
-        ar& flag;
-        ar& aTracklet;
-    }
   protected:
-#ifndef __CINT__ // for BOOST serialization
-    friend class boost::serialization::access;
-#endif  // for BOOST serialization
-
     std::vector<unsigned int>  aTracklet;         ///< list of indices
     Int_t flag; // reserved for type of tracklet  ///< type of tracklet
-    ClassDef(Tracklet,1);
+    ClassDef(Tracklet,2);
 
 };
 

--- a/tests/test_rntuple_io.cxx
+++ b/tests/test_rntuple_io.cxx
@@ -29,6 +29,7 @@
 #include "TargetPoint.h"
 #include "TimeDetHit.h"
 #include "TimeDetPoint.h"
+#include "TrackInfo.h"
 #include "Tracklet.h"
 #include "UpstreamTaggerHit.h"
 #include "UpstreamTaggerPoint.h"
@@ -161,8 +162,8 @@ int main(int argc, char** argv)
 
     {
         std::vector<vetoHitOnTrack> objects;
-        objects.emplace_back();
-        objects.emplace_back();
+        objects.emplace_back(0, 99999.0f);
+        objects.emplace_back(5, 42.5f);
         total++;
         if (test_rntuple_io("vetoHitOnTrack", objects))
             passed++;
@@ -170,27 +171,25 @@ int main(int argc, char** argv)
 
     {
         std::vector<Tracklet> objects;
-        // Create first tracklet with some hit indices
-        Tracklet tracklet1;
-        tracklet1.setType(1);   // Type 1 = fitted track
-        std::vector<unsigned int>* hits1 = tracklet1.getList();
-        hits1->push_back(10);
-        hits1->push_back(15);
-        hits1->push_back(20);
-        hits1->push_back(25);
-        objects.push_back(tracklet1);
+        // Create first tracklet with some hit indices using modern constructor
+        std::vector<unsigned int> hits1 = {10, 15, 20, 25};
+        objects.emplace_back(1, hits1);   // Type 1 = fitted track
 
         // Create second tracklet with different hit indices
-        Tracklet tracklet2;
-        tracklet2.setType(1);
-        std::vector<unsigned int>* hits2 = tracklet2.getList();
-        hits2->push_back(30);
-        hits2->push_back(35);
-        hits2->push_back(40);
-        objects.push_back(tracklet2);
+        std::vector<unsigned int> hits2 = {30, 35, 40};
+        objects.emplace_back(1, hits2);
 
         total++;
         if (test_rntuple_io("Tracklet", objects))
+            passed++;
+    }
+
+    {
+        std::vector<TrackInfo> objects;
+        objects.emplace_back();
+        objects.emplace_back();
+        total++;
+        if (test_rntuple_io("TrackInfo", objects))
             passed++;
     }
 

--- a/veto/vetoHitOnTrack.h
+++ b/veto/vetoHitOnTrack.h
@@ -5,11 +5,6 @@
 #include "TObject.h"    //
 #include "TVector3.h"   // for TVector3
 
-#ifndef __CINT__
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
-#endif   //__CINT__
-
 /**
  * copied from shipdata/ShipHit.h
  */
@@ -37,23 +32,11 @@ class vetoHitOnTrack : public TObject
     /*** Output to screen */
     virtual void Print(const Option_t* opt = "") const { ; }
 
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int version)
-    {
-        ar& boost::serialization::base_object<TObject>(*this);
-        ar & fHitID;
-        ar & fDist;
-    }
-
   protected:
-#ifndef __CINT__   // for BOOST serialization
-    friend class boost::serialization::access;
-#endif   // for BOOST serialization
-
     Float_t fDist;   ///< distance to closest veto hit
     Int_t fHitID;    ///< hit ID
 
-    ClassDef(vetoHitOnTrack, 1);
+    ClassDef(vetoHitOnTrack, 2);
 };
 
 #endif   // VETO_VETOHITONTRACK_H_


### PR DESCRIPTION
Remove obsolete BOOST serialisation from Tracklet, vetoHitOnTrack, ShipHit, and TrackInfo. ROOT 6 handles serialisation natively.

Changes:
- Remove BOOST dependency from CMake
- Remove BOOST serialisation code from 4 classes
- Modernise Tracklet and vetoHitOnTrack constructors
- Add const correctness to TrackInfo accessors
- Update Python code to use new constructors
- Add TrackInfo to RNTuple I/O tests
- Bump ClassDef versions for schema evolution