### PR TITLE
refactor(build): make EGPythia6 dependency conditional on ROOT version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ it in future.
 - Enclose target in steel (316L) cylinder
 * First version of SND/SiliconTarget, this layout for this iteration consists of 120 3.5mm W planes with pairs of silicon planes placed 1mm from the surface of the tungsten. As a temporary solution, the detector is placed within the second last magnet of the muon shield. Configuration of detector in simScript is coupled to the SND_design == 2 along with the MTC.
 * Add visualization methods to SciFiMapping.py to visualize Sci-Fi in MTC, including draw_channel(), draw_channel_XY(), and draw_combined_scifi_views()
+* Support using TPythia6 provided by ROOTEGPythia6 for ROOT ≥ 6.32
 
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,21 @@ find_package2(PUBLIC FairLogger REQUIRED)
 find_package2(PUBLIC VMC REQUIRED)
 find_package(genfit2 REQUIRED)
 
+# Configure TPythia6 interface based on ROOT version
+# ROOT < 6.32: TPythia6 is built into libEG (no external dependency needed)
+# ROOT >= 6.32: TPythia6 removed from ROOT, use external EGPythia6 package
+if(ROOT_VERSION VERSION_LESS "6.32")
+  # For older ROOT versions, TPythia6 is built-in
+  message(STATUS "Using built-in TPythia6 from ROOT ${ROOT_VERSION}")
+  set(USE_EXTERNAL_TPYTHIA6 OFF)
+else()
+  # For ROOT >= 6.32, we need external EGPythia6
+  message(STATUS "ROOT ${ROOT_VERSION} requires external EGPythia6")
+  set(USE_EXTERNAL_TPYTHIA6 ON)
+  find_package(ROOTEGPythia6 REQUIRED)
+  message(STATUS "Found ROOTEGPythia6 via CMake config")
+endif()
+
 if(DEFINED $ENV{GSL_ROOT})
   set(GSL_DIR $ENV{GSL_ROOT})
 endif(DEFINED $ENV{GSL_ROOT})

--- a/gconfig/basiclibs.C
+++ b/gconfig/basiclibs.C
@@ -12,7 +12,15 @@ void basiclibs()
   gSystem->Load("libGeomPainter");
   gSystem->Load("libVMC");
   gSystem->Load("libEG");
-  gSystem->Load("libEGPythia6");
+
+  // For ROOT >= 6.32, TPythia6 is not included in ROOT and must be loaded from EGPythia6
+  // For ROOT < 6.32, TPythia6 is built into libEG
+  Int_t rootVersion = gROOT->GetVersionInt();
+  if (rootVersion >= 63200) {
+    // Load external EGPythia6 for ROOT >= 6.32
+    gSystem->Load("libEGPythia6");
+  }
+
   gSystem->Load("libPythia6");
   gSystem->Load("libPhysics");
   gSystem->Load("libNet");

--- a/python/basiclibs.py
+++ b/python/basiclibs.py
@@ -1,16 +1,11 @@
 # Macro for loading basic libraries used with both Geant3 and Geant4
-from ROOT import gSystem
-#gSystem.Load("libEventDisplay.so")
-#gSystem.Load("libRIO.so")
-#gSystem.Load("libGeom.so")
-#gSystem.Load("libGeomPainter.so")
-#gSystem.Load("libVMC.so")
-#gSystem.Load("libEG.so")
-gSystem.Load("libEGPythia6.so")
+from ROOT import gSystem, gROOT
+
+# For ROOT >= 6.32, TPythia6 is not included in ROOT and must be loaded from EGPythia6
+# For ROOT < 6.32, TPythia6 is built into libEG
+root_version = gROOT.GetVersionInt()
+if root_version >= 63200:
+    # Load external EGPythia6 for ROOT >= 6.32
+    gSystem.Load("libEGPythia6.so")
 gSystem.Load("libPythia6.so")
-#gSystem.Load("libPhysics.so")
-#gSystem.Load("libNet.so")
-#gSystem.Load("libTree.so")
-#gSystem.Load("libMinuit.so")
-#gSystem.Load("libMathMore.so")
 gSystem.Load("libpythia8.so")

--- a/shipgen/CMakeLists.txt
+++ b/shipgen/CMakeLists.txt
@@ -4,7 +4,13 @@
 
 set(INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/generators
-    ${genfit2_INCDIR} ${TPYTHIA6_INCLUDE_DIR})
+    ${genfit2_INCDIR})
+
+# Add EGPythia6 include directory only for ROOT >= 6.32
+# The CMake config provides ROOTEGPythia6_INCLUDE_DIR
+if(USE_EXTERNAL_TPYTHIA6)
+  list(APPEND INCLUDE_DIRECTORIES ${ROOTEGPythia6_INCLUDE_DIR})
+endif()
 
 set(SYSTEM_INCLUDE_DIRECTORIES
     ${SYSTEM_INCLUDE_DIRECTORIES} ${PYTHIA8_INCLUDE_DIR}
@@ -45,6 +51,12 @@ set(LINK_DIRECTORIES
     ${ROOT_LIBRARY_DIR} ${FAIRROOT_LIBRARY_DIR} ${PYTHIA8_LIBRARY_DIR}
     ${EVTGEN_LIBRARY_DIR} ${genfit2_LIBDIR})
 
+# Add EGPythia6 library directory only for ROOT >= 6.32
+# The CMake config provides ROOTEGPythia6_LIB_DIR
+if(USE_EXTERNAL_TPYTHIA6)
+  list(APPEND LINK_DIRECTORIES ${ROOTEGPythia6_LIB_DIR})
+endif()
+
 link_directories(${LINK_DIRECTORIES})
 
 set(SRCS
@@ -68,5 +80,11 @@ set(LIBRARY_NAME ShipGen)
 
 set(DEPENDENCIES Base ShipData veto EvtGen EvtGenExternal
                  FairLogger::FairLogger)
+
+# Add EGPythia6 dependency only for ROOT >= 6.32
+# Use the ROOT::EGPythia6 target provided by the CMake config
+if(USE_EXTERNAL_TPYTHIA6)
+  list(APPEND DEPENDENCIES ROOT::EGPythia6)
+endif()
 
 generate_library()


### PR DESCRIPTION
For ROOT < 6.32, TPythia6 is built into libEG (no external dependency). For ROOT >= 6.32, TPythia6 was removed and requires external EGPythia6.

Changes:
- CMake detects ROOT version and conditionally uses find_package(ROOTEGPythia6)
- Uses modern ROOT::EGPythia6 CMake target from ROOTEGPythia6Config.cmake
- Runtime library loading adapted for both ROOT versions in Python and C++
- Simplified implementation by removing unused environment variable fallbacks

This reduces build complexity for older ROOT versions whilst maintaining compatibility with modern ROOT releases.