### PR TITLE
Nuhist cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ it in future.
   - Update Python code in shipDigiReco.py to use modern constructors
   - Bump ClassDef versions to 2 for schema evolution
   - Add TrackInfo to RNTuple I/O test suite
+* Fixed the weird cut on P in the script that produces P and P-Pt histograms for neutrinos
 
 ### Removed
 

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -142,8 +142,8 @@ for n in range(nEvents):
          if par.id()<0: idhnu+=1000
          pt2=par.px()**2+par.py()**2
          ptot=ROOT.TMath.Sqrt(pt2+par.pz()**2)
-         l10ptot=min(max(ROOT.TMath.Log10(ptot),-0.3),1.69999)
-         l10pt=min(max(ROOT.TMath.Log10(ROOT.TMath.Sqrt(pt2)),-2.),0.4999)
+         l10ptot= max(ROOT.TMath.Log10(ptot),-0.3)
+         l10pt= max(ROOT.TMath.Log10(ROOT.TMath.Sqrt(pt2)),-2.)
          h[str(idhnu)].Fill(ptot,wspill)
          h[str(idhnu+100)].Fill(l10ptot,l10pt,wspill)
          h[str(idhnu+200)].Fill(l10ptot,l10pt,wspill)


### PR DESCRIPTION
Fixed the 50 GeV cut for the production of P-Pt histograms of neutrino. I would investigate more what exactly this script does and what was the reason for that before using it. I don't think this is an urgent thing: it does not affect the production at all.