### PR TITLE
fix(ci): ensure build failures propagate in pipeline

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Build
         run: |
+          set -o pipefail
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           aliBuild build FairShip --always-prefer-system --config-dir $SHIPDIST --defaults release --jobs 4 --debug 2>&1 | tee build.log | python3 FairShip/.github/scripts/annotate_build.py
 


### PR DESCRIPTION
Add set -o pipefail to Build step to ensure aliBuild failures cause the CI step to fail. Without this, the pipeline exit code was determined by the last command (python3), masking build errors.