### PR TITLE
fix(ci): fetch existing notes before adding new ones

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -158,6 +158,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Fetch existing notes first to avoid conflicts
+          echo "Fetching existing notes..."
+          git fetch origin 'refs/notes/ci/physics-metrics/*:refs/notes/ci/physics-metrics/*' || echo "No existing notes found"
+
           # Store metrics for each configuration
           for dir in metrics/metrics-*; do
             if [ -d "$dir" ]; then


### PR DESCRIPTION
The store-metrics job was failing because it tried to push notes without first fetching the existing notes refs from the remote. This caused push failures as the local notes tree was out of sync.

Now fetch all existing notes refs before adding new ones to ensure the push is a fast-forward update.