### PR TITLE
Use nproc for aliBuild parallel jobs in build step

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           set -o pipefail
           source /cvmfs/ship.cern.ch/$version/setUp.sh
-          aliBuild build FairShip --always-prefer-system --config-dir $SHIPDIST --defaults release --jobs 4 --debug 2>&1 | tee build.log | python3 FairShip/.github/scripts/annotate_build.py
+          aliBuild build FairShip --always-prefer-system --config-dir $SHIPDIST --defaults release --jobs $(nproc) --debug 2>&1 | tee build.log | python3 FairShip/.github/scripts/annotate_build.py
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Use $(nproc) instead of hardcoded 4 to scale to different CI hosts