### PR TITLE
G4 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ it in future.
 
 ### Fixed
 
+* Changes to g4config.in to ensure it works with newer versions of GEANT4
 * refactor(splitcal): Replace splitcalPoint* constructor with vector-based constructor
 * fix(splitcal): Move energy weights from Hit to Cluster, eliminating internal vectors
 + Fix FixedTargetGenerator to ensure it works with newer versions of Pythia

--- a/gconfig/g4config.in
+++ b/gconfig/g4config.in
@@ -4,7 +4,6 @@
 
 /mcVerbose/all 0
 /mcTracking/loopVerbose 0    # suggested by Ivana Hrivnacova to switch off *** Particle reached max step number ....
-/mcPhysics/g4NeutronHPVerbose 0 #   - suppress the warnings about missing neutron data
 /mcPhysics/g4HadronicProcessStoreVerbose 0
 
 /mcVerbose/all 0
@@ -12,6 +11,8 @@
 # switch on other sources of di muon
 /physics_lists/em/PositronToMuons true
 /physics_lists/em/GammaToMuons true
+# turn off UseGeneralProcess to access GammaToMuons directly when cross-sections need to be changed
+/process/em/UseGeneralProcess false
 
 # drives me crazy how to stop this tons of output !!!
 /process/em/verbose 0

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -267,6 +267,7 @@ if args.charm or args.beauty:
 primGen.AddGenerator(P8gen)
 #
 run.SetGenerator(primGen)
+
 # -----Initialize simulation run------------------------------------
 run.Init()
 
@@ -286,8 +287,8 @@ if args.boostFactor > 1:
     gProcessTable = ROOT.G4ProcessTable.GetProcessTable()
     procAnnihil = gProcessTable.FindProcess(ROOT.G4String('AnnihiToMuPair'), ROOT.G4String('e+'))
     procGMuPair = gProcessTable.FindProcess(ROOT.G4String('GammaToMuPair'), ROOT.G4String('gamma'))
-    procGMuPair.SetCrossSecFactor(args.boostFactor)
     procAnnihil.SetCrossSecFactor(args.boostFactor)
+    procGMuPair.SetCrossSecFactor(args.boostFactor)
 
 # -----Start run----------------------------------------------------
 run.Run(args.nev)


### PR DESCRIPTION
Fixes to account for use of newer GEANT4 version
- If the `GammaToMuPair` process cannot be found in `gProcessTable`, it is added separately as a discrete process. Any feedback on this appreciated.
- `/mcPhysics/g4NeutronHPVerbose 0` is commented out

Update: instead of the above, `process/em/UseGeneralProcess false` is used to access `GammaToMuPair` in `gProcessTable` directly.