### PR TITLE
feat(macro): add RNTuple conversion and inspection utilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,9 @@ repos:
   - id: ruff-check
     types_or: [python, pyi, jupyter]
     args: [--fix, --show-fixes]
-    files: ^(\.github/scripts/.*\.py|macro/makeGenieEvents\.py|python/genie_interface\.py|python/SciFiMapping\.py|python/BaseDetector\.py|python/detectors/.*\.py|python/experimental/.*\.py)$
+    files: ^(\.github/scripts/.*\.py|macro/makeGenieEvents\.py|macro/convertTreeToRNTuple\.py|macro/inspect_tree_branches\.py|python/genie_interface\.py|python/SciFiMapping\.py|python/BaseDetector\.py|python/detectors/.*\.py|python/experimental/.*\.py)$
   - id: ruff-format
-    files: ^(\.github/scripts/.*\.py|python/experimental/.*\.py|python/geometry_config\.py|macro/makeGenieEvents\.py|python/genie_interface\.py|python/SciFiMapping\.py|python/BaseDetector\.py|python/detectors/.*\.py)$
+    files: ^(\.github/scripts/.*\.py|python/experimental/.*\.py|python/geometry_config\.py|macro/makeGenieEvents\.py|macro/convertTreeToRNTuple\.py|macro/inspect_tree_branches\.py|python/genie_interface\.py|python/SciFiMapping\.py|python/BaseDetector\.py|python/detectors/.*\.py)$
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v21.1.7
   hooks:
@@ -52,7 +52,7 @@ repos:
     - id: mypy
       name: mypy (type-check)
       types_or: [python, pyi]
-      files: ^(\.github/scripts/.*\.py|python/experimental/|python/geometry_config\.py|macro/makeGenieEvents\.py|python/genie_interface\.py|python/SciFiMapping\.py|python/BaseDetector\.py|python/detectors/.*\.py)$
+      files: ^(\.github/scripts/.*\.py|python/experimental/|python/geometry_config\.py|macro/makeGenieEvents\.py|macro/convertTreeToRNTuple\.py|macro/inspect_tree_branches\.py|python/genie_interface\.py|python/SciFiMapping\.py|python/BaseDetector\.py|python/detectors/.*\.py)$
       args:
         - --python-version=3.9
         - --ignore-missing-imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ it in future.
 * Add EventId and TrackID for MCTrack and HAPoint #944
 * **Data classes now support ROOT RNtuple I/O**
   All FairShip data classes (Hits, Points, Tracks, Particles) have been refactored for ROOT RNtuple compatibility. Changes include: public copy constructors, const-correct getter methods, replacement of TVector3 storage with std::array, and complete refactoring of ShipParticle to remove TParticle inheritance. Comprehensive RNtuple I/O tests verify all 20 data classes can be written to and read from RNtuple format.
+* Add RNtuple conversion and inspection utilities (`macro/convertTreeToRNTuple.py`, `macro/inspect_tree_branches.py`) for testing and validation. Note that FairRoot I/O currently uses TClonesArray which is not supported by RNtuple.
 + Add option for an additional sensitive plane around the target in run_fixedTarget
 * Add CI job to run fixed target simulation (run_fixedTarget.py)
 * feat(python): Add experimental script to compare histograms

--- a/macro/convertTreeToRNTuple.py
+++ b/macro/convertTreeToRNTuple.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+"""
+Convert TTree to RNTuple using ROOT's RNTupleImporter.
+
+This script imports TTrees from ROOT files and converts them to RNTuple format,
+which provides better compression, faster I/O, and modern columnar storage.
+
+Usage:
+    python convertTreeToRNTuple.py -f input.root -t cbmsim -o output.root -n fairdata
+    python convertTreeToRNTuple.py -f input.root  # Uses default tree/ntuple names
+
+Note:
+    RNTuple has some limitations compared to TTree:
+    - TObjArray and other legacy ROOT containers cannot be stored natively
+    - Use std::vector instead of TObjArray for RNTuple compatibility
+    - TClonesArray is also not supported; migrate to std::vector
+"""
+
+import argparse
+import sys
+
+import ROOT
+
+
+def convert_tree_to_rntuple(input_file, tree_name, output_file, ntuple_name):
+    """
+    Convert a TTree to RNTuple format.
+
+    Args:
+        input_file: Path to input ROOT file containing TTree
+        tree_name: Name of the TTree to convert
+        output_file: Path to output ROOT file for RNTuple
+        ntuple_name: Name for the output RNTuple
+    """
+    print("Converting TTree → RNTuple")
+    print(f"  Input:  {input_file}:{tree_name}")
+    print(f"  Output: {output_file}:{ntuple_name}")
+    print()
+
+    with ROOT.TFile.Open(input_file, "READ") as input_root_file:
+        tree = input_root_file.Get(tree_name)
+        if not tree:
+            print(f"ERROR: Tree '{tree_name}' not found in {input_file}")
+            print("Available trees:")
+            for key in input_root_file.GetListOfKeys():
+                obj = key.ReadObj()
+                if obj.InheritsFrom("TTree"):
+                    print(f"  - {key.GetName()}")
+            return False
+
+        num_entries = tree.GetEntries()
+        print(f"Found TTree '{tree_name}' with {num_entries} entries")
+        print()
+
+    # Convert using RNTupleImporter
+    try:
+        importer = ROOT.ROOT.Experimental.RNTupleImporter.Create(
+            input_file, tree_name, output_file
+        )
+
+        if not importer:
+            print("ERROR: Failed to create RNTupleImporter")
+            return False
+
+        # Set the RNTuple name (defaults to tree name if not set)
+        importer.SetNTupleName(ntuple_name)
+
+        # Optional: Configure import options
+        # importer.SetMaxUnzippedPageSize(...)  # Adjust page size if needed
+        # importer.SetCompressionSettings(...)  # Adjust compression (default: zstd)
+
+        print("Starting conversion...")
+        importer.Import()  # Import() throws exception on failure
+
+        print("✓ Conversion complete!")
+        print()
+
+        # Verify output
+        with ROOT.TFile.Open(output_file, "READ"):
+            reader = ROOT.ROOT.RNTupleReader.Open(ntuple_name, output_file)
+            num_rntuple_entries = reader.GetNEntries()
+
+            print("Verification:")
+            print(f"  TTree entries:   {num_entries}")
+            print(f"  RNTuple entries: {num_rntuple_entries}")
+
+            if num_entries == num_rntuple_entries:
+                print("  ✓ Entry count matches")
+            else:
+                print("  ✗ WARNING: Entry count mismatch!")
+
+        return True
+
+    except Exception as e:
+        print(f"ERROR: Exception during conversion: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def main():
+    """Parse arguments and run the TTree to RNTuple conversion."""
+    parser = argparse.ArgumentParser(
+        description="Convert TTree to RNTuple using ROOT's RNTupleImporter",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Convert cbmsim tree to fairdata RNTuple
+  %(prog)s -f ship.conical.Pythia8-TGeant4.root -t cbmsim -o output.root -n fairdata
+
+  # Use defaults (cbmsim → fairdata)
+  %(prog)s -f ship.conical.Pythia8-TGeant4.root
+
+  # Convert custom tree
+  %(prog)s -f mydata.root -t mytree -o converted.root -n myntuple
+        """,
+    )
+
+    parser.add_argument(
+        "-f", "--input-file", required=True, help="Input ROOT file containing TTree"
+    )
+    parser.add_argument(
+        "-t",
+        "--tree-name",
+        default="cbmsim",
+        help="Name of TTree to convert (default: cbmsim)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        default=None,
+        help="Output ROOT file for RNTuple (default: <input>_rntuple.root)",
+    )
+    parser.add_argument(
+        "-n",
+        "--ntuple-name",
+        default="fairdata",
+        help="Name for output RNTuple (default: fairdata)",
+    )
+
+    args = parser.parse_args()
+
+    if args.output_file is None:
+        if args.input_file.endswith(".root"):
+            args.output_file = args.input_file.replace(".root", "_rntuple.root")
+        else:
+            args.output_file = args.input_file + "_rntuple.root"
+
+    success = convert_tree_to_rntuple(
+        args.input_file, args.tree_name, args.output_file, args.ntuple_name
+    )
+
+    if success:
+        print()
+        print("Success! RNTuple file created:")
+        print(f"  {args.output_file}")
+        return 0
+    else:
+        print()
+        print("Conversion failed!")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/macro/inspect_tree_branches.py
+++ b/macro/inspect_tree_branches.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+"""
+Inspect TTree branches to find which ones use TObjArray or other unsupported types.
+
+This helps identify branches that would prevent RNTuple conversion.
+"""
+
+import argparse
+import sys
+
+import ROOT
+
+
+def inspect_tree_branches(input_file, tree_name):
+    """
+    Inspect all branches in a TTree and report their types.
+
+    Args:
+        input_file: Path to input ROOT file
+        tree_name: Name of the TTree to inspect
+    """
+    print(f"Inspecting TTree: {input_file}:{tree_name}")
+    print("=" * 80)
+    print()
+
+    with ROOT.TFile.Open(input_file, "READ") as f:
+        tree = f.Get(tree_name)
+        if not tree:
+            print(f"ERROR: Tree '{tree_name}' not found")
+            return False
+
+        branches = tree.GetListOfBranches()
+        print(f"Found {branches.GetEntries()} branches\n")
+
+        problematic_branches = []
+
+        for i in range(branches.GetEntries()):
+            branch = branches.At(i)
+            branch_name = branch.GetName()
+            class_name = branch.GetClassName()
+
+            is_problematic = False
+            reason = ""
+
+            if "TObjArray" in class_name:
+                is_problematic = True
+                reason = "TObjArray not supported in RNTuple"
+            elif "TClonesArray" in class_name:
+                is_problematic = True
+                reason = "TClonesArray not supported in RNTuple"
+            elif class_name and "TObject" in class_name and "std::" not in class_name:
+                # Other legacy ROOT types might be problematic
+                is_problematic = True
+                reason = "Legacy ROOT container"
+
+            status = "⚠️  PROBLEM" if is_problematic else "✓  OK"
+            print(f"{status:12} {branch_name:40} {class_name}")
+
+            if is_problematic:
+                problematic_branches.append((branch_name, class_name, reason))
+
+        print()
+        print("=" * 80)
+
+        if problematic_branches:
+            print(f"\n❌ Found {len(problematic_branches)} problematic branch(es):\n")
+            for name, cls, reason in problematic_branches:
+                print(f"  • {name}")
+                print(f"    Type: {cls}")
+                print(f"    Issue: {reason}")
+                print()
+
+            print("These branches prevent RNTuple conversion.")
+            print("Consider migrating to std::vector or other supported types.")
+            return False
+        else:
+            print("\n✓ All branches appear to be RNTuple-compatible!")
+            return True
+
+
+def main():
+    """Parse arguments and run the TTree branch inspection."""
+    parser = argparse.ArgumentParser(
+        description="Inspect TTree branches for RNTuple compatibility"
+    )
+    parser.add_argument("-f", "--input-file", required=True, help="Input ROOT file")
+    parser.add_argument(
+        "-t",
+        "--tree-name",
+        default="cbmsim",
+        help="Name of TTree to inspect (default: cbmsim)",
+    )
+
+    args = parser.parse_args()
+
+    success = inspect_tree_branches(args.input_file, args.tree_name)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add two Python utilities for working with ROOT's RNTuple format:

- convertTreeToRNTuple.py: Converts TTree to RNTuple using RNTupleImporter with proper error handling and verification
- inspect_tree_branches.py: Diagnoses TTree branches for RNTuple compatibility, identifying TClonesArray and other unsupported types

Uses correct PyROOT namespacing (ROOT.ROOT.Experimental) and modern Python practices (context managers for file handling).

~~Note: Current FairShip data uses TClonesArray which is not supported by RNTuple. Migration to std::vector required for compatibility.~~