### PR TITLE
fix: use GetLayerType instead of GetStationType in MTCDetector

### DIFF
--- a/python/detectors/MTCDetector.py
+++ b/python/detectors/MTCDetector.py
@@ -45,7 +45,8 @@ class MTCDetector(BaseDetector):
         norm = {}
         for k, mc_point in enumerate(self.intree.MTCDetPoint):
             det_id = mc_point.GetDetectorID()
-            station_type = mc_point.GetStationType()  # 0 for +5 degrees, 1 for -5 degrees, 2 for scint plane, extraction: int(fDetectorID / 100000) % 10
+            # 0: +5 deg, 1: -5 deg, 2: scint plane
+            station_type = mc_point.GetLayerType()
             energy_loss = mc_point.GetEnergyLoss()
 
             if station_type == 0:


### PR DESCRIPTION
MTCDetPoint class provides GetLayerType() method, not GetStationType(). This fixes the CI failure where the digitisation step was calling a non-existent method.

Fixes #990