### PR TITLE
Suggestion: saving hits on post-target plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ it in future.
 
 ### Fixed
 
++ Update run_fixedTarget to save tracks for hits in post-target sensitive plane
 * Set correct trackIDs for exitHadronAbsorber class
 
 ### Removed

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -344,7 +344,7 @@ sTree = t.CloneTree(0)
 nEvents = 0
 for n in range(t.GetEntries()):
     rc = t.GetEvent(n)
-    if (len(t.PlaneHAPoint) > 0) or (args.AddCylindricalSensPlane and len(t.PlaneTPoint) > 0):
+    if (len(t.PlaneHAPoint) > 0) or (args.AddCylindricalSensPlane and len(t.PlaneTPoint) > 0) or (args.AddPostTargetSensPlane and len(t.PlanePostTPoint) > 0):
         rc = sTree.Fill()
         nEvents += 1
 fout.cd()


### PR DESCRIPTION
Saving tracks reaching post-target sensitive plane (currently, if a post-target sensitive plane is added, tracks are only saved if they also reach the post-hadron absorber sensitive plane). 

This would not be used for the main production, but could be useful for side studies (?)