### PR TITLE
fix(sim): update SetPhiRandom call to SetPhiRandomize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ it in future.
 
 ### Fixed
 
+* Fix function call in run_simScript.py to use SetPhiRandomize instead of deprecated SetPhiRandom
 + Update run_fixedTarget to save tracks for hits in post-target sensitive plane
 * Set correct trackIDs for exitHadronAbsorber class
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -479,7 +479,7 @@ if options.muonback:
  MuonBackgen.Init(inputFile, options.firstEvent)
  MuonBackgen.SetPaintRadius(options.PaintBeam*u.cm)
  MuonBackgen.SetSmearBeam(options.SmearBeam*u.cm)
- MuonBackgen.SetPhiRandom(options.phiRandom)
+ MuonBackgen.SetPhiRandomize(options.phiRandom)
  if DownScaleDiMuon:
     testf = ROOT.TFile.Open(inputFile)
     if not testf.FileHeader.GetTitle().find('diMu100.0')<0:


### PR DESCRIPTION
The function was renamed from SetPhiRandom to SetPhiRandomize in MuonBackGenerator, but run_simScript.py was not updated accordingly.

Fixes #1006

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
