### PR TITLE
Remove unused functions and dead code from rootUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ it in future.
 
 * Remove unused ShipStyle, which seems copy-pasted from LHCb
 * Remove old scripts run_simEcal.py and flux_map.py
+* Remove unused functions and dead code from rootUtils: `printout`, `setAttributes`, `container_sizes`, `stripOffBranches`, `findMaximumAndMinimum`, `makeIntegralDistrib`, `PyListOfLeaves`
+* Remove unused rootUtils imports from `dumpEvent.py` and `extractMuonsAndUpdateWeight.py`
 
 ## 25.12 - 2025-12-22
 

--- a/macro/dumpEvent.py
+++ b/macro/dumpEvent.py
@@ -3,7 +3,6 @@
 
 # example for dumping an MC event
 import ROOT,os,sys
-import rootUtils as ut
 import shipunit as u
 import ShipGeoConfig
 ship_geo = ShipGeoConfig.Config().loadpy("$FAIRSHIP/geometry/geometry_config.py")

--- a/muonShieldOptimization/extractMuonsAndUpdateWeight.py
+++ b/muonShieldOptimization/extractMuonsAndUpdateWeight.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
 import os,ROOT
-import rootUtils as ut
 path =  '/eos/experiment/ship/data/Mbias/background-prod-2018/'
 
 # functions, should extract events with muons, update weight based on process/decay and PoT

--- a/python/rootUtils.py
+++ b/python/rootUtils.py
@@ -1,15 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
-#---Enable Tab completion-----------------------------------------
-try:
-  import rlcompleter, readline
-  readline.parse_and_bind( 'tab: complete' )
-  readline.parse_and_bind( 'set show-all-if-ambiguous On' )
-except:
-  pass
-
-
 from ROOT import TFile,gROOT,TH3D,TH2D,TH1D,TCanvas,TProfile,gSystem
 import os,sys
 
@@ -89,98 +80,6 @@ def errorSummary():
  if len(l) > 0: "Summary of recorded incidents:"
  for e in l:
     print(e,':',l[e])
-def printout(atc,name,Work):
-  atc.Update()
-  for x in ['.gif','.eps','.jpg'] :
-    temp = name+x
-    atc.Print(temp)
-    if x!='.jpg':
-      os.system('cp '+temp+' '+Work)
-
-def setAttributes(pyl,leaves,printout=False):
-  names = {}
-  if printout: print('entries',leaves.GetEntries())
-  for i in range(0,leaves.GetEntries() ) :
-    leaf = leaves.At(i)
-    name = leaf.GetName()
-    if printout: print(name)
-    names[name]=i
-    pyl.__setattr__(name,leaf)
-  return names
-# read back
-class PyListOfLeaves(dict) :
-    pass
-
-import operator
-def container_sizes(sTree,perEvent=False):
- counter = {}
- print("name      ZipBytes[MB]    TotBytes[MB]    TotalSize[MB]")
- counter['total']=[0,0,0]
- for l in sTree.GetListOfLeaves():
-  b = l.GetBranch()
-  nm = b.GetName()
-  print("%30s :%8.3F   %8.3F    %8.3F "%(nm,b.GetZipBytes()/1.E6,b.GetTotBytes()/1.E6,b.GetTotalSize()/1.E6))
-  bnm = nm.split('.')[0]
-  if bnm not in counter: counter[bnm]=[0,0,0]
-  counter[bnm][0]+=b.GetZipBytes()/1.E6
-  counter[bnm][1]+=b.GetTotBytes()/1.E6
-  counter[bnm][2]+=b.GetTotalSize()/1.E6
-  counter['total'][0]+=b.GetZipBytes()/1.E6
-  counter['total'][1]+=b.GetTotBytes()/1.E6
-  counter['total'][2]+=b.GetTotalSize()/1.E6
- print("---> SUMMARY <---------------")
- N = sTree.GetEntries()/1000.
- if perEvent:
-  print("                     name     ZipBytes[kB]/ev  TotBytes[kB]/ev  TotalSize[kB]/ev")
- else:
-  print("                     name     ZipBytes[MB]  TotBytes[MB]  TotalSize[MB]")
- sorted_c = sorted(counter.items(), key=operator.itemgetter(1))
- sorted_c.reverse()
- for i in range(len(sorted_c)):
-  x = sorted_c[i][0]
-  if perEvent:
-   print("%30s :%8.3F      %8.3F       %8.3F"%(x,counter[x][0]/N,counter[x][1]/N,counter[x][2]/N))
-  else:
-   print("%30s :%8.3F   %8.3F    %8.3F"%(x,counter[x][0],counter[x][1],counter[x][2]))
-
-def stripOffBranches(fout):
-    f = TFile(fout)
-    sTree = f.Get("cbmsim")
-    nEvents = sTree.GetEntries()
-    strip = False
-    oldTargetClass = False
-    if sTree.GetBranch("SmearedHits"):
-         sTree.SetBranchStatus("SmearedHits",0)
-         strip = True
-    if sTree.GetBranch("TargetPoint"):
-         if sTree.GetLeaf("cbmroot.Target.TargetPoint.fEmTop"): oldTargetClass = True # old class
-         else:
-           for x in sTree.GetListOfLeaves():
-              if not x.GetName().find("TargetPoint")<0:
-               b = x.GetBranch().GetName()
-               sTree.SetBranchStatus(b,0)
-         strip = True
-    if not strip: return
-    sFile = fout.replace("_rec.root","_recs.root")
-    recf = TFile(sFile,"recreate")
-    if not oldTargetClass: newTree = sTree.CloneTree(-1,'fast')
-    else:
-     newTree = sTree.CloneTree(0)
-     for n in range(nEvents):
-      sTree.GetEntry(n)
-      if oldTargetClass: sTree.TargetPoint.Clear()
-      rc = newTree.Fill()
-      sTree.FitTracks.Delete() # stupid ROOT or whoever, otherwise huge memory leak, does not help
-    sTree.Clear()
-    newTree.AutoSave()
-    f.Close()
-    recf.Close()
-    # should do some sanity checks before deleting old file
-    f = TFile(sFile)
-    sTree = f.Get("cbmsim")
-    if nEvents == sTree.GetEntries(): print("looks ok, could be deleted",os.path.abspath('.'))
-    else:  print("stripping failed, keep old file",os.path.abspath('.'))
-    # os.system('mv '+sFile +' '+fout)
 def checkFileExists(x):
     if x[0:4] == "/eos": f=gSystem.Getenv("EOSSHIP")+x
     else: f=x
@@ -192,22 +91,3 @@ def checkFileExists(x):
      return 'tree'
     else:
      return 'ntuple'
-def findMaximumAndMinimum(histo):
- amin,amax = 1E30, -130
- nmin,nmax = 0, 0
- for n in range(1,histo.GetNbinsX()+1):
-  c =  histo.GetBinContent(n)
-  if c>amax:
-    amax = c
-    nmax = n
-  if c<amin:
-    amin = c
-    nmin = n
- return amin,amax,nmin,nmax
-def makeIntegralDistrib(h,key):
- name = 'I-'+key
- h[name]=h[key].Clone(name)
- h[name].SetTitle('Integral > '+h[key].GetTitle())
- for n in range(1,h[key].GetNbinsX()+1):
-   if n==1: h[name].SetBinContent(1,h[key].GetSumOfWeights())
-   else: h[name].SetBinContent(n,h[name].GetBinContent(n-1)-h[key].GetBinContent(n-1))


### PR DESCRIPTION
Remove 6 unused functions (printout, setAttributes, container_sizes, stripOffBranches, findMaximumAndMinimum, makeIntegralDistrib), the dead PyListOfLeaves class, module-level readline side effect, and unused rootUtils imports from dumpEvent.py and extractMuonsAndUpdateWeight.py.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
