### PR TITLE
Replace fragile sys.modules error logging in rootUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ it in future.
 
 ### Fixed
 
+* Fix `errorSummary` not printing its header (bare string expression instead of `print`)
+* Fix `reportError`/`errorSummary` using fragile `sys.modules['__main__'].log` pattern; use module-level counter instead
 * Fix file-filtering logic to support STL branches
 * Update MuonBackGenerator to support both TClonesArray and std::vector input formats for MCTrack and vetoPoint branches
 * Fix function call in run_simScript.py to use SetPhiRandomize instead of deprecated SetPhiRandom

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -100,7 +100,6 @@ for x in ROOT.gGeoManager.GetListOfVolumes():
 import shipVeto
 veto = shipVeto.Task(sTree)
 vetoDets={}
-log={}
 h = {}
 ut.bookHist(h,'delPOverP','delP / P',400,0.,200.,100,-0.5,0.5)
 ut.bookHist(h,'pullPOverPx','delPx / sigma',400,0.,200.,100,-3.,3.)

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -83,7 +83,6 @@ from ShipGeoConfig import load_from_root_file
 ShipGeo = load_from_root_file(fgeo, 'ShipGeo')
 
 h={}
-log={}
 if withHists:
  ut.bookHist(h,'distu','distance to wire',100,0.,5.)
  ut.bookHist(h,'distv','distance to wire',100,0.,5.)
@@ -117,7 +116,6 @@ global_variables.ShipGeo = ShipGeo
 global_variables.modules = modules
 global_variables.withNoStrawSmearing = options.withNoStrawSmearing
 global_variables.h = h
-global_variables.log = log
 global_variables.iEvent = 0
 
 # import reco tasks

--- a/python/rootUtils.py
+++ b/python/rootUtils.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
 from ROOT import TFile,gROOT,TH3D,TH2D,TH1D,TCanvas,TProfile,gSystem
-import os,sys
+import os
+from collections import Counter
+
+_error_log = Counter()
 
 def readHists(h,fname,wanted=[]):
   if fname[0:4] == "/eos":
@@ -72,14 +75,12 @@ def bookCanvas(h,key=None,title='',nx=900,ny=600,cx=1,cy=1):
     h[key]=TCanvas(key,title,nx,ny)
     h[key].Divide(cx,cy)
 def reportError(s):
- l = sys.modules['__main__'].log
- if s not in l: l[s]=0
- l[s]+=1
+ _error_log[s] += 1
 def errorSummary():
- l = sys.modules['__main__'].log
- if len(l) > 0: "Summary of recorded incidents:"
- for e in l:
-    print(e,':',l[e])
+ if _error_log:
+    print("Summary of recorded incidents:")
+ for e in _error_log:
+    print(e, ':', _error_log[e])
 def checkFileExists(x):
     if x[0:4] == "/eos": f=gSystem.Getenv("EOSSHIP")+x
     else: f=x


### PR DESCRIPTION
reportError/errorSummary accessed sys.modules['__main__'].log, coupling them to caller globals. Replace with a module-level collections.Counter. Also fix errorSummary's header which was a bare string expression (never printed). Remove now-unnecessary log={} from ShipReco and ShipAna.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
