### PR TITLE
feat(sim): add --dump-g4-config option to dump Geant4 VMC configuration

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
-          python $FAIRSHIP/macro/run_simScript.py --test --debug 2 --${{ matrix.vessel_option }} --SND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml --EvtGenDecayer --tag ci-test
+          python $FAIRSHIP/macro/run_simScript.py --test --debug 2 --${{ matrix.vessel_option }} --SND --SND_design=${{ matrix.SND_option }} --shieldName ${{ matrix.muon_shield }} --target-yaml=$FAIRSHIP/geometry/target_config_${{ matrix.target }}.yaml --EvtGenDecayer --dump-g4-config --tag ci-test
 
       - name: Overlap check
         run: |

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -537,7 +537,6 @@ if options.dump_g4_config:
     gMC.ProcessGeantCommand("/mcVerbose/composedPhysicsList 2")
     gMC.ProcessGeantCommand("/mcVerbose/regionsManager 3")
     print(f"Stack type: {type(fStack).__name__}")
-    print(f"Stack StoreSecondaries: {fStack.GetStoreSecondaries()}")
 
 # -----J/psi external decayer configuration handled in g4config.in------------------------------------
 # VMC command /mcPhysics/setExtDecayerSelection J/psi forces external decayer usage

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -143,6 +143,7 @@ parser.add_argument("--MesonMother", dest="MM", help="Choose DP production meson
 parser.add_argument("--debug", help="Control FairLogger verbosity: 0=info (default), 1=+debug, 2=+debug1, 3=+debug2", default=0, type=int, choices=range(0,4))
 parser.add_argument("--print-fields", help="Print VMC fields and weights information", action="store_true")
 parser.add_argument("--check-overlaps", help="Perform geometry overlap checking", action="store_true")
+parser.add_argument("--dump-g4-config", help="Dump Geant4 VMC configuration after initialisation", action="store_true")
 parser.add_argument("--field_map", default=None, help="Specify spectrometer field map.")
 parser.add_argument("--z-offset", dest="z_offset", help="z-offset for the FixedTargetGenerator [mm]", default=-84., type=float)
 parser.add_argument(
@@ -531,6 +532,12 @@ if options.dryrun: # Early stop after setting up Pythia 8
  sys.exit(0)
 gMC = ROOT.TVirtualMC.GetMC()
 fStack = gMC.GetStack()
+
+if options.dump_g4_config:
+    gMC.ProcessGeantCommand("/mcVerbose/composedPhysicsList 2")
+    gMC.ProcessGeantCommand("/mcVerbose/regionsManager 3")
+    print(f"Stack type: {type(fStack).__name__}")
+    print(f"Stack StoreSecondaries: {fStack.GetStoreSecondaries()}")
 
 # -----J/psi external decayer configuration handled in g4config.in------------------------------------
 # VMC command /mcPhysics/setExtDecayerSelection J/psi forces external decayer usage

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -534,8 +534,7 @@ gMC = ROOT.TVirtualMC.GetMC()
 fStack = gMC.GetStack()
 
 if options.dump_g4_config:
-    gMC.ProcessGeantCommand("/mcVerbose/composedPhysicsList 2")
-    gMC.ProcessGeantCommand("/mcVerbose/regionsManager 3")
+    gMC.ProcessGeantCommand("/run/dumpCouples")
     print(f"Stack type: {type(fStack).__name__}")
 
 # -----J/psi external decayer configuration handled in g4config.in------------------------------------


### PR DESCRIPTION
Prints material/cuts couples table and region info after initialisation. Enable in CI for diagnostics.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
