### PR TITLE
feat: set UseGeneralProcess to false only when cross-sections need to be changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ it in future.
 
 ### Changed
 
+* UseGeneralProcess is only set to false when cross-sections need to be changed (in order to access GammaToMuons directly)
 * Bump minimum ROOT version to 6.36
 * Bump minimum CMake version to 3.20 (same as ROOT)
 * Change naming convention for simulation files to `{sim,geo,params}_{uuid4}.root`, with optional `--tag` parameter to specify custom identifier

--- a/gconfig/g4Config.C
+++ b/gconfig/g4Config.C
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
 // Collaboration
+#include "G4UImanager.hh"
 
 // Configuration macro for Geant4 VirtualMC
 void Config() {
@@ -53,9 +54,21 @@ void Config() {
 
   TString configm(gSystem->Getenv("VMCWORKDIR"));
   TString configm1 = configm + "/gconfig/g4config.in";
-  cout << " -I g4Config() using g4conf  macro: " << configm1 << endl;
+  std::cout << " -I g4Config() using g4conf  macro: " << configm1 << std::endl;
   // set geant4 specific stuff
   // still stupid bug in geant4_vmc
   // geant4->SetMaxNStep(10000.);  // default is 30000
   geant4->ProcessGeantMacro(configm1.Data());
+
+  const std::string set_general_process_to_false =
+      getenv("SET_GENERAL_PROCESS_TO_FALSE")
+          ? getenv("SET_GENERAL_PROCESS_TO_FALSE")
+          : "";
+  if (set_general_process_to_false == "1") {
+    // Turn off UseGeneralProcess to access GammaToMuons directly when
+    // cross-sections need to be changed
+    std::cout << "Setting /process/em/UseGeneralProcess false" << std::endl;
+    G4UImanager::GetUIpointer()->ApplyCommand(
+        "/process/em/UseGeneralProcess false");
+  }
 }

--- a/gconfig/g4config.in
+++ b/gconfig/g4config.in
@@ -11,8 +11,6 @@
 # switch on other sources of di muon
 /physics_lists/em/PositronToMuons true
 /physics_lists/em/GammaToMuons true
-# turn off UseGeneralProcess to access GammaToMuons directly when cross-sections need to be changed
-/process/em/UseGeneralProcess false
 
 # drives me crazy how to stop this tons of output !!!
 /process/em/verbose 0

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -248,6 +248,9 @@ timer.Start()
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
 run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
+if args.boostFactor > 1:
+    # Turn off UseGeneralProcess to access GammaToMuons directly when cross-sections need to be changed
+    os.environ["SET_GENERAL_PROCESS_TO_FALSE"] = "1"
 run.SetUserConfig("g4Config.C")  # user configuration file default g4Config.C
 rtdb = run.GetRuntimeDb()
 

--- a/muonShieldOptimization/study_GammaConv.py
+++ b/muonShieldOptimization/study_GammaConv.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
+import os
 import sys
 import time
 
@@ -50,6 +51,11 @@ timer.Start()
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
 run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
+
+boostFactor = 100.0
+if boostFactor > 1:
+    # Turn off UseGeneralProcess to access GammaToMuons directly when cross-sections need to be changed
+    os.environ["SET_GENERAL_PROCESS_TO_FALSE"] = "1"
 run.SetUserConfig("g4Config.C")  # user configuration file default g4Config.C
 rtdb = run.GetRuntimeDb()
 
@@ -118,7 +124,6 @@ fStack = gMC.GetStack()
 fStack.SetMinPoints(1)
 fStack.SetEnergyCut(-1.0)
 
-boostFactor = 100.0
 if boostFactor > 1:
     ROOT.gROOT.ProcessLine('#include "Geant4/G4ProcessTable.hh"')
     ROOT.gROOT.ProcessLine('#include "Geant4/G4AnnihiToMuPair.hh"')


### PR DESCRIPTION
`UseGeneralProcess` is true by default (which gives a slight speedup for cases where the cross-sections are not changed), and is only set to false when cross-sections need to be changed. This is done by setting an environment variable.
Two scripts which change the cross sections are updated. 

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
