### PR TITLE
fix(build): force CMAKE_INSTALL_LIBDIR to lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ project(FairShip VERSION 0.0.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
+include(GNUInstallDirs)
+# aliBuild modulefile expects libraries in lib/, not lib64/
+set(CMAKE_INSTALL_LIBDIR lib)
+
 # C++17 required by ROOT 6.36
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
GNUInstallDirs sets CMAKE_INSTALL_LIBDIR to lib64 on 64-bit RHEL, but the aliBuild modulefile expects lib/. This causes the CI run jobs to load stale libraries from CVMFS instead of the freshly built ones.

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
