### PR TITLE
fix: update number of muons passed to MuonBackgen

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -596,7 +596,7 @@ if options.muonback:
     primGen.AddGenerator(MuonBackgen)
 
     n_mu = 0
-    with (ROOT.TFile.Open(inputFile, "read") as f_muonfile):
+    with ROOT.TFile.Open(inputFile, "read") as f_muonfile:
         tree = f_muonfile["cbmsim"]
         for event in tree:
             for point in event.PlaneHAPoint:


### PR DESCRIPTION
If a too large number of events is passed to `run.Run` using the `MuonBackGen` generator, this results in a segfault. This is because only muons are considered. Suggest to update the code to run over the minimum between the number of events passed as an option, and the number of muons in `PlaneHAPoint`.

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
