### PR TITLE
Clamp random seed to PYTHIA8 maximum allowed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ it in future.
 * Fix function call in run_simScript.py to use SetPhiRandomize instead of deprecated SetPhiRandom
 + Update run_fixedTarget to save tracks for hits in post-target sensitive plane
 * Set correct trackIDs for exitHadronAbsorber class
+* Clamp random seed to PYTHIA8's maximum allowed value (900000000) to prevent out-of-range errors when using time-based seeds
 
 ### Removed
 

--- a/macro/runPythia8.py
+++ b/macro/runPythia8.py
@@ -5,8 +5,15 @@
 import ROOT
 import rootUtils as ut
 
+# PYTHIA8 requires Random:seed to be in range [0, 900000000]
+# When theSeed=0, ROOT generates a seed from system time which can exceed this limit
 theSeed = 0
 h = {}
+ROOT.gRandom.SetSeed(0)  # Generate time-based seed
+theSeed = ROOT.gRandom.GetSeed()
+# Clamp to PYTHIA8's maximum allowed seed value
+if theSeed > 900000000:
+    theSeed = theSeed % 900000000
 ROOT.gRandom.SetSeed(theSeed)
 ROOT.gSystem.Load("libpythia8")
 

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -224,7 +224,16 @@ else:
 
 os.chdir(args.work_dir)
 # -------------------------------------------------------------------
-ROOT.gRandom.SetSeed(args.seed)  # this should be propagated via ROOT to Pythia8 and Geant4VMC
+# PYTHIA8 requires Random:seed to be in range [0, 900000000]
+# When seed=0, ROOT generates a seed from system time which can exceed this limit
+seed = args.seed
+if seed == 0:
+    ROOT.gRandom.SetSeed(0)  # Generate time-based seed
+    seed = ROOT.gRandom.GetSeed()
+# Clamp to PYTHIA8's maximum allowed seed value
+if seed > 900000000:
+    seed = seed % 900000000
+ROOT.gRandom.SetSeed(seed)
 shipRoot_conf.configure()  # load basic libraries, prepare atexit for python
 ship_geo_kwargs = {
     "Yheight": dy,
@@ -376,7 +385,7 @@ if args.boostDiMuon > 1:
         args.boostDiMuon
     )  # will increase BR for rare eta,omega,rho ... mesons decaying to 2 muons in Pythia8
     # and later copied to Geant4
-P8gen.SetSeed(args.seed)
+P8gen.SetSeed(seed)
 # for charm/beauty
 #        print ' for experts: p pot= number of protons on target per spill to normalize on'
 #        print '            : c chicc= ccbar over mbias cross section'

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -323,7 +323,16 @@ if (options.ntuple or options.muonback) and defaultInputFile:
     print("input file required if simEngine = Ntuple or MuonBack")
     print(" for example -f $EOSSHIP/eos/experiment/ship/data/Mbias/pythia8_Geant4-withCharm_onlyMuons_4magTarget.root")
     sys.exit()
-ROOT.gRandom.SetSeed(options.theSeed)  # this should be propagated via ROOT to Pythia8 and Geant4VMC
+# PYTHIA8 requires Random:seed to be in range [0, 900000000]
+# When theSeed=0, ROOT generates a seed from system time which can exceed this limit
+seed = options.theSeed
+if seed == 0:
+    ROOT.gRandom.SetSeed(0)  # Generate time-based seed
+    seed = ROOT.gRandom.GetSeed()
+    # Clamp to PYTHIA8's maximum allowed seed value
+if seed > 900000000:
+    seed = seed % 900000000
+ROOT.gRandom.SetSeed(seed)
 shipRoot_conf.configure(0)  # load basic libraries, prepare atexit for python
 
 # Configure FairLogger verbosity based on debug level

--- a/muonShieldOptimization/study_thinTarget.py
+++ b/muonShieldOptimization/study_thinTarget.py
@@ -38,7 +38,15 @@ theSeed = 0
 ecut = 0.0
 
 # -------------------------------------------------------------------
-ROOT.gRandom.SetSeed(theSeed)  # this should be propagated via ROOT to Pythia8 and Geant4VMC
+# PYTHIA8 requires Random:seed to be in range [0, 900000000]
+# When theSeed=0, ROOT generates a seed from system time which can exceed this limit
+if theSeed == 0:
+    ROOT.gRandom.SetSeed(0)  # Generate time-based seed
+    theSeed = ROOT.gRandom.GetSeed()
+    # Clamp to PYTHIA8's maximum allowed seed value
+if theSeed > 900000000:
+    theSeed = theSeed % 900000000
+ROOT.gRandom.SetSeed(theSeed)
 shipRoot_conf.configure()  # load basic libraries, prepare atexit for python
 ship_geo = geometry_config.create_config(Yheight=10, shieldName="warm_opt")
 


### PR DESCRIPTION
PYTHIA8 requires Random:seed to be in range [0, 900000000] (see https://pythia.org/latest-manual/RandomNumberSeed.html). When seed is set to 0, ROOT generates a time-based seed which can exceed this limit, causing PYTHIA8 to throw an out-of-range error.

This commit adds seed clamping logic to ensure automatically-generated seeds fall within PYTHIA8's valid range whilst preserving randomness.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
