### PR TITLE
fix: prevent double-filling of TTree branches in digitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ it in future.
 + Update run_fixedTarget to save tracks for hits in post-target sensitive plane
 * Set correct trackIDs for exitHadronAbsorber class
 * Clamp random seed to PYTHIA8's maximum allowed value (900000000) to prevent out-of-range errors when using time-based seeds
+* Fix duplicated events in digitisation output by removing individual branch.Fill() calls; all branches are now filled synchronously by recoTree.Fill() in the main loop. #1028
 
 ### Removed
 

--- a/python/BaseDetector.py
+++ b/python/BaseDetector.py
@@ -45,10 +45,12 @@ class BaseDetector(ABC):
             self.MCdet.clear()
 
     def fill(self):
-        """Fill detector hit branches."""
-        self.branch.Fill()
-        if self.mcBranch:
-            self.mcBranch.Fill()
+        """Fill detector hit branches.
+
+        Note: This method is now a no-op to prevent double-filling.
+        All branches are filled synchronously by recoTree.Fill() in the main loop.
+        """
+        pass
 
     @abstractmethod
     def digitize(self):

--- a/python/detectors/splitcalDetector.py
+++ b/python/detectors/splitcalDetector.py
@@ -21,9 +21,12 @@ class splitcalDetector(BaseDetector):
         self.reco.clear()
 
     def fill(self):
-        # Override to also fill reconstruction branch
-        super().fill()
-        self.recoBranch.Fill()
+        """Fill detector hit branches.
+
+        Note: This method is now a no-op to prevent double-filling.
+        All branches are filled synchronously by recoTree.Fill() in the main loop.
+        """
+        pass
 
     def digitize(self):
         """Digitize splitcal hits and perform cluster reconstruction."""

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -111,7 +111,6 @@ class ShipDigiReco:
         self.header.SetEventTime(self.sTree.t0)
         self.header.SetRunId(self.sTree.MCEventHeader.GetRunID())
         self.header.SetMCEntryNumber(self.sTree.MCEventHeader.GetEventID())  # counts from 1
-        self.eventHeader.Fill()
         self.digiSBT.process()
         self.strawtubes.process()
         self.timeDetector.process()
@@ -323,9 +322,6 @@ class ShipDigiReco:
                 indices.push_back(index)
             aTracklet = ROOT.Tracklet(1, indices)
             self.fTrackletsArray.push_back(aTracklet)
-        self.Tracklets.Fill()
-        self.fitTracks.Fill()
-        self.mcLink.Fill()
         # debug
         if global_variables.debug:
             print("save tracklets:")
@@ -345,7 +341,6 @@ class ShipDigiReco:
             if chi2 < 50 and not chi2 < 0:
                 self.goodTracksVect.push_back(i)
                 nGoodTracks += 1
-        self.goodTracksBranch.Fill()
         return nGoodTracks
 
     def findVetoHitOnTrack(self, track):
@@ -376,7 +371,6 @@ class ShipDigiReco:
         for good_track in self.goodTracksVect:
             track = self.fGenFitArray[good_track]
             self.vetoHitOnTrackArray.push_back(self.findVetoHitOnTrack(track))
-        self.vetoHitOnTrackBranch.Fill()
 
     def fracMCsame(self, trackids):
         track = {}

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -51,7 +51,6 @@ class Task:
     def execute(self):
         # make particles persistent
         self.TwoTrackVertex()
-        self.Particles.Fill()
 
     # define global data and functions for vertex fit with TMinuit
     y_data = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])


### PR DESCRIPTION
Remove individual branch.Fill() calls from detector classes and reconstruction methods. All branches are now filled synchronously by the single recoTree.Fill() call in the main event loop.

This fixes issue #1028 where events were duplicated in the digi output file because branches were filled twice per event.

Closes #1028

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
