### PR TITLE
Remove molybdenum target option and simplify config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ it in future.
 
 ### Removed
 
+* Remove molybdenum target option; simplify target_config.yaml
 * Remove g4Ex scripts, which are unused and rely on g4py and Geant4 python imports
 * Remove old (CDR) target configuration; Jun25 is now the only supported target
 

--- a/geometry/target_config.yaml
+++ b/geometry/target_config.yaml
@@ -1,30 +1,31 @@
 target:
-    Nplates: 19 #number of sublayer blocks = layers
-    M:
-        - "tungsten"
+    nS: 19  # number of target slices
+    material: "tungsten"
+    xy: 25.  # [cm] full length in x and y
+    HeT: 90  # He temperature in Celsius degrees, integer, Medium with name PressurisedHe<value> must exist in media.geo file
 
-    L:
-        - 4.5 #*u.cm
-        - 1.8 #*u.cm
-        - 1.7 #*u.cm
-        - 1.7 #*u.cm
-        - 1.8 #*u.cm
-        - 1.9 #*u.cm
-        - 2.1 #*u.cm
-        - 1.9 #*u.cm
-        - 2.1 #*u.cm
-        - 2.4 #*u.cm
-        - 2.8 #*u.cm
-        - 3.3 #*u.cm
-        - 4.1 #*u.cm
-        - 5.6 #*u.cm
-        - 8.8 #*u.cm
-        - 17.2 #*u.cm
-        - 28.7 #*u.cm
-        - 28.8 #*u.cm
-        - 28.8 #*u.cm
+    L:  # slice lengths [cm]
+        - 4.5
+        - 1.8
+        - 1.7
+        - 1.7
+        - 1.8
+        - 1.9
+        - 2.1
+        - 1.9
+        - 2.1
+        - 2.4
+        - 2.8
+        - 3.3
+        - 4.1
+        - 5.6
+        - 8.8
+        - 17.2
+        - 28.7
+        - 28.8
+        - 28.8
 
-    G:
+    G:  # gaps after each slice [cm]
         - 0.45
         - 0.45
         - 0.45
@@ -44,27 +45,3 @@ target:
         - 0.68
         - 0.68
         - 0
-    N:
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-        - 1
-
-    nS: 19
-    xy: 25.  # [cm] full length in x and y
-    HeT: 90 # He temperature in Celsius degrees, integer, Medium with name PressurisedHe<value> must exist in media.geo file

--- a/passive/ShipTargetStation.cxx
+++ b/passive/ShipTargetStation.cxx
@@ -62,8 +62,6 @@ void ShipTargetStation::ConstructGeometry() {
   TGeoMedium* tungsten = gGeoManager->GetMedium("tungsten");
   InitMedium("tantalum");
   TGeoMedium* tantalum = gGeoManager->GetMedium("tantalum");
-  InitMedium("molybdenum");
-  TGeoMedium* mo = gGeoManager->GetMedium("molybdenum");
   InitMedium("iron");
   TGeoMedium* iron = gGeoManager->GetMedium("iron");
   InitMedium("steel316L");
@@ -182,29 +180,18 @@ void ShipTargetStation::ConstructGeometry() {
     TString nmi_core = "TargetCore_";
     nmi_core += i + 1;
 
-    TGeoMedium* material = nullptr;
-    if (fM.at(i) == "molybdenum") {
-      material = mo;
-    } else if (fM.at(i) == "tungsten") {
-      material = tungsten;
-    }
-
     // Create outer cladded volume (tantalum, full dimensions)
     claddedTarget = gGeoManager->MakeTube(nmi_cladded, tantalum, 0.,
                                           fDiameter / 2., fL.at(i) / 2.);
     claddedTarget->SetLineColor(8);  // Green for tantalum
 
-    // Create inner target core (W or Mo, reduced dimensions)
+    // Create inner target core (tungsten, reduced dimensions)
     // Positioned at centre (z=0) of cladded volume - tantalum fills the gaps
     // automatically
-    targetCore = gGeoManager->MakeTube(nmi_core, material, 0.,
+    targetCore = gGeoManager->MakeTube(nmi_core, tungsten, 0.,
                                        fDiameter / 2. - cladding_width,
                                        (fL.at(i) - 2 * cladding_width) / 2.);
-    if (fM.at(i) == "molybdenum") {
-      targetCore->SetLineColor(28);
-    } else {
-      targetCore->SetLineColor(38);
-    };  // silver/blue
+    targetCore->SetLineColor(38);  // Blue for tungsten
 
     // Nest core inside cladding (at centre, z=0 in cladded volume's coordinate
     // system)

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -10,7 +10,6 @@ from ShipGeoConfig import AttrDict, Config
 # Parameters for geometry configuration are passed to create_config() function
 # nuTargetPassive = 1  #0 = with active layers, 1 = only passive
 
-# targetOpt      = 5  # 0=solid   >0 sliced, 5: 5 pieces of tungsten, 4 air slits, 17: molybdenum tungsten interleaved with H20
 # strawOpt       = 0  # 4=aluminium frame 10=steel frame (default)
 
 # Here you can select the MS geometry, if the MS design is using SC magnet change the hybrid to True
@@ -297,24 +296,9 @@ def create_config(
         targetconfig = yaml.safe_load(file)
         c.target = AttrDict(targetconfig["target"])
 
-    c.target.slices_length = []
-    c.target.slices_gap = []
-    c.target.slices_material = []
-
-    for i in range(c.target.Nplates):
-        for j in range(c.target.N[i]):
-            if len(c.target.L) == 1:
-                c.target.slices_length.append(c.target.L[0])
-            else:
-                c.target.slices_length.append(c.target.L[i])
-            if len(c.target.G) == 1:
-                c.target.slices_gap.append(c.target.G[0])
-            else:
-                c.target.slices_gap.append(c.target.G[i])
-            if len(c.target.M) == 1:
-                c.target.slices_material.append(c.target.M[0])
-            else:
-                c.target.slices_material.append(c.target.M[i])
+    c.target.slices_length = c.target.L
+    c.target.slices_gap = c.target.G
+    c.target.slices_material = [c.target.material] * c.target.nS
     # Last gap should be 0...
     c.target.slices_gap[c.target.nS - 1] = 0
     print(c.target.slices_material, c.target.slices_length, c.target.slices_gap)


### PR DESCRIPTION
- Remove molybdenum medium initialisation from ShipTargetStation.cxx
- Simplify target_config.yaml: remove unused Nplates, N list; change M to scalar
- Update geometry_config.py to handle simplified YAML format
- Target material is now always tungsten (the only option in production)

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
