### PR TITLE
Break one event before the end in `MuonBackGenerator`

### DIFF
--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -196,7 +196,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     return fUseSTL ? MCTrack_vec->size() : MCTrack->GetEntries();
   };
 
-  while (fn < fNevents-1) {
+  while (fn < fNevents - 1) {
     fTree->GetEntry(fn);
     muList.clear();
     moList.clear();


### PR DESCRIPTION
Stops the segfault when `FairMCApplication` tries to get the next event when finishing (another route round #1033).

Not sure I like this - seems a bit of a hack. What do you think @THanae ?

## Checklist

- [x] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
