### PR TITLE
Remove //! from public methods to expose them to Python

### DIFF
--- a/shipgen/CosmicsGenerator.h
+++ b/shipgen/CosmicsGenerator.h
@@ -62,9 +62,9 @@ class CosmicsGenerator : public FairGenerator {
   };
 
   /** public method ReadEvent **/
-  Bool_t ReadEvent(FairPrimaryGenerator*);  //!
+  Bool_t ReadEvent(FairPrimaryGenerator*);
   //  virtual Bool_t Init(); //!
-  virtual Bool_t Init(Bool_t largeMom);  //!
+  virtual Bool_t Init(Bool_t largeMom);
 
   double z0, yBox, xBox, zBox, xdist, zdist, minE;
   int n_EVENTS;

--- a/shipgen/DPPythia8Generator.h
+++ b/shipgen/DPPythia8Generator.h
@@ -36,15 +36,15 @@ class DPPythia8Generator : public FairGenerator {
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
   void SetParameters(char*);
-  void Print() { fPythia->settings.listAll(); };          //!
-  void List(int id) { fPythia->particleData.list(id); };  //!
+  void Print() { fPythia->settings.listAll(); };
+  void List(int id) { fPythia->particleData.list(id); };
 
   // void SetDecayToHadrons(){
   // std::cout << " INFO: Adding decay to hadrons." << std::endl;
   // fHadDecay = true;
   // };
 
-  virtual Bool_t Init();  //!
+  virtual Bool_t Init();
 
   void SetMom(Double_t mom) { fMom = mom; };
   Double_t GetMom() { return fMom; };

--- a/shipgen/EvtCalcGenerator.h
+++ b/shipgen/EvtCalcGenerator.h
@@ -23,8 +23,8 @@ class EvtCalcGenerator : public FairGenerator {
 
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
-  virtual Bool_t Init(const char*, int);  //!
-  virtual Bool_t Init(const char*);       //!
+  virtual Bool_t Init(const char*, int);
+  virtual Bool_t Init(const char*);
 
   Int_t GetNevents() { return fNevents; }
   void SetPositions(Double_t zTa, Double_t zDV) {

--- a/shipgen/FixedTargetGenerator.h
+++ b/shipgen/FixedTargetGenerator.h
@@ -34,11 +34,11 @@ class FixedTargetGenerator : public FairGenerator {
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
   void SetParameters(char*);
-  void Print();  //!
+  void Print();
 
-  virtual Bool_t Init();  //!
+  virtual Bool_t Init();
   Bool_t InitForCharmOrBeauty(TString fInName, Int_t nev, Double_t npots = 5E13,
-                              Int_t nStart = 0);  //!
+                              Int_t nStart = 0);
 
   void SetMom(Double_t mom) { fMom = mom; };
   void UseRandom1() {

--- a/shipgen/GenieGenerator.h
+++ b/shipgen/GenieGenerator.h
@@ -28,8 +28,8 @@ class GenieGenerator : public FairGenerator {
   /** public method ReadEvent **/
   Bool_t OldReadEvent(FairPrimaryGenerator*);
   Bool_t ReadEvent(FairPrimaryGenerator*);
-  virtual Bool_t Init(const char*, int);  //!
-  virtual Bool_t Init(const char*);       //!
+  virtual Bool_t Init(const char*, int);
+  virtual Bool_t Init(const char*);
   Int_t GetNevents();
   void NuOnly() { fNuOnly = true; }
   void SetPositions(Double_t zTa, Double_t zS = -3400., Double_t zE = 2650.) {

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -50,10 +50,10 @@ class HNLPythia8Generator : public FairGenerator {
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
   void SetParameters(char*);
-  void Print() { fPythia->settings.listAll(); };          //!
-  void List(int id) { fPythia->particleData.list(id); };  //!
+  void Print() { fPythia->settings.listAll(); };
+  void List(int id) { fPythia->particleData.list(id); };
 
-  virtual Bool_t Init();  //!
+  virtual Bool_t Init();
 
   void SetMom(Double_t mom) { fMom = mom; };
   void SetId(Double_t id) { fId = id; };

--- a/shipgen/MuDISGenerator.h
+++ b/shipgen/MuDISGenerator.h
@@ -26,8 +26,8 @@ class MuDISGenerator : public FairGenerator {
 
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
-  virtual Bool_t Init(const char*, int);  //!
-  virtual Bool_t Init(const char*);       //!
+  virtual Bool_t Init(const char*, int);
+  virtual Bool_t Init(const char*);
   Int_t GetNevents();
 
   void SetPositions(Double_t z_start, Double_t z_end) {

--- a/shipgen/MuonBackGenerator.h
+++ b/shipgen/MuonBackGenerator.h
@@ -27,13 +27,13 @@ class MuonBackGenerator : public FairGenerator {
 
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
-  virtual Bool_t Init(const char*, int);                      //!
-  virtual Bool_t Init(const char*);                           //!
-  virtual Bool_t Init(const std::vector<std::string>&, int);  //!
-  virtual Bool_t Init(const std::vector<std::string>&);       //!
+  virtual Bool_t Init(const char*, int);
+  virtual Bool_t Init(const char*);
+  virtual Bool_t Init(const std::vector<std::string>&, int);
+  virtual Bool_t Init(const std::vector<std::string>&);
 
-  Int_t GetNevents();  //!
-  void CloseFile();    //!
+  Int_t GetNevents();
+  void CloseFile();
   void FollowAllParticles() { followMuons = false; };
   void SetSmearBeam(Double_t sb) { fsmearBeam = sb; };
   void SetPaintRadius(Double_t r) { fPaintBeam = r; };

--- a/shipgen/NtupleGenerator.h
+++ b/shipgen/NtupleGenerator.h
@@ -22,8 +22,8 @@ class NtupleGenerator : public FairGenerator {
 
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
-  virtual Bool_t Init(const char*, int);  //!
-  virtual Bool_t Init(const char*);       //!
+  virtual Bool_t Init(const char*, int);
+  virtual Bool_t Init(const char*);
   Int_t GetNevents();
 
  private:

--- a/shipgen/Pythia8Generator.h
+++ b/shipgen/Pythia8Generator.h
@@ -25,9 +25,9 @@ class Pythia8Generator : public FairGenerator {
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
   void SetParameters(char*);
-  void Print();  //!
+  void Print();
 
-  virtual Bool_t Init();  //!
+  virtual Bool_t Init();
 
   void SetMom(Double_t mom) { fMom = mom; };
   void SetId(Double_t id) { fId = id; };

--- a/shipgen/tPythia6Generator.h
+++ b/shipgen/tPythia6Generator.h
@@ -24,7 +24,7 @@ class tPythia6Generator : public FairGenerator {
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*);
 
-  virtual Bool_t Init();  //!
+  virtual Bool_t Init();
 
   void SetMom(Double_t mom) { fMom = mom; };
   void SetTarget(TString Type, TString Target) {


### PR DESCRIPTION
The //! comment tells ROOT's dictionary generator to skip creating bindings. While correct for data members (prevents serialisation), it incorrectly hides public methods from Python when using rootcling with -inlineInputHeader.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
