### PR TITLE
fix: validate that multiple input files are only passed to supported …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ it in future.
 
 ### Fixed
 
+* Validate that multiple input files are only passed to generators that support them (currently only MuonBackGenerator). #1045
 * Fix `errorSummary` not printing its header (bare string expression instead of `print`)
 * Fix `reportError`/`errorSummary` using fragile `sys.modules['__main__'].log` pattern; use module-level counter instead
 * Fix file-filtering logic to support STL branches


### PR DESCRIPTION
…generators

Only MuonBackGenerator supports multiple input files (via TChain). Other generators require exactly one file. Add validation after glob expansion to raise a clear error when multiple files are passed to single-file generators.

Fixes #1045

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
