### PR TITLE
feat: Add option to split pions and kaons in run_fixedTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ it in future.
 ## Unreleased
 
 ### Added
+* Add option to split kaons and pions right before they decay, to increase the number of muons
 
 ### Changed
 

--- a/gconfig/g4Config.C
+++ b/gconfig/g4Config.C
@@ -30,10 +30,18 @@ void Config() {
   /// - stackPopper       - stackPopper process
   /// When more than one options are selected, they should be separated with '+'
   /// character: eg. stepLimit+specialCuts.
-  TG4RunConfiguration* runConfiguration = new TG4RunConfiguration(
-      "geomRoot", "FTFP_BERT_HP_EMZ", "stepLimiter+specialCuts+specialControls",
-      false,   // specialStacking (default)
-      false);  // disable MT
+
+  const char* env = std::getenv("KAON_PION_SPLITS");
+  int32_t fNsplits = env ? std::atoi(env) : 0;
+
+  std::string controls = "stepLimiter+specialCuts+specialControls";
+  /// stackPopper is required when adding secondaries, e.g. when splitting the
+  /// pions and kaons
+  if (fNsplits > 0) controls += "+stackPopper";
+  TG4RunConfiguration* runConfiguration =
+      new TG4RunConfiguration("geomRoot", "FTFP_BERT_HP_EMZ", controls.c_str(),
+                              false,   // specialStacking (default)
+                              false);  // disable MT
 
   /// Create the G4 VMC
   TGeant4* geant4 =

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -78,6 +78,16 @@ ap.add_argument("-t", "--tau-only", action=argparse.BooleanOptionalAction, dest=
 ap.add_argument("-J", "--Jpsi-mainly", action=argparse.BooleanOptionalAction, dest="JpsiMainly", default=False)
 ap.add_argument("-b", "--boostDiMuon", type=float, default=1.0, help="boost Di-muon branching ratios")
 ap.add_argument("-X", "--boostFactor", type=float, default=1.0, help="boost Di-muon prod cross sections")
+ap.add_argument(
+    "--kaon-pion-splits",
+    type=int,
+    default=0,
+    help="splitting factor for kaons and pions, in order to boost the number of muons stemming from their decays",
+)
+ap.add_argument(
+    "--multiple-kpi-splits", action="store_true", help="split kaons and pions multiple times along the track path"
+)
+
 ap.add_argument("-C", "--charm", action=argparse.BooleanOptionalAction, default=False, help="generate charm decays")
 ap.add_argument("-B", "--beauty", action=argparse.BooleanOptionalAction, default=False, help="generate beauty decays")
 ap.add_argument(
@@ -186,6 +196,11 @@ args = ap.parse_args()
 if args.debug:
     logger.setLevel(logging.DEBUG)
 
+if args.kaon_pion_splits < 0:
+    ap.error("--kaon-pion-splits must be >= 0")
+if args.multiple_kpi_splits and args.kaon_pion_splits == 0:
+    ap.error("--multiple-kpi-splits requires --kaon-pion-splits > 0")
+
 
 if args.G4only:
     args.charm = False
@@ -272,6 +287,8 @@ ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 if args.boostFactor > 1:
     # Turn off UseGeneralProcess to access GammaToMuons directly when cross-sections need to be changed
     os.environ["SET_GENERAL_PROCESS_TO_FALSE"] = "1"
+if args.kaon_pion_splits > 0:
+    os.environ["KAON_PION_SPLITS"] = str(args.kaon_pion_splits)
 run.SetUserConfig("g4Config.C")  # user configuration file default g4Config.C
 rtdb = run.GetRuntimeDb()
 
@@ -342,6 +359,9 @@ if args.AddMuonShield or args.AddHadronAbsorberOnly:
 
 
 sensPlaneHA = ROOT.exitHadronAbsorber()
+sensPlaneHA.SetNSplits(args.kaon_pion_splits)  # type: ignore[missing-attribute]
+if args.multiple_kpi_splits:
+    sensPlaneHA.SetSplitMultipleTimes()  # type: ignore[missing-attribute]
 sensPlaneHA.SetEnergyCut(args.ecut * u.GeV)
 sensPlaneHA.SetVetoPointName("PlaneHA")
 
@@ -422,6 +442,8 @@ gMC = ROOT.TVirtualMC.GetMC()
 fStack = gMC.GetStack()
 fStack.SetMinPoints(1)
 fStack.SetEnergyCut(-1.0)
+if args.kaon_pion_splits > 0:
+    fStack.SetSplitting()
 #
 import AddDiMuonDecayChannelsToG4
 

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -12,10 +12,12 @@
 #include "FairGeoMedia.h"
 #include "FairGeoNode.h"
 #include "FairGeoVolume.h"
+#include "FairLogger.h"
 #include "FairRootManager.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
 #include "ShipStack.h"
+#include "TArrayI.h"
 #include "TDatabasePDG.h"
 #include "TGeoBBox.h"
 #include "TGeoBoolNode.h"
@@ -24,9 +26,13 @@
 #include "TGeoMaterial.h"
 #include "TH1D.h"
 #include "TH2D.h"
+#include "TLorentzVector.h"
+#include "TMCProcess.h"
 #include "TParticle.h"
 #include "TROOT.h"
 #include "TVirtualMC.h"
+#include "vetoPoint.h"
+
 using std::cout;
 using std::endl;
 
@@ -41,7 +47,10 @@ exitHadronAbsorber::exitHadronAbsorber(const char* Name, Bool_t Active)
       fVetoName("veto"),
       fzPos(3E8),
       withNtuple(kFALSE),
-      fCylindricalPlane(kFALSE) {}
+      fCylindricalPlane(kFALSE),
+      fUseCaveCoordinates(kFALSE),
+      fNsplits(0),
+      fCurrentSurvivalFactor(1) {}
 
 exitHadronAbsorber::exitHadronAbsorber()
     : Detector("exitHadronAbsorber", kTRUE, kVETO),
@@ -52,33 +61,109 @@ exitHadronAbsorber::exitHadronAbsorber()
       fzPos(3E8),
       withNtuple(kFALSE),
       fCylindricalPlane(kFALSE),
-      fUseCaveCoordinates(kFALSE) {}
+      fUseCaveCoordinates(kFALSE),
+      fNsplits(0),
+      fCurrentSurvivalFactor(1) {}
 
 Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
   /** This method is called from the MC stepping */
-  if (gMC->IsTrackEntering()) {
-    fTrackID = gMC->GetStack()->GetCurrentTrackNumber();
-    fEventID = gMC->CurrentEvent();
-    TParticle* p = gMC->GetStack()->GetCurrentTrack();
-    fUniqueID = p->GetUniqueID();
-    Int_t pdgCode = p->GetPdgCode();
-    gMC->TrackMomentum(fMom);
-    if (!fOnlyMuons || TMath::Abs(pdgCode) == 13) {
-      fTime = gMC->TrackTime() * 1.0e09;
-      fLength = gMC->TrackLength();
-      gMC->TrackPosition(fPos);
-      if ((fMom.E() - fMom.M()) > EMax) {
-        AddHit(fEventID, fTrackID, 111, TVector3(fPos.X(), fPos.Y(), fPos.Z()),
-               TVector3(fMom.Px(), fMom.Py(), fMom.Pz()), fTime, fLength, 0,
-               pdgCode, TVector3(p->Vx(), p->Vy(), p->Vz()),
-               TVector3(p->Px(), p->Py(), p->Pz()));
-        ShipStack* stack = dynamic_cast<ShipStack*>(gMC->GetStack());
-        stack->AddPoint(kVETO);
+  TString volName = gMC->CurrentVolName();
+
+  if (volName.Contains("exitHadronAbsorber")) {
+    if (gMC->IsTrackEntering()) {
+      fTrackID = gMC->GetStack()->GetCurrentTrackNumber();
+      fEventID = gMC->CurrentEvent();
+      TParticle* p = gMC->GetStack()->GetCurrentTrack();
+      fUniqueID = p->GetUniqueID();
+      Int_t pdgCode = p->GetPdgCode();
+      Int_t motherId = p->GetFirstMother();
+      gMC->TrackMomentum(fMom);
+      if (!fOnlyMuons || TMath::Abs(pdgCode) == 13) {
+        fTime = gMC->TrackTime() * 1.0e09;
+        fLength = gMC->TrackLength();
+        gMC->TrackPosition(fPos);
+        if (((fMom.E() - fMom.M()) > EMax) &&
+            (fDecayedParentIDs.count(motherId) == 0)) {
+          AddHit(fEventID, fTrackID, 111,
+                 TVector3(fPos.X(), fPos.Y(), fPos.Z()),
+                 TVector3(fMom.Px(), fMom.Py(), fMom.Pz()), fTime, fLength, 0,
+                 pdgCode, TVector3(p->Vx(), p->Vy(), p->Vz()),
+                 TVector3(p->Px(), p->Py(), p->Pz()));
+          auto* stack = dynamic_cast<ShipStack*>(gMC->GetStack());
+          stack->AddPoint(kVETO);
+        }
       }
     }
+
+    if ((!fCylindricalPlane) && fzPos > 1E8) {
+      gMC->StopTrack();
+    }
   }
-  if ((!fCylindricalPlane) && fzPos > 1E8) {
-    gMC->StopTrack();
+
+  if (fNsplits > 0 && (!fSplitOnce)) {
+    Int_t currentTrackId = gMC->GetStack()->GetCurrentTrackNumber();
+
+    if (fCloneTracks.count(currentTrackId) > 0 ||
+        fContinuationTracks.count(currentTrackId) > 0) {
+      return kTRUE;
+    }
+
+    Int_t track_pid = gMC->TrackPid();
+    bool kaon_or_pion =
+        (TMath::Abs(track_pid) == 211 || TMath::Abs(track_pid) == 321);
+
+    if (kaon_or_pion) {
+      TParticle* part = gMC->GetStack()->GetCurrentTrack();
+      if (!part) return kTRUE;
+
+      Double_t delta_s = gMC->TrackStep();
+
+      if (delta_s > 0) {
+        TLorentzVector pos, mom;
+        gMC->TrackPosition(pos);
+        gMC->TrackMomentum(mom);
+
+        Double_t mass = gMC->TrackMass();
+        Double_t tau = gMC->ParticleLifeTime(track_pid);  // in nanoseconds
+        Double_t c_tau = tau * 29.9792458;                // in cm/ns
+
+        Double_t instantP = mom.P();
+
+        Double_t lambda_decay = (instantP / mass) * c_tau;
+        Double_t P_decay = 1.0 - TMath::Exp(-delta_s / lambda_decay);
+        if ((P_decay > 0.0) && ((mom.E() - mom.M()) > EMax)) {
+          double polX = 0, polY = 0, polZ = 0;
+          TVector3 polVector;
+          part->GetPolarisation(polVector);
+          polX = polVector.X();
+          polY = polVector.Y();
+          polZ = polVector.Z();
+          Int_t trueParentId = part->GetFirstMother();
+
+          Double_t decayBranchWeight = fCurrentSurvivalFactor * P_decay;
+          Double_t cloneWeight = decayBranchWeight / fNsplits;
+          for (int i = 0; i < fNsplits; ++i) {
+            TrackBuffer clone;
+            clone.pdg = track_pid;
+            clone.px = mom.Px();
+            clone.py = mom.Py();
+            clone.pz = mom.Pz();
+            clone.e = mom.E();
+            clone.x = pos.X();
+            clone.y = pos.Y();
+            clone.z = pos.Z();
+            clone.t = pos.T();
+            clone.polx = polX;
+            clone.poly = polY;
+            clone.polz = polZ;
+            clone.weight = cloneWeight;
+            clone.parentID = trueParentId;
+            fSecondaryBuffer.push_back(clone);
+          }
+          fCurrentSurvivalFactor *= (1.0 - P_decay);
+        }
+      }
+    }
   }
   return kTRUE;
 }
@@ -152,14 +237,128 @@ void exitHadronAbsorber::Initialize() {
   }
 }
 
+void exitHadronAbsorber::BeginEvent() {
+  fCloneTracks.clear();
+  fContinuationTracks.clear();
+  fDecayedParentIDs.clear();
+  fSecondaryBuffer.clear();
+}
+
+void exitHadronAbsorber::PostTrack() {
+  Int_t currentTrackId = gMC->GetStack()->GetCurrentTrackNumber();
+
+  if (fCloneTracks.count(currentTrackId) > 0 ||
+      fContinuationTracks.count(currentTrackId) > 0) {
+    return;
+  }
+
+  Int_t track_pid = gMC->TrackPid();
+  bool kaon_or_pion =
+      (TMath::Abs(track_pid) == 211 || TMath::Abs(track_pid) == 321);
+
+  if (fNsplits > 0 && kaon_or_pion) {
+    bool isNaturalDecay = false;
+    bool isParticleDestroyed = gMC->IsTrackStop() || gMC->IsTrackDisappeared();
+    TArrayI processes;
+    gMC->StepProcesses(processes);
+    for (int i = 0; i < processes.GetSize(); i++) {
+      if (processes[i] == kPDecay) {
+        isNaturalDecay = true;
+        break;
+      }
+    }
+
+    TParticle* part = gMC->GetStack()->GetCurrentTrack();
+    if (!part) return;
+
+    TLorentzVector finalPos, finalMom;
+    gMC->TrackPosition(finalPos);
+    gMC->TrackMomentum(finalMom);
+
+    double polX = 0, polY = 0, polZ = 0;
+    TVector3 polVector;
+    part->GetPolarisation(polVector);
+    polX = polVector.X();
+    polY = polVector.Y();
+    polZ = polVector.Z();
+    Int_t trueParentId = part->GetFirstMother();
+
+    auto* stack = dynamic_cast<ShipStack*>(gMC->GetStack());
+
+    // All remaining weight used if cloning happens at point where original
+    // particle decays
+    if (isNaturalDecay) {
+      Double_t finalEndpointWeight = fCurrentSurvivalFactor / fNsplits;
+      for (int i = 0; i < fNsplits; ++i) {
+        TrackBuffer clone;
+        clone.pdg = track_pid;
+        clone.px = finalMom.Px();
+        clone.py = finalMom.Py();
+        clone.pz = finalMom.Pz();
+        clone.e = finalMom.E();
+        clone.x = finalPos.X();
+        clone.y = finalPos.Y();
+        clone.z = finalPos.Z();
+        clone.t = finalPos.T();
+        clone.polx = polX;
+        clone.poly = polY;
+        clone.polz = polZ;
+        clone.weight = finalEndpointWeight;
+        clone.parentID = trueParentId;
+        fSecondaryBuffer.push_back(clone);
+      }
+      fCurrentSurvivalFactor = 0.0;
+      fDecayedParentIDs.insert(currentTrackId);
+    }
+
+    // tracks which do not decay are stopped with stoptrack and added back with
+    // a given weight
+    if (!isNaturalDecay && !isParticleDestroyed && stack) {
+      Int_t ntr;
+      stack->PushTrack(1, trueParentId, track_pid, finalMom.Px(), finalMom.Py(),
+                       finalMom.Pz(), finalMom.E(), finalPos.X(), finalPos.Y(),
+                       finalPos.Z(), finalPos.T(), polX, polY, polZ,
+                       kPNoProcess, ntr, fCurrentSurvivalFactor, 999);
+      fContinuationTracks.insert(ntr);
+    }
+
+    gMC->StopTrack();
+  }
+}
+
 void exitHadronAbsorber::PreTrack() {
+  bool stackbufferisnotempty = !fSecondaryBuffer.empty();
+  if (stackbufferisnotempty) {
+    auto* stack = dynamic_cast<ShipStack*>(gMC->GetStack());
+    Int_t ntr;
+    for (const auto& trk : fSecondaryBuffer) {
+      stack->PushTrack(1, trk.parentID, trk.pdg, trk.px, trk.py, trk.pz, trk.e,
+                       trk.x, trk.y, trk.z, trk.t, trk.polx, trk.poly, trk.polz,
+                       kPNoProcess, ntr, trk.weight, 999);
+      fCloneTracks.insert(ntr);
+    }
+    // Clear the buffer so we don't duplicate them for the next track
+    fSecondaryBuffer.clear();
+  }
+
+  // Reset relative survival factor to 1.0
+  fCurrentSurvivalFactor = 1.0;
+
   gMC->TrackMomentum(fMom);
   if ((fMom.E() - fMom.M()) < EMax) {
     gMC->StopTrack();
     return;
   }
   TParticle* p = gMC->GetStack()->GetCurrentTrack();
+  Int_t currentID = gMC->GetStack()->GetCurrentTrackNumber();
+
+  if (fCloneTracks.find(currentID) != fCloneTracks.end()) {
+    //  Force the decay time to 0
+    gMC->ForceDecayTime(0);
+  }
+
   Int_t pdgCode = p->GetPdgCode();
+
   // record statistics for neutrinos, electrons and photons
   // add pi0 111 eta 221 eta' 331  omega 223
   Int_t idabs = TMath::Abs(pdgCode);
@@ -252,6 +451,26 @@ void exitHadronAbsorber::FinishRun() {
   }
 }
 
+void RegisterDaughtersRecursively(TGeoVolume* volume,
+                                  exitHadronAbsorber* detector) {
+  if (!volume) return;
+  Int_t nDaughters = volume->GetNdaughters();
+  for (Int_t i = 0; i < nDaughters; ++i) {
+    TGeoNode* daughterNode = volume->GetNode(i);
+    if (daughterNode) {
+      TGeoVolume* daughterVol = daughterNode->GetVolume();
+      if (daughterVol) {
+        // register daughter volume
+        detector->AddSensitiveVolume(daughterVol);
+        LOG(info) << "[exitHadronAbsorber] Registered subvolume: "
+                  << daughterVol->GetName();
+        // call function recursively
+        RegisterDaughtersRecursively(daughterVol, detector);
+      }
+    }
+  }
+}
+
 void exitHadronAbsorber::ConstructGeometry() {
   static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
   static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
@@ -327,6 +546,14 @@ void exitHadronAbsorber::ConstructGeometry() {
     nav->GetCurrentNode()->GetVolume()->AddNode(sensPlaneCyl, 1,
                                                 new TGeoTranslation(0, 0, 0));
     AddSensitiveVolume(sensPlaneCyl);
+  }
+  if ((fNsplits > 0) && (!fSplitOnce)) {
+    TString parentVolumeName = "/target_vacuum_box_1";
+    nav->cd(parentVolumeName.Data());
+    TGeoVolume* vol = nav->GetCurrentNode()->GetVolume();
+    AddSensitiveVolume(vol);
+    // register each unique daughter volume
+    RegisterDaughtersRecursively(vol, this);
   }
 }
 

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -5,6 +5,7 @@
 #ifndef MUONSHIELDOPTIMIZATION_EXITHADRONABSORBER_H_
 #define MUONSHIELDOPTIMIZATION_EXITHADRONABSORBER_H_
 
+#include <set>
 #include <utility>
 
 #include "Detector.h"
@@ -13,6 +14,15 @@
 #include "vetoPoint.h"
 
 class FairVolume;
+
+struct TrackBuffer {
+  Int_t pdg;
+  Double_t px, py, pz, e;
+  Double_t x, y, z, t;
+  Double_t polx, poly, polz;
+  Double_t weight;
+  Int_t parentID;
+};
 
 class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
  public:
@@ -29,6 +39,12 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
 
   void FinishRun() override;
   void PreTrack() override;
+  void PostTrack() override;
+  void BeginEvent() override;
+  // void FinishEvent();
+
+  void SetNSplits(Int_t n) { fNsplits = n; }
+  void SetSplitMultipleTimes() { fSplitOnce = kFALSE; }
 
   inline void SetEnergyCut(Float_t emax) { EMax = emax; }
   inline void SetOnlyMuons() { fOnlyMuons = kTRUE; }
@@ -50,6 +66,18 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   Float_t EMax;              //! max energy to transport
   Bool_t fCylindricalPlane;  //! cylindrical sensPlane flag
   Bool_t fUseCaveCoordinates;  //! set position from cave
+
+  int32_t fNsplits;
+  Double_t fCurrentSurvivalFactor;  // survival factor at every step, if we
+                                    // choose to split at every step
+  Bool_t fSplitOnce =
+      kTRUE;  // determine if we want to split once (when the particle decays)
+              // or at every step (taking decay probabilities into account)
+
+  std::vector<TrackBuffer> fSecondaryBuffer;
+  std::set<Int_t> fCloneTracks;
+  std::set<Int_t> fContinuationTracks;
+  std::set<Int_t> fDecayedParentIDs;
 
   TFile* fout;               //!
   TClonesArray* fElectrons;  //!

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -47,7 +47,8 @@ ShipStack::ShipStack(Int_t size)
       fStoreSecondaries(kTRUE),
       fMinPoints(1),
       fEnergyCut(0.),
-      fStoreMothers(kTRUE) {
+      fStoreMothers(kTRUE),
+      fSplitting(kFALSE) {
   fTracks = new std::vector<ShipMCTrack>();
   fTracks->reserve(size);
 }
@@ -86,14 +87,33 @@ void ShipStack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode,
   // cout << "ShipStack:  " << fNParticles << " " << pdgCode << " " << parentId
   // <<    " " << secondparentID<<" "<<proc<< endl;
 
+  // update weight to correspond to parentWeight * weight for splitting cases
+  if (fSplitting) {
+    if (parentId >= 0) {
+      if (parentId < fParticles->GetEntriesFast()) {
+        TParticle* parentPart =
+            dynamic_cast<TParticle*>(fParticles->At(parentId));
+        if (parentPart) {
+          Double_t parentWeight = parentPart->GetWeight();
+          weight = weight * parentWeight;
+        }
+      }
+    }
+  }
+
+  Int_t trackId = fNParticles;
+
   // --> Get TParticle array
   TClonesArray& partArray = *fParticles;
 
-  // --> Create new TParticle and add it to the TParticle array
-  Int_t trackId = fNParticles;
+  // --> Set argument variable
+  ntr = trackId;
+
   Int_t nPoints = 0;
   Int_t daughter1Id = -1;
   Int_t daughter2Id = -1;
+
+  // --> Create new TParticle and add it to the TParticle array
   TParticle* particle = new (partArray[fNParticles++])
       TParticle(pdgCode, trackId, parentId, nPoints, daughter1Id, daughter2Id,
                 px, py, pz, e, vx, vy, vz, time);
@@ -118,12 +138,8 @@ void ShipStack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode,
   if (parentId < 0) {
     fNPrimaries++;
   }
-
-  // --> Set argument variable
-  ntr = trackId;
-
-  // --> Push particle on the stack if toBeDone is set
   if (toBeDone == 1) {
+    // --> Push particle on the stack if toBeDone is set
     particle->SetBit(kDoneBit);
     fStack.push(particle);
   }

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -153,6 +153,7 @@ class ShipStack : public FairGenericStack {
   void SetMinPoints(Int_t min) { fMinPoints = min; }
   void SetEnergyCut(Double_t eMin) { fEnergyCut = eMin; }
   void StoreMothers(Bool_t choice = kTRUE) { fStoreMothers = choice; }
+  void SetSplitting() { fSplitting = kTRUE; }
 
   /** Increment number of points for the current track in a given detector
    *@param iDet  Detector unique identifier
@@ -204,6 +205,7 @@ class ShipStack : public FairGenericStack {
   Int_t fMinPoints;
   Double32_t fEnergyCut;
   Bool_t fStoreMothers;
+  Bool_t fSplitting;
 
   /** Mark tracks for output using selection criteria  **/
   void SelectTracks();


### PR DESCRIPTION
Add option to split kaons and pions right before they decay. This allows to increase the number of muons (many muons post-HA stem from kaons and pions) in a smaller amount of time than that taken by increasing the number of PoTs.


## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added kaon/pion splitting controls to simulations via `--kaon-pion-splits` (default `0`, mapped to `KAON_PION_SPLITS`) and optional repeat mode `--multiple-kpi-splits`.
  * Enables more detailed kaon/pion splitting with per-event secondary-track propagation and continued tracks after non-decays.
* **Bug Fixes**
  * Improved splitting bookkeeping, track weighting, and veto-hit handling for decayed parents, with proper per-event reset behavior.
* **Documentation**
  * Updated the changelog to document the new kaon/pion splitting option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->