### PR TITLE
fix: prevent NaN mass/energy for photons in ShipMCTrack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ it in future.
 * Fix off-by-one in FixedTargetGenerator target node access
 * Fix uninitialised members in vetoHit, strawtubesHit, and ShipMuonShield
 * Change vetoHit and strawtubesHit flag member from Float_t to Bool_t to match actual usage
+* Fix NaN mass/energy for photons in ShipMCTrack due to floating-point rounding (#384)
 
 ### Changed
 

--- a/shipdata/ShipMCTrack.cxx
+++ b/shipdata/ShipMCTrack.cxx
@@ -83,7 +83,16 @@ ShipMCTrack::ShipMCTrack(TParticle* part)
       fPx(part->Px()),
       fPy(part->Py()),
       fPz(part->Pz()),
-      fM(TMath::Sqrt(part->Energy() * part->Energy() - part->P() * part->P())),
+      fM([](const TParticle* p) {
+        Double_t m2 = p->Energy() * p->Energy() - p->P() * p->P();
+        if (m2 >= 0.) return TMath::Sqrt(m2);
+        // Tiny negative: numerical noise for on-shell massless particle
+        Double_t e2 = p->Energy() * p->Energy();
+        if (-m2 < 1e-10 * e2) return 0.;
+        // Genuinely spacelike (virtual photon): store negative mass (ROOT
+        // convention)
+        return -TMath::Sqrt(-m2);
+      }(part)),
       fStartX(part->Vx()),
       fStartY(part->Vy()),
       fStartZ(part->Vz()),


### PR DESCRIPTION
Use IIFE in initialiser list to handle three cases for $E^2-P^2$: positive (normal sqrt), tiny negative (numerical noise, clamp to 0), and significantly negative (virtual/spacelike, store as negative mass per ROOT convention).

Closes #384

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
