### PR TITLE
Move TimeDetHit constants to static constexpr, saving 40 bytes per hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ it in future.
 * Fix uninitialised members in vetoHit, strawtubesHit, and ShipMuonShield
 * Change vetoHit and strawtubesHit flag member from Float_t to Bool_t to match actual usage
 * Fix NaN mass/energy for photons in ShipMCTrack due to floating-point rounding (#384)
+* Move TimeDetHit v_drift and par[] to static constexpr, saving 40 bytes per serialised hit (#685)
 
 ### Changed
 

--- a/TimeDet/TimeDetHit.cxx
+++ b/TimeDet/TimeDetHit.cxx
@@ -19,8 +19,9 @@
 using std::cout;
 using std::endl;
 
-Double_t speedOfLight =
-    TMath::C() * 100. / 1000000000.0;  // from m/sec to cm/ns
+namespace {
+constexpr Double_t speedOfLight = 29.9792458;  // TMath::C() * 100 / 1e9, cm/ns
+}  // namespace
 
 // -----   Default constructor   --------------
 TimeDetHit::TimeDetHit() : ShipHit() { flag = true; }

--- a/TimeDet/TimeDetHit.h
+++ b/TimeDet/TimeDetHit.h
@@ -56,13 +56,13 @@ class TimeDetHit : public ShipHit {
   bool isValid() const { return flag; }
 
  private:
-  Double_t v_drift = 15.;  // cm/ns
-  Double_t par[4] = {0.0272814, 109.303, 0, 0.0539487};
+  static constexpr Double_t v_drift = 15.;  // cm/ns
+  static constexpr Double_t par[4] = {0.0272814, 109.303, 0, 0.0539487};
 
   Float_t flag;      ///< flag
   Float_t t_1, t_2;  ///< TDC on both sides
 
-  ClassDef(TimeDetHit, 2);
+  ClassDef(TimeDetHit, 3);
 };
 
 #endif  // TIMEDET_TIMEDETHIT_H_

--- a/splitcal/splitcalHit.cxx
+++ b/splitcal/splitcalHit.cxx
@@ -26,8 +26,9 @@
 using std::cout;
 using std::endl;
 
-Double_t speedOfLight =
-    TMath::C() * 100. / 1000000000.0;  // from m/sec to cm/ns
+namespace {
+constexpr Double_t speedOfLight = 29.9792458;  // TMath::C() * 100 / 1e9, cm/ns
+}  // namespace
 // -----   Default constructor   -------------------------------------------
 splitcalHit::splitcalHit() : ShipHit() { flag = true; }
 // -----   Standard constructor   ------------------------------------------


### PR DESCRIPTION
v_drift and par[4] are physics constants that were stored as instance members, wasting 40 bytes per serialised hit. Move to static constexpr. Bump ClassDef version 2→3 for schema evolution. Also move file-scope speedOfLight globals in TimeDetHit.cxx and splitcalHit.cxx to anonymous namespace constants.

Closes #685

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
