### PR TITLE
Include MC point time in splitcalHit digitisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ it in future.
 * Move TimeDetHit v_drift and par[] to static constexpr, saving 40 bytes per serialised hit (#685)
 * Fix event display errors for nonexistent MC point branches (#900)
 * Fix digitisation crash when optional detector branches are missing (#738)
+* Fix splitcalHit dropping MC point arrival time in digitisation (#925)
 
 ### Changed
 

--- a/splitcal/splitcalHit.cxx
+++ b/splitcal/splitcalHit.cxx
@@ -60,8 +60,7 @@ splitcalHit::splitcalHit(const std::vector<splitcalPoint>& points, Double_t t0)
     pointE += point.GetEnergyLoss();
   }
 
-  // fdigi = t0 + t;
-  fdigi = t0;
+  fdigi = t0 + firstPoint.GetTime();
   // SetDigi(SetTimeRes(fdigi));
   SetDetectorID(detID);
 


### PR DESCRIPTION
The digitised time was set to just t0 (random event offset), dropping the MC truth arrival time. Now uses t0 + firstPoint.GetTime(), matching the TimeDetHit pattern.

Closes #925

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
