### PR TITLE
style: normalise include guard defines

### DIFF
--- a/SND/MTC/MTCDetHit.h
+++ b/SND/MTC/MTCDetHit.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SND_MTC_MTCDETHIT_H_
-#define SND_MTC_MTCDETHIT_H_ 1
+#define SND_MTC_MTCDETHIT_H_
 
 #include "MTCDetPoint.h"
 #include "ShipHit.h"

--- a/SND/MTC/MTCDetPoint.h
+++ b/SND/MTC/MTCDetPoint.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SND_MTC_MTCDETPOINT_H_
-#define SND_MTC_MTCDETPOINT_H_ 1
+#define SND_MTC_MTCDETPOINT_H_
 
 #include "FairMCPoint.h"
 #include "TObject.h"

--- a/SND/SiliconTarget/SiliconTargetHit.h
+++ b/SND/SiliconTarget/SiliconTargetHit.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SND_SILICONTARGET_SILICONTARGETHIT_H_
-#define SND_SILICONTARGET_SILICONTARGETHIT_H_ 1
+#define SND_SILICONTARGET_SILICONTARGETHIT_H_
 
 #include "ShipHit.h"
 #include "SiliconTargetPoint.h"

--- a/SND/SiliconTarget/SiliconTargetPoint.h
+++ b/SND/SiliconTarget/SiliconTargetPoint.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SND_SILICONTARGET_SILICONTARGETPOINT_H_
-#define SND_SILICONTARGET_SILICONTARGETPOINT_H_ 1
+#define SND_SILICONTARGET_SILICONTARGETPOINT_H_
 
 #include "FairMCPoint.h"
 #include "TObject.h"

--- a/TimeDet/TimeDetPoint.h
+++ b/TimeDet/TimeDetPoint.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef TIMEDET_TIMEDETPOINT_H_
-#define TIMEDET_TIMEDETPOINT_H_ 1
+#define TIMEDET_TIMEDETPOINT_H_
 
 #include <array>
 

--- a/field/ShipBellField.h
+++ b/field/ShipBellField.h
@@ -17,7 +17,7 @@
  **/
 
 #ifndef FIELD_SHIPBELLFIELD_H_
-#define FIELD_SHIPBELLFIELD_H_ 1
+#define FIELD_SHIPBELLFIELD_H_
 
 #include "FairField.h"
 

--- a/field/ShipConstField.h
+++ b/field/ShipConstField.h
@@ -16,7 +16,7 @@
  **/
 
 #ifndef FIELD_SHIPCONSTFIELD_H_
-#define FIELD_SHIPCONSTFIELD_H_ 1
+#define FIELD_SHIPCONSTFIELD_H_
 
 #include "FairField.h"
 

--- a/shipdata/ShipDetectorList.h
+++ b/shipdata/ShipDetectorList.h
@@ -9,7 +9,7 @@
 /** Defines unique identifier for all SHiP detector systems **/
 
 #ifndef SHIPDATA_SHIPDETECTORLIST_H_
-#define SHIPDATA_SHIPDETECTORLIST_H_ 1
+#define SHIPDATA_SHIPDETECTORLIST_H_
 
 // kSTOPHERE is needed for iteration over the enum. All detectors have to be put
 // before.

--- a/shipdata/ShipHit.h
+++ b/shipdata/ShipHit.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPDATA_SHIPHIT_H_
-#define SHIPDATA_SHIPHIT_H_ 1
+#define SHIPDATA_SHIPHIT_H_
 
 #include "Rtypes.h"    // for Double_t, Int_t, Double32_t, etc
 #include "TObject.h"   //

--- a/shipdata/ShipMCTrack.h
+++ b/shipdata/ShipMCTrack.h
@@ -13,7 +13,7 @@
  **/
 
 #ifndef SHIPDATA_SHIPMCTRACK_H_
-#define SHIPDATA_SHIPMCTRACK_H_ 1
+#define SHIPDATA_SHIPMCTRACK_H_
 
 #include "Rtypes.h"            // for Double_t, Int_t, Double32_t, etc
 #include "ShipDetectorList.h"  // for DetectorId

--- a/shipdata/ShipParticle.h
+++ b/shipdata/ShipParticle.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPDATA_SHIPPARTICLE_H_
-#define SHIPDATA_SHIPPARTICLE_H_ 1
+#define SHIPDATA_SHIPPARTICLE_H_
 
 #include <array>  // for std::array
 

--- a/shipgen/DPPythia8Generator.h
+++ b/shipgen/DPPythia8Generator.h
@@ -4,7 +4,7 @@
 
 #ifndef SHIPGEN_DPPYTHIA8GENERATOR_H_
 #define SHIPGEN_DPPYTHIA8GENERATOR_H_
-#define DPP8GENERATOR_H 1
+#define DPP8GENERATOR_H
 // Avoid the inclusion of dlfcn.h by Pyhtia.h that CINT is not able to process
 // #ifdef __CINT__
 // #define _DLFCN_H_

--- a/shipgen/EvtCalcGenerator.h
+++ b/shipgen/EvtCalcGenerator.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPGEN_EVTCALCGENERATOR_H_
-#define SHIPGEN_EVTCALCGENERATOR_H_ 1
+#define SHIPGEN_EVTCALCGENERATOR_H_
 
 #include <memory>
 

--- a/shipgen/Generator.h
+++ b/shipgen/Generator.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPGEN_GENERATOR_H_
-#define SHIPGEN_GENERATOR_H_ 1
+#define SHIPGEN_GENERATOR_H_
 
 #include <optional>
 #include <string>

--- a/shipgen/GenieGenerator.h
+++ b/shipgen/GenieGenerator.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPGEN_GENIEGENERATOR_H_
-#define SHIPGEN_GENIEGENERATOR_H_ 1
+#define SHIPGEN_GENIEGENERATOR_H_
 
 #include "FairLogger.h"  // for FairLogger, MESSAGE_ORIGIN
 #include "Generator.h"

--- a/shipgen/MuDISGenerator.h
+++ b/shipgen/MuDISGenerator.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPGEN_MUDISGENERATOR_H_
-#define SHIPGEN_MUDISGENERATOR_H_ 1
+#define SHIPGEN_MUDISGENERATOR_H_
 
 #include "FairLogger.h"  // for FairLogger, MESSAGE_ORIGIN
 #include "Generator.h"

--- a/shipgen/MuonBackGenerator.h
+++ b/shipgen/MuonBackGenerator.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPGEN_MUONBACKGENERATOR_H_
-#define SHIPGEN_MUONBACKGENERATOR_H_ 1
+#define SHIPGEN_MUONBACKGENERATOR_H_
 
 #include <vector>
 

--- a/shipgen/tPythia6Generator.h
+++ b/shipgen/tPythia6Generator.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef SHIPGEN_TPYTHIA6GENERATOR_H_
-#define SHIPGEN_TPYTHIA6GENERATOR_H_ 1
+#define SHIPGEN_TPYTHIA6GENERATOR_H_
 
 #include "Generator.h"
 #include "TPythia6.h"

--- a/strawtubes/strawtubesHit.h
+++ b/strawtubes/strawtubesHit.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef STRAWTUBES_STRAWTUBESHIT_H_
-#define STRAWTUBES_STRAWTUBESHIT_H_ 1
+#define STRAWTUBES_STRAWTUBESHIT_H_
 
 #include "ShipHit.h"
 #include "TObject.h"

--- a/veto/vetoHit.h
+++ b/veto/vetoHit.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef VETO_VETOHIT_H_
-#define VETO_VETOHIT_H_ 1
+#define VETO_VETOHIT_H_
 #include "ShipHit.h"
 
 class vetoPoint;

--- a/veto/vetoHitOnTrack.h
+++ b/veto/vetoHitOnTrack.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef VETO_VETOHITONTRACK_H_
-#define VETO_VETOHITONTRACK_H_ 1
+#define VETO_VETOHITONTRACK_H_
 
 #include "Rtypes.h"    // for Double_t, Int_t, Double32_t, etc
 #include "TObject.h"   //

--- a/veto/vetoPoint.h
+++ b/veto/vetoPoint.h
@@ -3,7 +3,7 @@
 // Collaboration
 
 #ifndef VETO_VETOPOINT_H_
-#define VETO_VETOPOINT_H_ 1
+#define VETO_VETOPOINT_H_
 
 #include <array>
 


### PR DESCRIPTION
Remove trailing ' 1' from #define guards in 22 headers for consistency.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
