### PR TITLE
Add override specifier to virtual methods

### DIFF
--- a/SND/EmulsionTarget/Target.h
+++ b/SND/EmulsionTarget/Target.h
@@ -34,7 +34,7 @@ class Target : public FairDetector, public ISTLPointContainer {
   Target(const char* name, const Double_t Ydist, Bool_t Active,
          const char* Title = "NuTauTarget");
   Target();
-  virtual ~Target();
+  ~Target() override;
 
   /**      Create the detector geometry        */
 
@@ -84,24 +84,24 @@ class Target : public FairDetector, public ISTLPointContainer {
       Double_t DZ);  // other detector's parameters (needed for positioning)
 
   /**      Initialization of the detector is done here    */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**       this method is called for each step during simulation
    *       (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager.     */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /**      has to be called after each event to reset the containers      */
-  virtual void Reset();
+  void Reset() override;
 
   /**      This method is an example of how to add your own point
    *       of type TargetPoint to the clones array
@@ -124,22 +124,22 @@ class Target : public FairDetector, public ISTLPointContainer {
    *  any optional action in your detector during the transport.
    */
 
-  virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) {
+  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override {
     ;
   }
-  virtual void SetSpecialPhysicsCuts() { ; }
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun() { ; }
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack() { ; }
-  virtual void BeginEvent() { ; }
+  void SetSpecialPhysicsCuts() override { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override { ; }
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override { ; }
+  void BeginEvent() override { ; }
 
   Target(const Target&);
   Target& operator=(const Target&);
 
- ClassDef(Target, 5)
+ ClassDefOverride(Target, 5)
 
      private :
 

--- a/SND/EmulsionTarget/TargetTracker.h
+++ b/SND/EmulsionTarget/TargetTracker.h
@@ -33,7 +33,7 @@ class TargetTracker : public FairDetector, public ISTLPointContainer {
   TargetTracker(const char* name, Double_t TTX, Double_t TTY, Double_t TTZ,
                 Bool_t Active, const char* Title = "TargetTrackers");
   TargetTracker();
-  virtual ~TargetTracker();
+  ~TargetTracker() override;
 
   void ConstructGeometry();
 
@@ -49,24 +49,24 @@ class TargetTracker : public FairDetector, public ISTLPointContainer {
   void SetDesign(Int_t Design);
 
   /**      Initialization of the detector is done here    */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**       this method is called for each step during simulation
    *       (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager.     */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /**      has to be called after each event to reset the containers      */
-  virtual void Reset();
+  void Reset() override;
 
   /**      This method is an example of how to add your own point
    *       of type TTPoint to the clones array
@@ -80,22 +80,22 @@ class TargetTracker : public FairDetector, public ISTLPointContainer {
    *  any optional action in your detector during the transport.
    */
 
-  virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) {
+  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override {
     ;
   }
-  virtual void SetSpecialPhysicsCuts() { ; }
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun() { ; }
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack() { ; }
-  virtual void BeginEvent() { ; }
+  void SetSpecialPhysicsCuts() override { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override { ; }
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override { ; }
+  void BeginEvent() override { ; }
 
   TargetTracker(const TargetTracker&);
   TargetTracker& operator=(const TargetTracker&);
 
-  ClassDef(TargetTracker, 4);
+  ClassDefOverride(TargetTracker, 4);
 
  private:
   /** Track information to be stored until the track leaves the

--- a/SND/MTC/MTCDetector.h
+++ b/SND/MTC/MTCDetector.h
@@ -31,7 +31,7 @@ class MTCDetector : public FairDetector, public ISTLPointContainer {
   MTCDetector(const char* name, Bool_t Active, const char* Title = "",
               Int_t DetId = 0);
   MTCDetector();
-  virtual ~MTCDetector();
+  ~MTCDetector() override;
 
   void SetMTCParameters(Double_t width, Double_t height, Double_t angle,
                         Double_t ironThick, Double_t sciFiThick,
@@ -48,8 +48,8 @@ class MTCDetector : public FairDetector, public ISTLPointContainer {
                                  TGeoVolumeAssembly* modMotherVol,
                                  Double_t width, Double_t height,
                                  Double_t thickness, Int_t LayerId);
-  virtual void ConstructGeometry();
-  virtual void Initialize();
+  void ConstructGeometry() override;
+  void Initialize() override;
   /** Get position of single fibre in global coordinate system**/
   void GetPosition(Int_t fDetectorID, TVector3& vLeft,
                    TVector3& vRight);  // or top and bottom
@@ -75,19 +75,19 @@ class MTCDetector : public FairDetector, public ISTLPointContainer {
   Int_t Get_NSiPMChan() const { return fNSiPMChan; }
   Float_t Get_SciFiActiveX() const { return fSciFiActiveX; }
   virtual void SiPMOverlap();
-  virtual Bool_t ProcessHits(FairVolume* vol = 0);
+  Bool_t ProcessHits(FairVolume* vol = 0) override;
   MTCDetPoint* AddHit(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
                       Double_t time, Double_t length, Double_t eLoss,
                       Int_t pdgCode);
 
-  virtual void Register();
-  virtual void EndOfEvent();
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  void Register() override;
+  void EndOfEvent() override;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
-  virtual void Reset();
+  void Reset() override;
 
  private:
   /** Track information to be stored until the track leaves the
@@ -149,7 +149,7 @@ class MTCDetector : public FairDetector, public ISTLPointContainer {
   MTCDetector(const MTCDetector&);
   MTCDetector& operator=(const MTCDetector&);
   Int_t InitMedium(const char* name);
-  ClassDef(MTCDetector, 3)
+  ClassDefOverride(MTCDetector, 3)
 };
 
 #endif  // SND_MTC_MTCDETECTOR_H_

--- a/SND/SiliconTarget/SiliconTarget.h
+++ b/SND/SiliconTarget/SiliconTarget.h
@@ -21,7 +21,7 @@ class SiliconTarget : public FairDetector, public ISTLPointContainer {
  public:
   SiliconTarget(const char* name, Bool_t Active, const char* Title = "");
   SiliconTarget();
-  virtual ~SiliconTarget();
+  ~SiliconTarget() override;
 
   void SetSiliconTargetParameters(Double_t targetWidth, Double_t targetHeight,
                                   Double_t sensorWidth, Double_t sensorLength,
@@ -34,27 +34,27 @@ class SiliconTarget : public FairDetector, public ISTLPointContainer {
                                   Double_t sensorLength, Double_t planeSpacing,
                                   TGeoMedium* material, Int_t layerId);
 
-  virtual void ConstructGeometry();
+  void ConstructGeometry() override;
   /** Initialization of the detector is done here */
-  virtual void Initialize();
+  void Initialize() override;
 
-  virtual Bool_t ProcessHits(FairVolume* vol = 0);
+  Bool_t ProcessHits(FairVolume* vol = 0) override;
 
   SiliconTargetPoint* AddHit(Int_t trackID, Int_t detID, TVector3 pos,
                              TVector3 mom, Double_t time, Double_t length,
                              Double_t eLoss, Int_t pdgCode);
 
   /** Registers the produced collections in FAIRRootManager */
-  virtual void Register();
-  virtual void EndOfEvent();
+  void Register() override;
+  void EndOfEvent() override;
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /** Has to be called after each event to reset the containers */
-  virtual void Reset();
+  void Reset() override;
 
  private:
   /** Track information to be stored until the track leaves the
@@ -84,7 +84,7 @@ class SiliconTarget : public FairDetector, public ISTLPointContainer {
   SiliconTarget(const SiliconTarget&);
   SiliconTarget& operator=(const SiliconTarget&);
   Int_t InitMedium(const char* name);
-  ClassDef(SiliconTarget, 1)
+  ClassDefOverride(SiliconTarget, 1)
 };
 
 #endif  // SND_SILICONTARGET_SILICONTARGET_H_

--- a/TimeDet/TimeDet.h
+++ b/TimeDet/TimeDet.h
@@ -29,27 +29,27 @@ class TimeDet : public FairDetector, public ISTLPointContainer {
   TimeDet();
 
   /** destructor */
-  virtual ~TimeDet();
+  ~TimeDet() override;
 
   /** Initialization of the detector is done here */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**   this method is called for each step during simulation
    *    (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager. */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /** has to be called after each event to reset the containers */
-  virtual void Reset();
+  void Reset() override;
 
   /** Sets detector position along z */
   void SetZposition(Double_t z) { fzPos = z; }
@@ -77,13 +77,13 @@ class TimeDet : public FairDetector, public ISTLPointContainer {
                        Double_t eLoss, Int_t pdgCode, TVector3 Lpos,
                        TVector3 Lmom);
 
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun() { ; }
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack() { ; }
-  virtual void BeginEvent() { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override { ; }
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override { ; }
+  void BeginEvent() override { ; }
 
  private:
   /** Track information to be stored until the track leaves the active volume.*/
@@ -128,7 +128,7 @@ class TimeDet : public FairDetector, public ISTLPointContainer {
   TimeDet& operator=(const TimeDet&);
   Int_t InitMedium(const char* name);
 
-  ClassDef(TimeDet, 4)
+  ClassDefOverride(TimeDet, 4)
 };
 
 #endif  // TIMEDET_TIMEDET_H_

--- a/UpstreamTagger/UpstreamTagger.h
+++ b/UpstreamTagger/UpstreamTagger.h
@@ -54,27 +54,27 @@ class UpstreamTagger : public FairDetector, public ISTLPointContainer {
   UpstreamTagger();
 
   /** destructor */
-  virtual ~UpstreamTagger();
+  ~UpstreamTagger() override;
 
   /** Initialization of the detector is done here */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**   this method is called for each step during simulation
    *    (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager. */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /** has to be called after each event to reset the containers */
-  virtual void Reset();
+  void Reset() override;
 
   /** Sets detector position and sizes */
   void SetZposition(Double_t z) { det_zPos = z; }
@@ -95,13 +95,13 @@ class UpstreamTagger : public FairDetector, public ISTLPointContainer {
                               Double_t length, Double_t eLoss, Int_t pdgCode,
                               TVector3 Lpos, TVector3 Lmom);
 
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun() { ; }
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack() { ; }
-  virtual void BeginEvent() { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override { ; }
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override { ; }
+  void BeginEvent() override { ; }
 
   Double_t module[11][3];  // x,y,z centre positions for each module
   // TODO Avoid 1-indexed array!
@@ -135,7 +135,7 @@ class UpstreamTagger : public FairDetector, public ISTLPointContainer {
   UpstreamTagger& operator=(const UpstreamTagger&);
   Int_t InitMedium(const char* name);
 
-  ClassDef(UpstreamTagger, 2)
+  ClassDefOverride(UpstreamTagger, 2)
 };
 
 #endif  // UPSTREAMTAGGER_UPSTREAMTAGGER_H_

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -31,24 +31,24 @@ class exitHadronAbsorber : public FairDetector, public ISTLPointContainer {
   exitHadronAbsorber();
 
   /**       destructor     */
-  virtual ~exitHadronAbsorber();
+  ~exitHadronAbsorber() override;
 
   /**      Initialization of the detector is done here    */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**       this method is called for each step during simulation
    *       (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager.     */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /**      has to be called after each event to reset the containers      */
-  virtual void Reset();
+  void Reset() override;
 
   /**      Update track indices in points after track pruning      */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
@@ -60,17 +60,17 @@ class exitHadronAbsorber : public FairDetector, public ISTLPointContainer {
    *  any optional action in your detector during the transport.
    */
 
-  virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) {
+  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override {
     ;
   }
-  virtual void SetSpecialPhysicsCuts() { ; }
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun();
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack();
-  virtual void BeginEvent() { ; }
+  void SetSpecialPhysicsCuts() override { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override;
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override;
+  void BeginEvent() override { ; }
 
   vetoPoint* AddHit(Int_t eventID, Int_t trackID, Int_t detID, TVector3 pos,
                     TVector3 mom, Double_t time, Double_t length,
@@ -120,7 +120,7 @@ class exitHadronAbsorber : public FairDetector, public ISTLPointContainer {
   Int_t index;
   /** container for data points */
   std::vector<vetoPoint>* fexitHadronAbsorberPointCollection;
-  ClassDef(exitHadronAbsorber, 0)
+  ClassDefOverride(exitHadronAbsorber, 0)
 };
 
 #endif  // MUONSHIELDOPTIMIZATION_EXITHADRONABSORBER_H_

--- a/muonShieldOptimization/pyFairModule.h
+++ b/muonShieldOptimization/pyFairModule.h
@@ -15,14 +15,14 @@ void call_python_method(PyObject* self, const char* method);
 class pyFairModule : public FairModule {
  public:
   explicit pyFairModule(PyObject* self) : fSelf(self) {}
-  virtual ~pyFairModule() {}
-  virtual void ConstructGeometry() {
+  ~pyFairModule() override = default;
+  void ConstructGeometry() override {
     call_python_method(fSelf, "ConstructGeometry");
   }
 
  private:
   PyObject* fSelf;
-  ClassDef(pyFairModule, 0)
+  ClassDefOverride(pyFairModule, 0)
 };
 
 #endif  // MUONSHIELDOPTIMIZATION_PYFAIRMODULE_H_

--- a/shipdata/ShipHit.h
+++ b/shipdata/ShipHit.h
@@ -32,13 +32,13 @@ class ShipHit : public TObject {
   void SetDetectorID(Int_t detID) { fDetectorID = detID; }
 
   /*** Output to screen */
-  virtual void Print(const Option_t* opt = "") const { ; }
+  void Print(const Option_t* opt = "") const override { ; }
 
  protected:
   Float_t fdigi;      ///< digitized detector hit
   Int_t fDetectorID;  ///< Detector unique identifier
 
-  ClassDef(ShipHit, 2);
+  ClassDefOverride(ShipHit, 2);
 };
 
 #endif  // SHIPDATA_SHIPHIT_H_

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -53,7 +53,7 @@ class ShipStack : public FairGenericStack {
   explicit ShipStack(Int_t size = 100);
 
   /** Destructor  **/
-  virtual ~ShipStack();
+  ~ShipStack() override;
 
   /** Add a TParticle to the stack.
    ** Declared in TVirtualMCStack
@@ -70,79 +70,77 @@ class ShipStack : public FairGenericStack {
    *@param weight    Particle weight
    *@param is        Generation status code (whatever that means)
    **/
-  virtual void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode,
-                         Double_t px, Double_t py, Double_t pz, Double_t e,
-                         Double_t vx, Double_t vy, Double_t vz, Double_t time,
-                         Double_t polx, Double_t poly, Double_t polz,
-                         TMCProcess proc, Int_t& ntr, Double_t weight,
-                         Int_t is);
+  void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px,
+                 Double_t py, Double_t pz, Double_t e, Double_t vx, Double_t vy,
+                 Double_t vz, Double_t time, Double_t polx, Double_t poly,
+                 Double_t polz, TMCProcess proc, Int_t& ntr, Double_t weight,
+                 Int_t is) override;
 
-  virtual void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode,
-                         Double_t px, Double_t py, Double_t pz, Double_t e,
-                         Double_t vx, Double_t vy, Double_t vz, Double_t time,
-                         Double_t polx, Double_t poly, Double_t polz,
-                         TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is,
-                         Int_t secondParentId);
+  void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px,
+                 Double_t py, Double_t pz, Double_t e, Double_t vx, Double_t vy,
+                 Double_t vz, Double_t time, Double_t polx, Double_t poly,
+                 Double_t polz, TMCProcess proc, Int_t& ntr, Double_t weight,
+                 Int_t is, Int_t secondParentId) override;
 
   /** Get next particle for tracking from the stack.
    ** Declared in TVirtualMCStack
    *@param  iTrack  index of popped track (return)
    *@return Pointer to the TParticle of the track
    **/
-  virtual TParticle* PopNextTrack(Int_t& iTrack);
+  TParticle* PopNextTrack(Int_t& iTrack) override;
 
   /** Get primary particle by index for tracking from stack
    ** Declared in TVirtualMCStack
    *@param  iPrim   index of primary particle
    *@return Pointer to the TParticle of the track
    **/
-  virtual TParticle* PopPrimaryForTracking(Int_t iPrim);
+  TParticle* PopPrimaryForTracking(Int_t iPrim) override;
 
   /** Set the current track number
    ** Declared in TVirtualMCStack
    *@param iTrack  track number
    **/
-  virtual void SetCurrentTrack(Int_t iTrack) { fCurrentTrack = iTrack; }
+  void SetCurrentTrack(Int_t iTrack) override { fCurrentTrack = iTrack; }
 
   /** Get total number of tracks
    ** Declared in TVirtualMCStack
    **/
-  virtual Int_t GetNtrack() const { return fNParticles; }
+  Int_t GetNtrack() const override { return fNParticles; }
 
   /** Get number of primary tracks
    ** Declared in TVirtualMCStack
    **/
-  virtual Int_t GetNprimary() const { return fNPrimaries; }
+  Int_t GetNprimary() const override { return fNPrimaries; }
 
   /** Get the current track's particle
    ** Declared in TVirtualMCStack
    **/
-  virtual TParticle* GetCurrentTrack() const;
+  TParticle* GetCurrentTrack() const override;
 
   /** Get the number of the current track
    ** Declared in TVirtualMCStack
    **/
-  virtual Int_t GetCurrentTrackNumber() const { return fCurrentTrack; }
+  Int_t GetCurrentTrackNumber() const override { return fCurrentTrack; }
 
   /** Get the track number of the parent of the current track
    ** Declared in TVirtualMCStack
    **/
-  virtual Int_t GetCurrentParentTrackNumber() const;
+  Int_t GetCurrentParentTrackNumber() const override;
 
   /** Add a TParticle to the fParticles array **/
-  virtual void AddParticle(TParticle* part);
+  void AddParticle(TParticle* part);
 
   /** Fill the MCTrack output array, applying filter criteria **/
-  virtual void FillTrackArray();
+  void FillTrackArray() override;
 
   /** Update the track index in the MCTracks and MCPoints **/
-  virtual void UpdateTrackIndex(TRefArray* detArray = 0);
+  void UpdateTrackIndex(TRefArray* detArray = 0) override;
 
   /** Resets arrays and stack and deletes particles and tracks **/
-  virtual void Reset();
+  void Reset() override;
 
   /** Register the MCTrack array to the Root Manager  **/
-  virtual void Register();
+  void Register() override;
 
   /** Output to screen
    **@param iVerbose: 0=events summary, 1=track info
@@ -212,7 +210,7 @@ class ShipStack : public FairGenericStack {
   ShipStack(const ShipStack&);
   ShipStack& operator=(const ShipStack&);
 
-  ClassDef(ShipStack, 1)
+  ClassDefOverride(ShipStack, 1)
 };
 
 #endif  // SHIPDATA_SHIPSTACK_H_

--- a/shipdata/TrackInfo.h
+++ b/shipdata/TrackInfo.h
@@ -23,7 +23,7 @@ class TrackInfo : public TObject {
   TrackInfo(const TrackInfo& ti);
 
   /** Destructor **/
-  virtual ~TrackInfo();
+  ~TrackInfo() override;
 
   /** Accessors **/
   unsigned int N() const { return fDetIDs.size(); }
@@ -32,13 +32,13 @@ class TrackInfo : public TObject {
   float wR(Int_t n) const { return fWR[n]; }
 
   /*** Output to screen */
-  virtual void Print(const Option_t* opt = "") const { ; }
+  void Print(const Option_t* opt = "") const override { ; }
 
  protected:
   std::vector<unsigned int> fDetIDs;  ///< array of measurements
   std::vector<float> fWL;
   std::vector<float> fWR;
-  ClassDef(TrackInfo, 2);
+  ClassDefOverride(TrackInfo, 2);
 };
 
 #endif  // SHIPDATA_TRACKINFO_H_

--- a/splitcal/splitcal.h
+++ b/splitcal/splitcal.h
@@ -29,27 +29,27 @@ class splitcal : public FairDetector, public ISTLPointContainer {
   splitcal();
 
   /**       destructor     */
-  virtual ~splitcal();
+  ~splitcal() override;
 
   /**      Initialization of the detector is done here    */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**       this method is called for each step during simulation
    *       (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager.     */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /**      has to be called after each event to reset the containers      */
-  virtual void Reset();
+  void Reset() override;
 
   void SetZStart(Double_t ZStart);
   void SetEmpty(Double_t Empty, Double_t BigGap, Double_t ActiveECAL_gas_gap,
@@ -92,17 +92,17 @@ class splitcal : public FairDetector, public ISTLPointContainer {
    *  any optional action in your detector during the transport.
    */
 
-  virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) {
+  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override {
     ;
   }
-  virtual void SetSpecialPhysicsCuts() { ; }
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun() { ; }
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack() { ; }
-  virtual void BeginEvent() { ; }
+  void SetSpecialPhysicsCuts() override { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override { ; }
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override { ; }
+  void BeginEvent() override { ; }
 
  private:
   /** Track information to be stored until the track leaves the
@@ -141,7 +141,7 @@ class splitcal : public FairDetector, public ISTLPointContainer {
   splitcal& operator=(const splitcal&);
   Int_t InitMedium(const char* name);
 
-  ClassDef(splitcal, 2)
+  ClassDefOverride(splitcal, 2)
 };
 
 #endif  // SPLITCAL_SPLITCAL_H_

--- a/strawtubes/Tracklet.h
+++ b/strawtubes/Tracklet.h
@@ -33,7 +33,7 @@ class Tracklet : public TObject {
            const std::vector<strawtubesHit>& container);
 
   /** Destructor **/
-  virtual ~Tracklet();
+  ~Tracklet() override;
 
   std::vector<unsigned int>* getList() { return &aTracklet; }
   const std::vector<unsigned int>& getIndices() const { return aTracklet; }
@@ -44,12 +44,12 @@ class Tracklet : public TObject {
       Float_t min);  // give back MCTrack ID with max matched strawtubesHits
 
   /*** Output to screen */
-  virtual void Print(const Option_t* opt = "") const { ; }
+  void Print(const Option_t* opt = "") const override { ; }
 
  protected:
   std::vector<unsigned int> aTracklet;  ///< list of indices
   Int_t flag;  // reserved for type of tracklet  ///< type of tracklet
-  ClassDef(Tracklet, 2);
+  ClassDefOverride(Tracklet, 2);
 };
 
 #endif  // STRAWTUBES_TRACKLET_H_

--- a/strawtubes/strawtubes.h
+++ b/strawtubes/strawtubes.h
@@ -32,27 +32,27 @@ class strawtubes : public FairDetector, public ISTLPointContainer {
   strawtubes();
 
   /**       destructor     */
-  virtual ~strawtubes();
+  ~strawtubes() override;
 
   /**      Initialization of the detector is done here    */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**       this method is called for each step during simulation
    *       (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager.     */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /**      has to be called after each event to reset the containers      */
-  virtual void Reset();
+  void Reset() override;
 
   void SetzPositions(Double_t z1, Double_t z2, Double_t z3, Double_t z4);
   void SetApertureArea(Double_t width, Double_t height);
@@ -89,17 +89,17 @@ class strawtubes : public FairDetector, public ISTLPointContainer {
    *  any optional action in your detector during the transport.
    */
 
-  virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) {
+  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override {
     ;
   }
-  virtual void SetSpecialPhysicsCuts() { ; }
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun() { ; }
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack() { ; }
-  virtual void BeginEvent() { ; }
+  void SetSpecialPhysicsCuts() override { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override { ; }
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override { ; }
+  void BeginEvent() override { ; }
 
  private:
   /** Track information to be stored until the track leaves the
@@ -141,7 +141,7 @@ class strawtubes : public FairDetector, public ISTLPointContainer {
   strawtubes(const strawtubes&);
   strawtubes& operator=(const strawtubes&);
   Int_t InitMedium(const char* name);
-  ClassDef(strawtubes, 7)
+  ClassDefOverride(strawtubes, 7)
 };
 
 #endif  // STRAWTUBES_STRAWTUBES_H_

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -37,27 +37,27 @@ class veto : public FairDetector, public ISTLPointContainer {
   veto();
 
   /**       destructor     */
-  virtual ~veto();
+  ~veto() override;
 
   /**      Initialization of the detector is done here    */
-  virtual void Initialize();
+  void Initialize() override;
 
   /**       this method is called for each step during simulation
    *       (see FairMCApplication::Stepping())
    */
-  virtual Bool_t ProcessHits(FairVolume* v = 0);
+  Bool_t ProcessHits(FairVolume* v = 0) override;
 
   /**       Registers the produced collections in FAIRRootManager.     */
-  virtual void Register();
+  void Register() override;
 
   /** Gets the produced collections */
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
   /** Update track indices in point collection (for std::vector migration) */
   void UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap);
 
   /**      has to be called after each event to reset the containers      */
-  virtual void Reset();
+  void Reset() override;
 
   void SetFastMuon() { fFastMuon = true; }  // kill all tracks except of muons
   void SetFollowMuon() {
@@ -100,17 +100,17 @@ class veto : public FairDetector, public ISTLPointContainer {
    *  any optional action in your detector during the transport.
    */
 
-  virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) {
+  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override {
     ;
   }
-  virtual void SetSpecialPhysicsCuts() { ; }
-  virtual void EndOfEvent();
-  virtual void FinishPrimary() { ; }
-  virtual void FinishRun() { ; }
-  virtual void BeginPrimary() { ; }
-  virtual void PostTrack() { ; }
-  virtual void PreTrack();
-  virtual void BeginEvent() { ; }
+  void SetSpecialPhysicsCuts() override { ; }
+  void EndOfEvent() override;
+  void FinishPrimary() override { ; }
+  void FinishRun() override { ; }
+  void BeginPrimary() override { ; }
+  void PostTrack() override { ; }
+  void PreTrack() override;
+  void BeginEvent() override { ; }
 
   inline void SetUseSupport(Int_t use = 1) { fUseSupport = use; }
   inline Int_t GetUseSupport() const { return fUseSupport; }
@@ -253,7 +253,7 @@ class veto : public FairDetector, public ISTLPointContainer {
 
   TGeoVolume* MakeSegments();
 
-  ClassDef(veto, 2)
+  ClassDefOverride(veto, 2)
 };
 
 #endif  // VETO_VETO_H_


### PR DESCRIPTION
Replace 'virtual ReturnType Method(...)' with 'ReturnType Method(...) override' on all overriding methods in detector and data class headers. Destructors use '~Foo() override' or '~Foo() override = default' as appropriate.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
