### PR TITLE
Extract duplicated InitMedium and UpdatePointTrackIndices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ it in future.
 
 ### Changed
 
+* Extract duplicated `InitMedium` into `ShipGeo::InitMedium` free function (shipdata/ShipGeoUtil.h)
+* Extract duplicated `UpdatePointTrackIndices` loop into `UpdatePointTrackIndicesImpl` template (shipdata/ISTLPointContainer.h)
 * Expand ruff lint rules (B, C4, SIM, UP, RUF) and fix all detected issues
 * Replace bare `except:` with specific exception types in core modules
 * Expand mypy pre-commit coverage to rootUtils, geomGeant4, readDecayTable, geometry_config, shipDigiReco

--- a/SND/EmulsionTarget/Target.cxx
+++ b/SND/EmulsionTarget/Target.cxx
@@ -34,6 +34,7 @@
 #include "FairRuntimeDb.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "ShipUnit.h"
 #include "TClonesArray.h"
@@ -93,24 +94,6 @@ Target::~Target() {
 }
 
 void Target::Initialize() { FairDetector::Initialize(); }
-
-// -----   Private method InitMedium
-Int_t Target::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-  return geoBuild->createMedium(ShipMedium);
-}
 
 //--------------Options for detector construction
 void Target::SetDetectorDesign(Int_t Design) {
@@ -213,13 +196,13 @@ void Target::SetHpTParam(Int_t n, Double_t dd,
 void Target::ConstructGeometry() {
   // cout << "Design = " << fDesign << endl;
 
-  InitMedium("air");
+  ShipGeo::InitMedium("air");
   TGeoMedium* air = gGeoManager->GetMedium("air");
 
-  InitMedium("PlasticBase");
+  ShipGeo::InitMedium("PlasticBase");
   TGeoMedium* PBase = gGeoManager->GetMedium("PlasticBase");
 
-  InitMedium("NuclearEmulsion");
+  ShipGeo::InitMedium("NuclearEmulsion");
   TGeoMedium* NEmu = gGeoManager->GetMedium("NuclearEmulsion");
 
   TGeoMaterial* NEmuMat =
@@ -247,7 +230,7 @@ void Target::ConstructGeometry() {
 
   TGeoMedium* Emufilm = new TGeoMedium("EmulsionFilm", 100, emufilmmixture);
 
-  InitMedium("tungsten");
+  ShipGeo::InitMedium("tungsten");
   TGeoMedium* tungsten = gGeoManager->GetMedium("tungsten");
 
   Int_t NPlates = number_of_plates;  // Number of doublets emulsion + Pb
@@ -526,14 +509,7 @@ void Target::Register() {
 TClonesArray* Target::GetCollection(Int_t iColl) const { return nullptr; }
 
 void Target::UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fTargetPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fTargetPoints, indexMap);
 }
 
 void Target::Reset() { fTargetPoints->clear(); }

--- a/SND/EmulsionTarget/Target.h
+++ b/SND/EmulsionTarget/Target.h
@@ -231,8 +231,6 @@ class Target : public FairDetector, public ISTLPointContainer {
   Double_t fHpTDistance;
   Double_t fHpTDZ;
   Int_t fnHpT;
-
-  Int_t InitMedium(const char* name);
 };
 
 #endif  // SND_EMULSIONTARGET_TARGET_H_

--- a/SND/EmulsionTarget/TargetTracker.cxx
+++ b/SND/EmulsionTarget/TargetTracker.cxx
@@ -32,6 +32,7 @@
 #include "FairRuntimeDb.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "ShipUnit.h"
 #include "TClonesArray.h"
@@ -93,24 +94,6 @@ TargetTracker::~TargetTracker() {
 
 void TargetTracker::Initialize() { FairDetector::Initialize(); }
 
-// -----   Private method InitMedium
-Int_t TargetTracker::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-  return geoBuild->createMedium(ShipMedium);
-}
-
 void TargetTracker::SetSciFiParam(Double_t scifimat_width_,
                                   Double_t scifimat_hor_,
                                   Double_t scifimat_vert_, Double_t scifimat_z_,
@@ -144,16 +127,16 @@ void TargetTracker::SetNumberTT(Int_t n) { fNTT = n; }
 void TargetTracker::SetDesign(Int_t Design) { fDesign = Design; }
 
 void TargetTracker::ConstructGeometry() {
-  InitMedium("vacuum");
+  ShipGeo::InitMedium("vacuum");
   TGeoMedium* vacuum = gGeoManager->GetMedium("vacuum");
 
-  InitMedium("CarbonComposite");
+  ShipGeo::InitMedium("CarbonComposite");
   TGeoMedium* CarbonComposite = gGeoManager->GetMedium("CarbonComposite");
 
-  InitMedium("SciFiMat");
+  ShipGeo::InitMedium("SciFiMat");
   TGeoMedium* SciFiMat = gGeoManager->GetMedium("SciFiMat");
 
-  InitMedium("Airex");
+  ShipGeo::InitMedium("Airex");
   TGeoMedium* Airex = gGeoManager->GetMedium("Airex");
 
   // Target Tracker
@@ -340,14 +323,7 @@ TClonesArray* TargetTracker::GetCollection(Int_t iColl) const {
 
 void TargetTracker::UpdatePointTrackIndices(
     const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fTTPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fTTPoints, indexMap);
 }
 
 void TargetTracker::Reset() { fTTPoints->clear(); }

--- a/SND/EmulsionTarget/TargetTracker.h
+++ b/SND/EmulsionTarget/TargetTracker.h
@@ -132,8 +132,6 @@ class TargetTracker : public FairDetector, public ISTLPointContainer {
   Int_t fNTT;  // number of TT
 
   Int_t fDesign;
-
-  Int_t InitMedium(const char* name);
 };
 
 #endif  // SND_EMULSIONTARGET_TARGETTRACKER_H_

--- a/SND/MTC/MTCDetector.cxx
+++ b/SND/MTC/MTCDetector.cxx
@@ -8,6 +8,7 @@
 #include "FairLink.h"
 #include "MTCDetPoint.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "ShipUnit.h"
 
@@ -170,24 +171,6 @@ MTCDetector::~MTCDetector() {
     fMTCDetectorPoints->clear();
     delete fMTCDetectorPoints;
   }
-}
-
-// -----   Private method InitMedium
-Int_t MTCDetector::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-  return geoBuild->createMedium(ShipMedium);
 }
 
 void MTCDetector::SetMTCParameters(Double_t w, Double_t h, Double_t angle,
@@ -357,15 +340,15 @@ void MTCDetector::CreateSciFiModule(const char* name,
 
 void MTCDetector::ConstructGeometry() {
   // Initialize media (using FairROOT's interface)
-  InitMedium("SciFiMat");
-  InitMedium("Epoxy");
-  InitMedium("air");
+  ShipGeo::InitMedium("SciFiMat");
+  ShipGeo::InitMedium("Epoxy");
+  ShipGeo::InitMedium("air");
   TGeoMedium* air = gGeoManager->GetMedium("air");
   TGeoMedium* ironMed = gGeoManager->GetMedium("iron");
   // For the scintillator, you may use the same medium as SciFiMat or another if
   // defined.
   TGeoMedium* scintMed = gGeoManager->GetMedium("SciFiMat");
-  InitMedium("silicon");
+  ShipGeo::InitMedium("silicon");
 
   // Define the module spacing based on three sublayers:
   //   fIronThick (outer iron), fSciFiThick (SciFi module/fiber module),
@@ -800,14 +783,7 @@ TClonesArray* MTCDetector::GetCollection(Int_t iColl) const { return nullptr; }
 
 void MTCDetector::UpdatePointTrackIndices(
     const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fMTCDetectorPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fMTCDetectorPoints, indexMap);
 }
 
 void MTCDetector::Reset() { fMTCDetectorPoints->clear(); }

--- a/SND/MTC/MTCDetector.h
+++ b/SND/MTC/MTCDetector.h
@@ -148,7 +148,6 @@ class MTCDetector : public FairDetector, public ISTLPointContainer {
 
   MTCDetector(const MTCDetector&) = delete;
   MTCDetector& operator=(const MTCDetector&) = delete;
-  Int_t InitMedium(const char* name);
   ClassDefOverride(MTCDetector, 3)
 };
 

--- a/SND/SiliconTarget/SiliconTarget.cxx
+++ b/SND/SiliconTarget/SiliconTarget.cxx
@@ -6,6 +6,7 @@
 
 #include "FairLink.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "ShipUnit.h"
 #include "SiliconTargetPoint.h"
@@ -73,24 +74,6 @@ SiliconTarget::~SiliconTarget() {
 }
 
 void SiliconTarget::Initialize() { FairDetector::Initialize(); }
-
-// -----   Private method InitMedium
-Int_t SiliconTarget::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-  return geoBuild->createMedium(ShipMedium);
-}
 
 void SiliconTarget::SetSiliconTargetParameters(
     Double_t targetWidth, Double_t targetHeight, Double_t sensorWidth,
@@ -161,11 +144,11 @@ TGeoVolume* SiliconTarget::CreateSiliconPlanes(const char* name, Double_t width,
   return trackingStation;
 }
 void SiliconTarget::ConstructGeometry() {
-  InitMedium("tungstenalloySND");
+  ShipGeo::InitMedium("tungstenalloySND");
   TGeoMedium* tungsten = gGeoManager->GetMedium("tungstenalloySND");
-  InitMedium("air");
+  ShipGeo::InitMedium("air");
   TGeoMedium* air = gGeoManager->GetMedium("air");
-  InitMedium("silicon");
+  ShipGeo::InitMedium("silicon");
   TGeoMedium* Silicon = gGeoManager->GetMedium("silicon");
 
   Double_t totalLength = fLayers * fTargetSpacing;
@@ -273,14 +256,7 @@ TClonesArray* SiliconTarget::GetCollection(Int_t iColl) const {
 
 void SiliconTarget::UpdatePointTrackIndices(
     const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fSiliconTargetPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fSiliconTargetPoints, indexMap);
 }
 
 void SiliconTarget::Reset() { fSiliconTargetPoints->clear(); }

--- a/SND/SiliconTarget/SiliconTarget.h
+++ b/SND/SiliconTarget/SiliconTarget.h
@@ -83,7 +83,6 @@ class SiliconTarget : public FairDetector, public ISTLPointContainer {
 
   SiliconTarget(const SiliconTarget&) = delete;
   SiliconTarget& operator=(const SiliconTarget&) = delete;
-  Int_t InitMedium(const char* name);
   ClassDefOverride(SiliconTarget, 1)
 };
 

--- a/TimeDet/TimeDet.cxx
+++ b/TimeDet/TimeDet.cxx
@@ -23,6 +23,7 @@
 #include "FairRuntimeDb.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "TClonesArray.h"
 #include "TGeoBBox.h"
@@ -124,26 +125,6 @@ TimeDet::~TimeDet() {
   }
 }
 
-Int_t TimeDet::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-
-  return geoBuild->createMedium(ShipMedium);
-
-  return 0;
-}
-
 Bool_t TimeDet::ProcessHits(FairVolume* vol) {
   /** This method is called from the MC stepping */
   // Set parameters at entrance of volume. Reset ELoss.
@@ -219,14 +200,7 @@ void TimeDet::Register() {
 TClonesArray* TimeDet::GetCollection(Int_t iColl) const { return nullptr; }
 
 void TimeDet::UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fTimeDetPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fTimeDetPoints, indexMap);
 }
 
 void TimeDet::Reset() { fTimeDetPoints->clear(); }
@@ -234,7 +208,7 @@ void TimeDet::Reset() { fTimeDetPoints->clear(); }
 void TimeDet::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
 
-  InitMedium("polyvinyltoluene");
+  ShipGeo::InitMedium("polyvinyltoluene");
   TGeoMedium* Scint = gGeoManager->GetMedium("polyvinyltoluene");
 
   ///////////////////////////////////////////////////////

--- a/TimeDet/TimeDet.h
+++ b/TimeDet/TimeDet.h
@@ -126,8 +126,6 @@ class TimeDet : public FairDetector, public ISTLPointContainer {
 
   TimeDet(const TimeDet&) = delete;
   TimeDet& operator=(const TimeDet&) = delete;
-  Int_t InitMedium(const char* name);
-
   ClassDefOverride(TimeDet, 4)
 };
 

--- a/UpstreamTagger/UpstreamTagger.cxx
+++ b/UpstreamTagger/UpstreamTagger.cxx
@@ -24,6 +24,7 @@
 #include "FairRuntimeDb.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "TClonesArray.h"
 #include "TGeoBBox.h"
@@ -89,26 +90,6 @@ UpstreamTagger::~UpstreamTagger() {
     fUpstreamTaggerPoints->clear();
     delete fUpstreamTaggerPoints;
   }
-}
-
-Int_t UpstreamTagger::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-
-  return geoBuild->createMedium(ShipMedium);
-
-  return 0;
 }
 
 Bool_t UpstreamTagger::ProcessHits(FairVolume* vol) {
@@ -186,14 +167,7 @@ TClonesArray* UpstreamTagger::GetCollection(Int_t iColl) const {
 
 void UpstreamTagger::UpdatePointTrackIndices(
     const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fUpstreamTaggerPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fUpstreamTaggerPoints, indexMap);
 }
 
 void UpstreamTagger::Reset() { fUpstreamTaggerPoints->clear(); }
@@ -207,7 +181,7 @@ void UpstreamTagger::ConstructGeometry() {
 
   ///////////////////////////////////////////////////////
 
-  InitMedium("vacuum");
+  ShipGeo::InitMedium("vacuum");
   TGeoMedium* Vacuum_box = gGeoManager->GetMedium("vacuum");
   ///////////////////////////////////////////////////////////////////
 

--- a/UpstreamTagger/UpstreamTagger.h
+++ b/UpstreamTagger/UpstreamTagger.h
@@ -133,8 +133,6 @@ class UpstreamTagger : public FairDetector, public ISTLPointContainer {
 
   UpstreamTagger(const UpstreamTagger&) = delete;
   UpstreamTagger& operator=(const UpstreamTagger&) = delete;
-  Int_t InitMedium(const char* name);
-
   ClassDefOverride(UpstreamTagger, 2)
 };
 

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -392,12 +392,5 @@ void exitHadronAbsorber::Reset() {
 
 void exitHadronAbsorber::UpdatePointTrackIndices(
     const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fexitHadronAbsorberPointCollection) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fexitHadronAbsorberPointCollection, indexMap);
 }

--- a/passive/ShipCave.cxx
+++ b/passive/ShipCave.cxx
@@ -10,6 +10,7 @@
 #include "FairGeoLoader.h"     // for FairGeoLoader
 #include "FairGeoMedia.h"
 #include "ShipGeoCave.h"  // for ShipGeoCave
+#include "ShipGeoUtil.h"
 #include "ShipUnit.h"
 #include "TGeoBBox.h"
 #include "TGeoCompositeShape.h"
@@ -24,21 +25,6 @@ ShipCave::ShipCave(Double_t z) : FairModule("Cave", "ShipCave") {
   z_end_of_proximity_shielding = z;
 }
 
-Int_t ShipCave::InitMedium(TString name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium)
-    Fatal("InitMedium", "Material %s not defined in media file.", name.Data());
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium) return ShipMedium->getMediumIndex();
-  return geoBuild->createMedium(ShipMedium);
-}
-
 void ShipCave::ConstructGeometry() {
   FairGeoLoader* loader = FairGeoLoader::Instance();
   FairGeoInterface* GeoInterface = loader->getGeoInterface();
@@ -50,7 +36,7 @@ void ShipCave::ConstructGeometry() {
     MGeo->create(loader->getGeoBuilder());
   }
   TGeoVolume* top = gGeoManager->GetTopVolume();
-  InitMedium("Concrete");
+  ShipGeo::InitMedium("Concrete");
   TGeoMedium* concrete = gGeoManager->GetMedium("Concrete");
 
   Double_t TCC8_length = 170 * m;

--- a/passive/ShipCave.h
+++ b/passive/ShipCave.h
@@ -19,7 +19,6 @@ class ShipCave : public FairModule {
  private:
   Double_t z_end_of_proximity_shielding;
   Double_t world[3];
-  Int_t InitMedium(TString name);
 
  public:
   ClassDef(ShipCave, 1)

--- a/passive/ShipMagnet.cxx
+++ b/passive/ShipMagnet.cxx
@@ -6,6 +6,7 @@
 
 #include "FairRun.h"        // for FairRun
 #include "FairRuntimeDb.h"  // for FairRuntimeDb
+#include "ShipGeoUtil.h"
 #include "TGeoManager.h"
 // #include "FairGeoMedia.h"
 // #include "FairGeoBuilder.h"
@@ -44,24 +45,6 @@ ShipMagnet::ShipMagnet(const char* name, const char* Title, Double_t z, Int_t c,
   CoilThick = CT;
 }
 
-// -----   Private method InitMedium
-Int_t ShipMagnet::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-
-  return geoBuild->createMedium(ShipMedium);
-}
 // private method make support of magnet
 TGeoVolume* ShipMagnet::MagnetSupport(Double_t hwidth, Double_t hheight,
                                       Double_t dz, Int_t colour,
@@ -116,9 +99,9 @@ TGeoVolume* ShipMagnet::MagnetSupport(Double_t hwidth, Double_t hheight,
 }
 void ShipMagnet::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
-  InitMedium("iron");
+  ShipGeo::InitMedium("iron");
   TGeoMedium* Fe = gGeoManager->GetMedium("iron");
-  InitMedium("Aluminum");
+  ShipGeo::InitMedium("Aluminum");
   TGeoMedium* Al = gGeoManager->GetMedium("Aluminum");
   TGeoVolumeAssembly* tMagnet = new TGeoVolumeAssembly("SHiPMagnet");
   top->AddNode(tMagnet, 1, new TGeoTranslation(0, 0, 0));

--- a/passive/ShipMagnet.h
+++ b/passive/ShipMagnet.h
@@ -31,7 +31,6 @@ class ShipMagnet : public FairModule {
   Double_t floorheight;
   TGeoVolume* MagnetSupport(Double_t hwidth, Double_t hheight, Double_t dz,
                             Int_t colour, TGeoMedium* material);
-  Int_t InitMedium(const char* name);
 };
 
 #endif  // PASSIVE_SHIPMAGNET_H_

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -11,6 +11,7 @@
 #include "FairGeoMedia.h"
 #include "FairLogger.h"     /// for FairLogger, MESSAGE_ORIGIN
 #include "FairRuntimeDb.h"  // for FairRuntimeDb
+#include "ShipGeoUtil.h"
 #include "ShipUnit.h"
 #include "TFile.h"
 #include "TGeoBBox.h"
@@ -49,22 +50,6 @@ ShipMuonShield::ShipMuonShield(std::vector<double> in_params, Double_t z,
   fWithConstShieldField = WithConstShieldField;
   fSC_mag = SC_key;
   z_end_of_proximity_shielding = z;
-}
-
-// -----   Private method InitMedium
-Int_t ShipMuonShield::InitMedium(TString name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium)
-    Fatal("InitMedium", "Material %s not defined in media file.", name.Data());
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium) return ShipMedium->getMediumIndex();
-  return geoBuild->createMedium(ShipMedium);
 }
 
 void ShipMuonShield::SetSNDSpace(Bool_t hole, Double_t hole_dx,
@@ -401,7 +386,7 @@ void ShipMuonShield::ConstructGeometry() {
   LOG(debug) << " Construct Geometry of the MS ";
   TGeoVolume* top = gGeoManager->GetTopVolume();
   TGeoVolume* tShield = new TGeoVolumeAssembly("MuonShieldArea");
-  InitMedium("iron");
+  ShipGeo::InitMedium("iron");
   TGeoMedium* iron = gGeoManager->GetMedium("iron");
 
   std::vector<TString> magnetName;

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -32,7 +32,6 @@ class ShipMuonShield : public FairModule {
   Double_t dZ0{0.}, dZ1{0.}, dZ2{0.}, dZ3{0.}, dZ4{0.}, dZ5{0.}, dZ6{0.},
       dZ7{0.}, dXgap{0.}, z_end_of_proximity_shielding{0.};
   size_t nMagnets{0};
-  Int_t InitMedium(TString name);
   Int_t nParams{0};
   Bool_t fWithConstShieldField{false};
   Bool_t fSC_mag{false};

--- a/passive/ShipTargetStation.cxx
+++ b/passive/ShipTargetStation.cxx
@@ -9,6 +9,7 @@
 #include "FairLogger.h"
 #include "FairRun.h"        // for FairRun
 #include "FairRuntimeDb.h"  // for FairRuntimeDb
+#include "ShipGeoUtil.h"
 #include "ShipUnit.h"
 #include "TGeoBBox.h"
 #include "TGeoCompositeShape.h"
@@ -37,44 +38,26 @@ ShipTargetStation::ShipTargetStation(const char* name, const Double_t tl,
   fHeT = HeT;
 }
 
-// -----   Private method InitMedium
-Int_t ShipTargetStation::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-  return geoBuild->createMedium(ShipMedium);
-}
-
 void ShipTargetStation::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
 
-  InitMedium("tungsten");
+  ShipGeo::InitMedium("tungsten");
   TGeoMedium* tungsten = gGeoManager->GetMedium("tungsten");
-  InitMedium("tantalum");
+  ShipGeo::InitMedium("tantalum");
   TGeoMedium* tantalum = gGeoManager->GetMedium("tantalum");
-  InitMedium("molybdenum");
+  ShipGeo::InitMedium("molybdenum");
   TGeoMedium* mo = gGeoManager->GetMedium("molybdenum");
-  InitMedium("iron");
+  ShipGeo::InitMedium("iron");
   TGeoMedium* iron = gGeoManager->GetMedium("iron");
-  InitMedium("steel316L");
+  ShipGeo::InitMedium("steel316L");
   TGeoMedium* steel316L = gGeoManager->GetMedium("steel316L");
-  InitMedium("copper");
+  ShipGeo::InitMedium("copper");
   TGeoMedium* copper = gGeoManager->GetMedium("copper");
 
-  InitMedium("Inconel718");
+  ShipGeo::InitMedium("Inconel718");
   TGeoMedium* inc718 = gGeoManager->GetMedium("Inconel718");
 
-  InitMedium("vacuums");
+  ShipGeo::InitMedium("vacuums");
   TGeoMedium* vacuum = gGeoManager->GetMedium("vacuums");
 
   double He_T = 273.15 + fHeT;       // in K, use average 90 degrees C.
@@ -82,7 +65,7 @@ void ShipTargetStation::ConstructGeometry() {
 
   std::ostringstream lHename;
   lHename << "PressurisedHe" << fHeT;
-  InitMedium(lHename.str().c_str());
+  ShipGeo::InitMedium(lHename.str().c_str());
   TGeoMedium* pressurised_He = gGeoManager->GetMedium(lHename.str().c_str());
 
   // CAMM- dirty fix to have pressure and temperature correct for Geant4.

--- a/passive/ShipTargetStation.h
+++ b/passive/ShipTargetStation.h
@@ -39,7 +39,6 @@ class ShipTargetStation : public FairModule {
   std::vector<float> fL;        // absorber width per layer
   std::vector<float> fG;        // gap after layer
   std::vector<std::string> fM;  // absorber material
-  Int_t InitMedium(const char* name);
   size_t fnS;
   Int_t fHeT;
 };

--- a/shipdata/ISTLPointContainer.h
+++ b/shipdata/ISTLPointContainer.h
@@ -2,6 +2,9 @@
 #define SHIPDATA_ISTLPOINTCONTAINER_H_
 
 #include <map>
+#include <vector>
+
+#include "FairLink.h"
 
 /**
  * @brief Interface for detectors using STL containers (std::vector) for MC
@@ -23,5 +26,21 @@ class ISTLPointContainer {
 
   virtual ~ISTLPointContainer() = default;
 };
+
+/// Reusable implementation of UpdatePointTrackIndices for any point type that
+/// provides GetTrackID(), SetTrackID() and SetLink() (i.e. FairMCPoint
+/// subclasses).
+template <typename PointType>
+void UpdatePointTrackIndicesImpl(std::vector<PointType>& points,
+                                 const std::map<Int_t, Int_t>& indexMap) {
+  for (auto& point : points) {
+    Int_t oldTrackID = point.GetTrackID();
+    auto iter = indexMap.find(oldTrackID);
+    if (iter != indexMap.end()) {
+      point.SetTrackID(iter->second);
+      point.SetLink(FairLink("MCTrack", iter->second));
+    }
+  }
+}
 
 #endif  // SHIPDATA_ISTLPOINTCONTAINER_H_

--- a/shipdata/ShipGeoUtil.h
+++ b/shipdata/ShipGeoUtil.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
+// Collaboration
+
+#ifndef SHIPDATA_SHIPGEOUTIL_H_
+#define SHIPDATA_SHIPGEOUTIL_H_
+
+#include "FairGeoBuilder.h"
+#include "FairGeoInterface.h"
+#include "FairGeoLoader.h"
+#include "FairGeoMedia.h"
+#include "TGeoManager.h"
+#include "TGeoMedium.h"
+
+namespace ShipGeo {
+
+/// Initialise a tracking medium from the FairRoot media file.
+/// Returns the medium index, or creates it via FairGeoBuilder if it does not
+/// yet exist in gGeoManager.
+inline Int_t InitMedium(const char* name) {
+  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
+  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
+  static FairGeoMedia* media = geoFace->getMedia();
+  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
+
+  FairGeoMedium* ShipMedium = media->getMedium(name);
+
+  if (!ShipMedium) {
+    Fatal("ShipGeo::InitMedium", "Material %s not defined in media file.",
+          name);
+    return -1111;
+  }
+  TGeoMedium* medium = gGeoManager->GetMedium(name);
+  if (medium != nullptr) return ShipMedium->getMediumIndex();
+
+  return geoBuild->createMedium(ShipMedium);
+}
+
+}  // namespace ShipGeo
+
+#endif  // SHIPDATA_SHIPGEOUTIL_H_

--- a/splitcal/splitcal.cxx
+++ b/splitcal/splitcal.cxx
@@ -18,6 +18,7 @@
 #include "FairRuntimeDb.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "TCanvas.h"
 #include "TClonesArray.h"
@@ -73,24 +74,7 @@ void splitcal::Initialize() {
   //  splitcalGeoPar*
   //  par=(splitcalGeoPar*)(rtdb->getContainer("splitcalGeoPar"));
 }
-// -----   Private method InitMedium
-Int_t splitcal::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
 
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-
-  return geoBuild->createMedium(ShipMedium);
-}
 Bool_t splitcal::ProcessHits(FairVolume* vol) {
   /** This method is called from the MC stepping */
   // Set parameters at entrance of volume. Reset ELoss.
@@ -161,14 +145,7 @@ void splitcal::Register() {
 TClonesArray* splitcal::GetCollection(Int_t iColl) const { return nullptr; }
 
 void splitcal::UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fsplitcalPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fsplitcalPoints, indexMap);
 }
 
 void splitcal::Reset() { fsplitcalPoints->clear(); }
@@ -241,11 +218,11 @@ void splitcal::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
   TGeoVolume* tSplitCal = new TGeoVolumeAssembly("SplitCalDetector");
 
-  InitMedium("iron");
-  InitMedium("lead");
-  InitMedium("Scintillator");
-  InitMedium("argon");
-  InitMedium("GEMmixture");
+  ShipGeo::InitMedium("iron");
+  ShipGeo::InitMedium("lead");
+  ShipGeo::InitMedium("Scintillator");
+  ShipGeo::InitMedium("argon");
+  ShipGeo::InitMedium("GEMmixture");
 
   TGeoMedium* A2 = gGeoManager->GetMedium("iron");
   TGeoMedium* A3 = gGeoManager->GetMedium("lead");

--- a/splitcal/splitcal.h
+++ b/splitcal/splitcal.h
@@ -139,8 +139,6 @@ class splitcal : public FairDetector, public ISTLPointContainer {
 
   splitcal(const splitcal&) = delete;
   splitcal& operator=(const splitcal&) = delete;
-  Int_t InitMedium(const char* name);
-
   ClassDefOverride(splitcal, 2)
 };
 

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -25,6 +25,7 @@
 #include "FairRuntimeDb.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "TClonesArray.h"
 #include "TGeoBBox.h"
@@ -90,25 +91,6 @@ void strawtubes::Initialize() {
   FairDetector::Initialize();
   //  FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
   //  vetoGeoPar* par=(vetoGeoPar*)(rtdb->getContainer("vetoGeoPar"));
-}
-
-// -----   Private method InitMedium
-Int_t strawtubes::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-
-  return geoBuild->createMedium(ShipMedium);
 }
 
 Bool_t strawtubes::ProcessHits(FairVolume* vol) {
@@ -209,14 +191,7 @@ TClonesArray* strawtubes::GetCollection(Int_t iColl) const { return nullptr; }
 
 void strawtubes::UpdatePointTrackIndices(
     const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fstrawtubesPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fstrawtubesPoints, indexMap);
 }
 
 void strawtubes::Reset() { fstrawtubesPoints->clear(); }
@@ -277,15 +252,15 @@ void strawtubes::ConstructGeometry() {
       implement here you own way of constructing the geometry. */
 
   TGeoVolume* top = gGeoManager->GetTopVolume();
-  InitMedium("mylar");
+  ShipGeo::InitMedium("mylar");
   TGeoMedium* mylar = gGeoManager->GetMedium("mylar");
-  InitMedium("STTmix8020_1bar");
+  ShipGeo::InitMedium("STTmix8020_1bar");
   TGeoMedium* sttmix8020_1bar = gGeoManager->GetMedium("STTmix8020_1bar");
-  InitMedium("tungsten");
+  ShipGeo::InitMedium("tungsten");
   TGeoMedium* tungsten = gGeoManager->GetMedium("tungsten");
-  InitMedium(f_frame_material);
+  ShipGeo::InitMedium(f_frame_material);
   TGeoMedium* FrameMatPtr = gGeoManager->GetMedium(f_frame_material);
-  InitMedium(fMedium.c_str());
+  ShipGeo::InitMedium(fMedium.c_str());
   TGeoMedium* med = gGeoManager->GetMedium(fMedium.c_str());
 
   gGeoManager->SetVisLevel(4);

--- a/strawtubes/strawtubes.h
+++ b/strawtubes/strawtubes.h
@@ -140,7 +140,6 @@ class strawtubes : public FairDetector, public ISTLPointContainer {
 
   strawtubes(const strawtubes&) = delete;
   strawtubes& operator=(const strawtubes&) = delete;
-  Int_t InitMedium(const char* name);
   ClassDefOverride(strawtubes, 7)
 };
 

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -32,6 +32,7 @@
 #include "FairRuntimeDb.h"
 #include "FairVolume.h"
 #include "ShipDetectorList.h"
+#include "ShipGeoUtil.h"
 #include "ShipStack.h"
 #include "TClonesArray.h"
 #include "TGeoArb8.h"
@@ -766,25 +767,6 @@ TGeoVolume* veto::MakeSegments() {
   return tTankVol;
 }
 
-// -----   Private method InitMedium
-Int_t veto::InitMedium(const char* name) {
-  static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-  static FairGeoInterface* geoFace = geoLoad->getGeoInterface();
-  static FairGeoMedia* media = geoFace->getMedia();
-  static FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
-
-  FairGeoMedium* ShipMedium = media->getMedium(name);
-
-  if (!ShipMedium) {
-    Fatal("InitMedium", "Material %s not defined in media file.", name);
-    return -1111;
-  }
-  TGeoMedium* medium = gGeoManager->GetMedium(name);
-  if (medium != nullptr) return ShipMedium->getMediumIndex();
-
-  return geoBuild->createMedium(ShipMedium);
-}
-
 // -------------------------------------------------------------------------
 /**
  * @brief Processes a hit in the veto detector.
@@ -867,14 +849,7 @@ void veto::Register()  // create a branch in the output tree
 TClonesArray* veto::GetCollection(Int_t iColl) const { return nullptr; }
 
 void veto::UpdatePointTrackIndices(const std::map<Int_t, Int_t>& indexMap) {
-  for (auto& point : *fvetoPoints) {
-    Int_t oldTrackID = point.GetTrackID();
-    auto iter = indexMap.find(oldTrackID);
-    if (iter != indexMap.end()) {
-      point.SetTrackID(iter->second);
-      point.SetLink(FairLink("MCTrack", iter->second));
-    }
-  }
+  UpdatePointTrackIndicesImpl(*fvetoPoints, indexMap);
 }
 
 void veto::Reset() { fvetoPoints->clear(); }
@@ -890,11 +865,11 @@ void veto::Reset() { fvetoPoints->clear(); }
 void veto::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
 
-  InitMedium("vacuums");
-  InitMedium("Aluminum");
-  InitMedium("helium");
-  InitMedium("Scintillator");
-  InitMedium("steel");
+  ShipGeo::InitMedium("vacuums");
+  ShipGeo::InitMedium("Aluminum");
+  ShipGeo::InitMedium("helium");
+  ShipGeo::InitMedium("Scintillator");
+  ShipGeo::InitMedium("steel");
 
   gGeoManager->SetNsegments(100);
 

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -184,7 +184,6 @@ class veto : public FairDetector, public ISTLPointContainer {
 
   veto(const veto&) = delete;
   veto& operator=(const veto&) = delete;
-  Int_t InitMedium(const char* name);
   /** Adds a solid Trapezoid of thickness (along z) wz with start cross-section
    * dimensions of wX_start * wY_start and end cross-section dimensions of
    * wX_end *wY_end


### PR DESCRIPTION
Extract identical InitMedium method (13 classes) into ShipGeo::InitMedium free function in shipdata/ShipGeoUtil.h. Extract identical UpdatePointTrackIndices loop (10 classes) into UpdatePointTrackIndicesImpl function template in shipdata/ISTLPointContainer.h.

Net removal of ~275 lines of duplicated code.

@mesmith75 This is from this morning before I saw your PR. Most of this I think you already fixed in your PR #1079. Not sure whether there is anything here that might still be useful. Maybe our approach to InitMedium is a bit different.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
