### PR TITLE
refactor: remove dead code from splitcal directory

### DIFF
--- a/splitcal/splitcal.cxx
+++ b/splitcal/splitcal.cxx
@@ -67,12 +67,7 @@ splitcal::~splitcal() {
   }
 }
 
-void splitcal::Initialize() {
-  FairDetector::Initialize();
-  //  FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
-  //  splitcalGeoPar*
-  //  par=(splitcalGeoPar*)(rtdb->getContainer("splitcalGeoPar"));
-}
+void splitcal::Initialize() { FairDetector::Initialize(); }
 // -----   Private method InitMedium
 Int_t splitcal::InitMedium(const char* name) {
   static FairGeoLoader* geoLoad = FairGeoLoader::Instance();
@@ -110,27 +105,15 @@ Bool_t splitcal::ProcessHits(FairVolume* vol) {
       gMC->IsTrackDisappeared()) {
     fEventID = gMC->CurrentEvent();
     fTrackID = gMC->GetStack()->GetCurrentTrackNumber();
-    // fVolumeID = vol->getMCid();
-    // cout << "splitcal proc "<< fVolumeID<<" "<<vol->GetName()<<"
-    // "<<vol->getVolumeId() <<endl;
-    //    cout << " "<<
-    //    gGeoManager->FindVolumeFast(vol->GetName())->GetNumber()<< "  " <<
-    //    gMC->CurrentVolID() << endl;
-    ///  fVolumeID = gGeoManager->FindVolumeFast(vol->GetName())->GetNumber();
-    // VolumeID = vol->getMCid();
     Int_t detID = 0;
     gMC->CurrentVolID(detID);
 
-    // if (fVolumeID == detID) {
-    //   return kTRUE; }
     fVolumeID = detID;
-    //    cout << " "<<fVolumeID << endl;
     if (fELoss == 0.) {
       return kFALSE;
     }
     TParticle* p = gMC->GetStack()->GetCurrentTrack();
     Int_t pdgCode = p->GetPdgCode();
-    //    if(fVolumeID<405 && fTime<70){
     AddHit(fEventID, fTrackID, fVolumeID,
            TVector3(fPos.X(), fPos.Y(), fPos.Z()),
            TVector3(fMom.Px(), fMom.Py(), fMom.Pz()), fTime, fLength, fELoss,
@@ -313,7 +296,6 @@ void splitcal::ConstructGeometry() {
                          new TGeoTranslation(0, 0, z_splitcal));
       z_splitcal += fFilterECALThickness / 2;
     }
-    // std::cout<< "--- i_nlayECAL*1e5 = "<< i_nlayECAL*1e5 << std::endl;
 
     if (i_nlayECAL == 0)
       z_splitcal += fEmpty;  // space after first layer? set to 0 in the config
@@ -336,8 +318,6 @@ void splitcal::ConstructGeometry() {
                            new TGeoTranslation(0, 0, z_splitcal));
         z_splitcal += fActiveECAL_gas_Thickness / 2;
       }
-      // std::cout<< "--- index high precision layer = "<<
-      // 1e8+(i_nlayECAL+1)*1e5 << std::endl;
     } else {
       // position sensitive layers
       z_splitcal += fActiveECALThickness / 2;
@@ -360,7 +340,7 @@ void splitcal::ConstructGeometry() {
               tSplitCal->AddNode(
                   stripGivingX, index,
                   new TGeoTranslation(xCoordinate, yCoordinate, z_splitcal));
-              // std::cout<< "--- index = "<< index << std::endl;
+
             }  // end loop on strips
           }  // end loop on modules in y
         }  // end loop on modules in x
@@ -384,7 +364,7 @@ void splitcal::ConstructGeometry() {
               tSplitCal->AddNode(
                   stripGivingY, index,
                   new TGeoTranslation(xCoordinate, yCoordinate, z_splitcal));
-              // std::cout<< "--- index = "<< index << std::endl;
+
             }  // end loop on strips
           }  // end loop on modules in y
         }  // end loop on modules in x
@@ -421,13 +401,12 @@ void splitcal::ConstructGeometry() {
     tSplitCal->AddNode(newHCALfilter[i_nlayHCAL], 1,
                        new TGeoTranslation(0, 0, z_splitcal));
     z_splitcal += fFilterHCALThickness / 2;
-    // z_splitcal+=fEmpty;
+
     z_splitcal += fActiveHCALThickness / 2;
     if (fActiveHCAL)
       tSplitCal->AddNode(newHCALdet[i_nlayHCAL], 1,
                          new TGeoTranslation(0, 0, z_splitcal));
     z_splitcal += fActiveHCALThickness / 2;
-    // z_splitcal+=fEmpty;
   }
 
   // finish assembly and position
@@ -436,19 +415,6 @@ void splitcal::ConstructGeometry() {
   Double_t totLength = asmb->GetDZ();
   top->AddNode(tSplitCal, 1,
                new TGeoTranslation(0, 0, zStartSplitCal + totLength));
-
-  // //gROOT->SetBatch(true);
-
-  //    TCanvas* c1 = new TCanvas("splitcalCanvas", "", 800, 800);
-  //    c1->cd();
-
-  //    TView3D* tview = (TView3D*) TView::CreateView();
-  //    tview->SetRange(-fXMax*1.2, -fYMax*1.2, 2500, fXMax*1.2, fYMax*1.2,
-  //    3800); tview->RotateView(0, 90, c1);
-
-  //    tSplitCal->Draw("ogle");
-  //    c1->SaveAs(TString("splitcal.eps"));
-  //    c1->SaveAs(TString("splitcal.pdf"));
 }
 
 splitcalPoint* splitcal::AddHit(Int_t eventID, Int_t trackID, Int_t detID,

--- a/splitcal/splitcalCluster.cxx
+++ b/splitcal/splitcalCluster.cxx
@@ -5,23 +5,8 @@
 #include "splitcalCluster.h"
 
 #include <cmath>
-#include <functional>
 #include <iostream>
 #include <map>
-#include <numeric>
-
-#include "TMath.h"
-
-// -----   constructor from list/vector of splitcalHit
-// ------------------------------------------
-// splitcalCluster::splitcalCluster(boost::python::list& l)
-// {
-//   std::vector<splitcalHit > v;
-//   for(int i=0; i<boost::python::len(l); i++) {
-//     v.push_back(boost::python::extract<splitcalHit >(l[i]));
-//   }
-//   SetVectorOfHits(v);
-// }
 
 // -----   Default constructor   -------------------------------------------
 splitcalCluster::splitcalCluster() {}
@@ -71,9 +56,6 @@ void splitcalCluster::ComputeEtaPhiE(const std::vector<splitcalHit>& hits) {
     }
   }  // end loop on hit
 
-  // FIXME: regression fit seems instable --> for the moment commented it out in
-  // favour of simple direction from initial and end point
-
   auto const& firstElementX = mapLayerWeigthedX.begin();
   int minLayerX = firstElementX->first;
   double minX = firstElementX->second / mapLayerSumWeigthsX[minLayerX];
@@ -109,88 +91,6 @@ void splitcalCluster::ComputeEtaPhiE(const std::vector<splitcalHit>& hits) {
   double eta = direction.Eta();
   double phi = direction.Phi();
   SetEtaPhiE(eta, phi, energy);
-
-  // // vectors holding the weighted coordinates per layer: x and z for the eta
-  // fit, and y and z for the phi fit std::vector<double > x; std::vector<double
-  // > z1; std::vector<double > y; std::vector<double > z2;
-
-  // for (auto const& element : mapLayerWeigthedX){
-  //   int key = element.first;
-  //   x.push_back(element.second/mapLayerSumWeigthsX[key]);
-  //   z1.push_back(mapLayerZ1[key]);
-  // }
-
-  // regression resultZX = LinearRegression(z1,x);
-  // double alpha = acos(resultZX.slope);
-
-  // for (auto const& element : mapLayerWeigthedY){
-  //   int key = element.first;
-  //   y.push_back(element.second/mapLayerSumWeigthsY[key]);
-  //   z2.push_back(mapLayerZ2[key]);
-  // }
-
-  // regression resultZY = LinearRegression(z2,y);
-  // double eta_check = acos(resultZY.slope);
-
-  // // regression resultXY = LinearRegression(x,y);
-  // // double phi = acos(resultXY.slope);
-
-  // std::cout<<" ---- before fit " << std::endl;
-  // _start.Print();
-  // _end.Print();
-
-  // // replace the x and y of start and end points with the re-evaluated values
-  // from the corresponding fit _start.SetX( resultZX.slope * _start.Z() +
-  // resultZX.intercept ); _start.SetY( resultZY.slope * _start.Z() +
-  // resultZY.intercept );
-
-  // _end.SetX( resultZX.slope * _end.Z() + resultZX.intercept );
-  // _end.SetY( resultZY.slope * _end.Z() + resultZY.intercept );
-
-  // // get direction vector from end-strat vector difference
-  // TVector3 direction;
-  // direction = _end - _start;
-  // double eta = direction.Eta();
-  // double phi = direction.Phi();
-
-  // std::cout<<" ---- after fit " << std::endl;
-  // _start.Print();
-  // _end.Print();
-
-  // std::cout<<" -- eta = "<< eta << std::endl;
-  // std::cout<<" -- eta_check = "<< eta_check << std::endl;
-  // std::cout<<" -- phi = "<< phi << std::endl;
-  // std::cout<<" -- energy = "<< energy << std::endl;
-
-  // SetEtaPhiE(eta, phi, energy);
-
-  // // temporary for test
-  // _mZX = resultZX.slope;
-  // _qZX = resultZX.intercept;
-  // _mZY = resultZY.slope;
-  // _qZY = resultZY.intercept;
-
-  return;
-}
-
-regression splitcalCluster::LinearRegression(std::vector<double>& x,
-                                             std::vector<double>& y) {
-  const auto n = x.size();
-  const auto s_x = std::accumulate(x.begin(), x.end(), 0.);
-  const auto s_y = std::accumulate(y.begin(), y.end(), 0.);
-  const auto s_xx = std::inner_product(x.begin(), x.end(), x.begin(), 0.);
-  const auto s_xy = std::inner_product(x.begin(), x.end(), y.begin(), 0.);
-
-  regression result;
-
-  result.slope = (n * s_xy - s_x * s_y) / (n * s_xx - s_x * s_x);
-  result.intercept = (s_x * s_x * s_y - s_xy * s_x) / (n * s_xx - s_x * s_x);
-
-  std::cout << "--- LinearRegression ---" << std::endl;
-  std::cout << "--------- slope = " << result.slope << std::endl;
-  std::cout << "--------- intercept = " << result.intercept << std::endl;
-
-  return result;
 }
 
 // -------------------------------------------------------------------------

--- a/splitcal/splitcalCluster.h
+++ b/splitcal/splitcalCluster.h
@@ -5,29 +5,18 @@
 #ifndef SPLITCAL_SPLITCALCLUSTER_H_
 #define SPLITCAL_SPLITCALCLUSTER_H_
 
+#include <TVector3.h>
+
 #include <array>
 #include <vector>
 
 #include "TObject.h"  //
 #include "splitcalHit.h"
-// #include <boost/python.hpp>
-
-// ROOT headers
-/* #include <TLorentzVector.h> */
-#include <TVector3.h>
-
-struct regression {
-  double slope;
-  double slopeError;
-  double intercept;
-  double interceptError;
-};
 
 class splitcalCluster : public TObject {
  public:
   /** Constructors **/
   splitcalCluster();
-  // splitcalCluster(boost::python::list& l);
 
   /** Destructor **/
   virtual ~splitcalCluster();
@@ -77,14 +66,7 @@ class splitcalCluster : public TObject {
   const std::vector<int>& GetHitIndices() const { return _hitIndices; }
   const std::vector<double>& GetHitWeights() const { return _hitWeights; }
 
-  regression LinearRegression(std::vector<double>& x, std::vector<double>& y);
   void ComputeEtaPhiE(const std::vector<splitcalHit>& hits);
-
-  // temporary for test
-  double GetSlopeZX() { return _mZX; }
-  double GetInterceptZX() { return _qZX; }
-  double GetSlopeZY() { return _mZY; }
-  double GetInterceptZY() { return _qZY; }
 
   /** Copy constructor **/
   splitcalCluster(const splitcalCluster& cluster) = default;
@@ -98,11 +80,7 @@ class splitcalCluster : public TObject {
   std::vector<int> _hitIndices;
   std::vector<double> _hitWeights;
 
-  // temporary for test
-  double _mZX, _qZX;
-  double _mZY, _qZY;
-
-  ClassDef(splitcalCluster, 3);
+  ClassDef(splitcalCluster, 4);
 };
 
 #endif  // SPLITCAL_SPLITCALCLUSTER_H_

--- a/splitcal/splitcalContFact.cxx
+++ b/splitcal/splitcalContFact.cxx
@@ -8,8 +8,6 @@
 
 #include "FairRuntimeDb.h"
 
-// static splitcalContFact gsplitcalContFact;
-
 splitcalContFact::splitcalContFact() : FairContFact() {
   /** Constructor (called when the library is loaded) */
   fName = "splitcalContFact";
@@ -18,34 +16,8 @@ splitcalContFact::splitcalContFact() : FairContFact() {
   FairRuntimeDb::instance()->addContFactory(this);
 }
 
-void splitcalContFact::setAllContainers() {
-  /** Creates the Container objects with all accepted
-      contexts and adds them to
-      the list of containers for the splitcal library.
-  */
-  /*
-    FairContainer* p= new FairContainer("splitcalGeoPar",
-                                        "splitcal Geometry Parameters",
-                                        "TestDefaultContext");
-    p->addContext("TestNonDefaultContext");
-
-    containers->Add(p);
-  */
-}
+void splitcalContFact::setAllContainers() {}
 
 FairParSet* splitcalContFact::createContainer(FairContainer* c) {
-  /** Calls the constructor of the corresponding parameter container.
-      For an actual context, which is not an empty string and not
-      the default context
-      of this container, the name is concatenated with the context.
-  */
-  /* const char* name=c->GetName();
-   FairParSet* p=NULL;
-   if (strcmp(name,"splitcalGeoPar")==0) {
-     p=new splitcalGeoPar(c->getConcatName().Data(),
-                             c->GetTitle(),c->getContext());
-   }
-   return p;
- */
-  return 0;
+  return nullptr;
 }

--- a/splitcal/splitcalHit.cxx
+++ b/splitcal/splitcalHit.cxx
@@ -60,7 +60,6 @@ splitcalHit::splitcalHit(const std::vector<splitcalPoint>& points, Double_t t0)
   }
 
   fdigi = t0 + firstPoint.GetTime();
-  // SetDigi(SetTimeRes(fdigi));
   SetDetectorID(detID);
 
   TGeoNavigator* navigator = gGeoManager->GetCurrentNavigator();
@@ -89,28 +88,6 @@ splitcalHit::splitcalHit(const std::vector<splitcalPoint>& points, Double_t t0)
 
   double zPassiveHalfLength = box->GetDZ();
 
-  // std::cout<< "----------------------"<<std::endl;
-  // std::cout<< "-- pointX = " << pointX << std::endl;
-  // std::cout<< "-- pointY = " << pointY << std::endl;
-  // std::cout<< "-- pointZ = " << pointZ << std::endl;
-  // std::cout<< "-- detID = " << detID << std::endl;
-  // std::cout<< "-- stripName = " << stripName << std::endl;
-  // std::cout<< "-- isPrec = " << isPrec << std::endl;
-  // std::cout<< "-- nL = " << nL << std::endl;
-  // std::cout<< "-- nMx = " << nMx << std::endl;
-  // std::cout<< "-- nMy = " << nMy << std::endl;
-  // std::cout<< "-- nS = " << nS << std::endl;
-  // std::cout<< "-- stripCoordinatesLocal[0] = " << stripCoordinatesLocal[0] <<
-  // std::endl; std::cout<< "-- stripCoordinatesLocal[1] = " <<
-  // stripCoordinatesLocal[1] << std::endl; std::cout<< "--
-  // stripCoordinatesLocal[2] = " << stripCoordinatesLocal[2] << std::endl;
-  // std::cout<< "-- stripCoordinatesMaster[0] = " << stripCoordinatesMaster[0]
-  // << std::endl; std::cout<< "-- stripCoordinatesMaster[1] = " <<
-  // stripCoordinatesMaster[1] << std::endl; std::cout<< "--
-  // stripCoordinatesMaster[2] = " << stripCoordinatesMaster[2] << std::endl;
-
-  // TGeoNode* check = navigator->FindNode(pointX,pointY,pointZ);
-
   SetEnergy(pointE);
   if (isPrec == 1)
     SetXYZ(pointX, pointY, stripCoordinatesMaster[2]);
@@ -133,7 +110,6 @@ std::string splitcalHit::GetPaddedString(int& id) {
 
 std::string splitcalHit::GetDetectorElementName(int& id) {
   std::string encodedID = GetPaddedString(id);
-  // std::cout << "-- encodedID = " << encodedID <<std::endl;
   int isPrec, nL, nMx, nMy, nS;
   Decoder(encodedID, isPrec, nL, nMx, nMy, nS);
 
@@ -152,7 +128,6 @@ std::string splitcalHit::GetDetectorElementName(int& id) {
     SetIsY(false);
   }
   name = name + std::to_string(id);
-  // std::cout << "--GetDetectorElementName - name  = " << name <<std::endl;
 
   return name;
 }


### PR DESCRIPTION
Remove disabled linear regression feature (unused methods, struct, member variables, ~60 lines of commented-out code) from splitcalCluster. Remove commented-out debug prints, visualisation code, and obsolete includes from splitcal, splitcalHit, and splitcalContFact. Bump splitcalCluster ClassDef version from 3 to 4.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
