### PR TITLE
Use IIFE and initializer lists to enable const

### DIFF
--- a/TimeDet/TimeDetHit.cxx
+++ b/TimeDet/TimeDetHit.cxx
@@ -54,10 +54,7 @@ std::vector<double> TimeDetHit::GetTime(Double_t x) const {
   Double_t dt = 1. / TMath::Sqrt(w1 + w2);
   Double_t t =
       ((t_1 - lneg / v_drift) * w1 + (t_2 - lpos / v_drift) * w2) / (w1 + w2);
-  std::vector<double> m;
-  m.push_back(t);
-  m.push_back(dt);
-  return m;
+  return {t, dt};
 }
 // ---- return mean time information
 std::vector<double> TimeDetHit::GetTime() const {
@@ -70,22 +67,14 @@ std::vector<double> TimeDetHit::GetTime() const {
   Float_t r1 = Resol(lneg);
   Float_t r2 = Resol(lpos);
   Double_t dt = TMath::Sqrt(r1 * r1 + r2 * r2);
-  std::vector<double> m;
-  m.push_back(t0);
-  m.push_back(dt);
-  return m;
+  return {t0, dt};
 }
 // -----   resolution function-------------------
 Double_t TimeDetHit::Resol(Double_t x) const {
   return par[0] * TMath::Exp((x - par[2]) / par[1]) + par[3];
 }
 
-std::vector<double> TimeDetHit::GetMeasurements() const {
-  std::vector<double> m;
-  m.push_back(t_1);
-  m.push_back(t_2);
-  return m;
-}
+std::vector<double> TimeDetHit::GetMeasurements() const { return {t_1, t_2}; }
 
 // distance to edges
 void TimeDetHit::Dist(Float_t x, Float_t& lpos, Float_t& lneg) const {

--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -319,11 +319,7 @@ void ShipBFieldMap::readRootFile() {
       Bz *= Tesla_;
 
       // Store the B field 3-vector
-      std::vector<Float_t> BVector(3);
-      BVector[0] = Bx;
-      BVector[1] = By;
-      BVector[2] = Bz;
-      fieldMap_->push_back(BVector);
+      fieldMap_->push_back({Bx, By, Bz});
     }
   }
 
@@ -369,11 +365,7 @@ void ShipBFieldMap::readTextFile() {
       Bz *= Tesla_;
 
       // Store the B field 3-vector
-      std::vector<Float_t> BVector(3);
-      BVector[0] = Bx;
-      BVector[1] = By;
-      BVector[2] = Bz;
-      fieldMap_->push_back(BVector);
+      fieldMap_->push_back({Bx, By, Bz});
     }
   }
 

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -441,11 +441,13 @@ void ShipMuonShield::ConstructGeometry() {
       "_MiddleMagL", "_MiddleMagR",  "_MagRetL",    "_MagRetR",
       "_MagTopLeft", "_MagTopRight", "_MagBotLeft", "_MagBotRight",
   };
-  TString absorber_magnet_components;
-  for (auto&& magnet_component : magnet_components) {
-    absorber_magnet_components +=
-        ("-" + absorber_magnets[0] + magnet_component);
-  }
+  const TString absorber_magnet_components = [&] {
+    TString result;
+    for (auto&& magnet_component : magnet_components) {
+      result += ("-" + absorber_magnets[0] + magnet_component);
+    }
+    return result;
+  }();
 
   TGeoCompositeShape* absorberShape = new TGeoCompositeShape(
       "Absorber", "absorber:absorber_shift" + absorber_magnet_components);

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -85,13 +85,9 @@ std::vector<double> GenieGenerator::Rotate(Double_t x, Double_t y, Double_t z,
   // rotate around z-axis
   Double_t pxr = c * px1 - s * py;
   Double_t pyr = s * px1 + c * py;
-  std::vector<double> pout;
-  pout.push_back(pxr);
-  pout.push_back(pyr);
-  pout.push_back(pzr);
-  // cout << "Info GenieGenerator: rotated" << pout[0] << " " << pout[1] << " "
-  // << pout[2] << " " << x << " " << y << " " << z <<endl;
-  return pout;
+  // cout << "Info GenieGenerator: rotated" << pxr << " " << pyr << " "
+  // << pzr << " " << x << " " << y << " " << z <<endl;
+  return {pxr, pyr, pzr};
 }
 
 // -----   Destructor   ----------------------------------------------------

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -375,34 +375,30 @@ void strawtubes::ConstructGeometry() {
 
     for (Int_t vnb = 0; vnb < 4; vnb++) {
       // View loop
-      TString nmview;
-      Double_t angle;
-      Double_t stereo_growth;
-      Double_t stereo_pitch;
-      Double_t offset_layer;
-      Int_t straws_per_layer;
-
-      switch (vnb) {
-        case 0:
-          angle = 0.;
-          nmview = nmstation + "_y1";
-          break;
-        case 1:
-          angle = f_view_angle;
-          nmview = nmstation + "_u";
-          break;
-        case 2:
-          angle = -f_view_angle;
-          nmview = nmstation + "_v";
-          break;
-        case 3:
-          angle = 0.;
-          nmview = nmstation + "_y2";
-          break;
-        default:
-          angle = 0.;
-          nmview = nmstation + "_y1";
-      }
+      const Double_t angle = [&] {
+        switch (vnb) {
+          case 1:
+            return f_view_angle;
+          case 2:
+            return -f_view_angle;
+          default:
+            return 0.;
+        }
+      }();
+      const TString nmview = [&] {
+        switch (vnb) {
+          case 0:
+            return nmstation + "_y1";
+          case 1:
+            return nmstation + "_u";
+          case 2:
+            return nmstation + "_v";
+          case 3:
+            return nmstation + "_y2";
+          default:
+            return nmstation + "_y1";
+        }
+      }();
 
       // Adjustments in the stereo views
       // stereo_growth: extension of stereo views beyond aperture
@@ -410,13 +406,13 @@ void strawtubes::ConstructGeometry() {
       // offset_layer: layer offset in stereo views
       // straws_per_layer: number of straws in one layer with stereo extension
       // If angle == 0., all numbers return the case of non-stereo views.
-      stereo_growth =
+      const Double_t stereo_growth =
           TMath::Tan(TMath::Abs(angle) * TMath::Pi() / 180.0) * straw_length;
-      stereo_pitch =
+      const Double_t stereo_pitch =
           f_straw_pitch / TMath::Cos(TMath::Abs(angle) * TMath::Pi() / 180.0);
-      offset_layer =
+      const Double_t offset_layer =
           f_offset_layer / TMath::Cos(TMath::Abs(angle) * TMath::Pi() / 180.0);
-      straws_per_layer =
+      const Int_t straws_per_layer =
           std::ceil(2 * (f_aperture_height + stereo_growth) / stereo_pitch);
 
       for (Int_t lnb = 0; lnb < 2; lnb++) {
@@ -525,23 +521,18 @@ void strawtubes::StrawEndPoints(Int_t fDetectorID, TVector3& vbot,
   stat += statnb;
   stat += "_";
   stat += statnb;
-  TString view;
-  switch (vnb) {
-    case 0:
-      view = "_y1";
-      break;
-    case 1:
-      view = "_u";
-      break;
-    case 2:
-      view = "_v";
-      break;
-    case 3:
-      view = "_y2";
-      break;
-    default:
-      view = "_y1";
-  }
+  const TString view = [&] {
+    switch (vnb) {
+      case 1:
+        return TString("_u");
+      case 2:
+        return TString("_v");
+      case 3:
+        return TString("_y2");
+      default:
+        return TString("_y1");
+    }
+  }();
   TGeoNavigator* nav = gGeoManager->GetCurrentNavigator();
   TString prefix = "Tr";
   prefix += statnb;


### PR DESCRIPTION
Use immediately invoked lambdas for switch-based initialisation in strawtubes and loop-based string building in ShipMuonShield. Replace push_back sequences with initializer lists in GenieGenerator, TimeDetHit and ShipBFieldMap.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
