### PR TITLE
MuonBackground Generator fix

### DIFF
--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -249,7 +249,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       }
     }
   }
-  if (fn == fNevents) {
+  if (fn > fNevents) {
     LOGF(info, "End of tree reached %i", fNevents);
     return kFALSE;
   }


### PR DESCRIPTION
Without fix FairShip fails at the very last event and does not close the output file properly (in case of -n > nEvents in file):

```
=======================================================================                                                                                                                                              
[INFO] End of tree reached 5                                                                                                                                                                                         
[ERROR] ReadEvent failed for generator                                                                                                                                                                               
[WARN] StopRun() exiting not safetly oopps !!!@@@!!!                                                                                                                                                                 
WARNING - Attempt to delete the physical volume store while geometry closed !                                                                                                                                        
WARNING - Attempt to delete the logical volume store while geometry closed !                                                                                                                                         
WARNING - Attempt to delete the solid store while geometry closed !                                                                                                                                                  
WARNING - Attempt to delete the region store while geometry closed !   
```

This occurs because fn++ is performed after the while condition check, meaning `if (fn == fNevents)` also triggers for the last event. I'm replacing this with` if (fn > fNevents)` to fix that issue.

small example to reproduce:
inpput: https://cernbox.cern.ch/s/q913GGqxmxvbSta

```
python3 "$FAIRSHIP/macro/run_simScript.py" \
            -n 5000 --MuonBack --FollowMuon --FastMuon \
            -f first5.root
```