### PR TITLE
Off-by-one in MuonBackGenerator end-of-tree check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ it in future.
 
 ### Fixed
 
+* Fix off-by-one in `MuonBackGenerator` end-of-tree check that incorrectly returned `kFALSE` when a muon was found on the last event
 * Fix uninitialised fDetPoints pointer in SHiP::Detector base class
 * Fix TStreamerInfo warnings for `SHiP::Detector` template instantiations by registering base class without streamer (`-`) in each detector's LinkDef
 * Fix TStreamerInfo warnings for ISTLPointContainer and generator classes by suppressing unnecessary streamer generation

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -195,6 +195,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     return fUseSTL ? MCTrack_vec->size() : MCTrack->GetEntries();
   };
 
+  bool found_muon = false;
   while (fn < fNevents) {
     fTree->GetEntry(fn);
     muList.clear();
@@ -208,6 +209,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       mass = pdgBase->GetParticle(id)->Mass();
       e = TMath::Sqrt(px * px + py * py + pz * pz + mass * mass);
       tof = 0;
+      found_muon = true;
       break;
     }
     if (id == -1) {  // use tree as input file
@@ -245,11 +247,12 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
         LOGF(debug, "No muon found %i", fn - 1);
       }
       if (found) {
+        found_muon = true;
         break;
       }
     }
   }
-  if (fn == fNevents) {
+  if (fn >= fNevents && !found_muon) {
     LOGF(info, "End of tree reached %i", fNevents);
     return kFALSE;
   }


### PR DESCRIPTION
When a muon is found on the last event, fn equals fNevents after the while loop increments it. The equality check incorrectly returned kFALSE despite having found a valid muon. Track whether a muon was found separately from the event counter.

Supersedes #1098 ?

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
