### PR TITLE
Graceful shutdown in MuonBackGenerator at end of input tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ it in future.
 
 ### Fixed
 
+* Fix `MuonBackGenerator` off-by-one returning `kFALSE` when a muon is found on the last event, and gracefully stop the MC run via `gMC->StopRun()` instead of triggering FairRoot's `exit(0)`
 * Fix duplicate `SHiP::Detector<vetoPoint>` rootmap entry warning by removing redundant LinkDef pragma from `muonShieldOptimization`
 * Fix uninitialised fDetPoints pointer in SHiP::Detector base class
 * Fix TStreamerInfo warnings for `SHiP::Detector` template instantiations by registering base class without streamer (`-`) in each detector's LinkDef

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -21,6 +21,7 @@
 #include "TRandom.h"
 #include "TSystem.h"
 #include "TVector.h"
+#include "TVirtualMC.h"
 #include "vetoPoint.h"
 
 using ShipUnit::cm;
@@ -195,6 +196,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     return fUseSTL ? MCTrack_vec->size() : MCTrack->GetEntries();
   };
 
+  bool found_muon = false;
   while (fn < fNevents) {
     fTree->GetEntry(fn);
     muList.clear();
@@ -208,6 +210,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       mass = pdgBase->GetParticle(id)->Mass();
       e = TMath::Sqrt(px * px + py * py + pz * pz + mass * mass);
       tof = 0;
+      found_muon = true;
       break;
     }
     if (id == -1) {  // use tree as input file
@@ -245,13 +248,15 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
         LOGF(debug, "No muon found %i", fn - 1);
       }
       if (found) {
+        found_muon = true;
         break;
       }
     }
   }
-  if (fn == fNevents) {
+  if (fn >= fNevents && !found_muon) {
     LOGF(info, "End of tree reached %i", fNevents);
-    return kFALSE;
+    gMC->StopRun();
+    return kTRUE;
   }
   if (fSameSeed) {
     Int_t theSeed = fn + fSameSeed * fNevents;


### PR DESCRIPTION
Fix off-by-one where fn == fNevents after finding a muon on the last event, incorrectly returning kFALSE. Track muon-found state separately from the event counter.

For genuine end-of-tree (no muon found), call gMC->StopRun() to request a graceful MC engine stop instead of returning kFALSE, which triggers FairRoot's StopRun() → exit(0) bug bypassing destructors and corrupting the output file.

Supersedes #1098 and #1099

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
