### PR TITLE
Restore original order of FairRunAna/FairEventManager creation

### DIFF
--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -34,12 +34,7 @@ def evExit() -> None:
 atexit.register(evExit)
 
 fMan = None
-
-fMan = ROOT.FairEventManager()
 fRun = None
-
-# -----   Reconstruction run   -------------------------------------------
-fRun = ROOT.FairRunAna()
 pdg = ROOT.TDatabasePDG.Instance()
 g = ROOT.gROOT
 gEnv = ROOT.gEnv
@@ -1158,6 +1153,8 @@ if root_version >= 63200:
 ROOT.gSystem.Load("libPythia6.so")
 ROOT.gSystem.Load("libpythia8.so")
 
+# -----   Reconstruction run   -------------------------------------------
+fRun = ROOT.FairRunAna()
 if options.geoFile:
     fRun.SetGeomFile(options.geoFile)
 
@@ -1174,6 +1171,8 @@ if options.ParFile:
     parInput1 = ROOT.FairParRootFileIo()
     parInput1.open(options.ParFile)
     rtdb.setFirstInput(parInput1)
+
+fMan = ROOT.FairEventManager()
 fMan.SetMaxEnergy(400.0)  # default is 25 GeV only !
 fMan.SetMinEnergy(0.1)  #  100 MeV
 fMan.SetEvtMaxEnergy(400.0)  # what is the difference between EvtMaxEnergy and MaxEnergy ?


### PR DESCRIPTION
Reverts the code-movement changes from 435a314 that moved FairRunAna and FairEventManager construction to the top of the file, before input files and parameters are configured. Keeps the SPDX license header.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass
