### PR TITLE
Eliminate CI build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ it in future.
 
 ### Fixed
 
+* Fix CI build warnings: add missing `override` specifiers, fix `Print()` and `Init()` virtual hiding, remove unused `FairShipFields` LinkDef entry
+
 ### Removed
 
 ## 26.03 - 2026-03-31

--- a/Detector/DetectorPoint.h
+++ b/Detector/DetectorPoint.h
@@ -42,7 +42,7 @@ class DetectorPoint : public FairMCPoint {
   std::array<Double_t, 3> fLpos, fLmom;
 
  private:
-  ClassDef(SHiP::DetectorPoint, 1);
+  ClassDefOverride(SHiP::DetectorPoint, 1);
 };
 }  // namespace SHiP
 

--- a/SND/EmulsionTarget/TTPoint.h
+++ b/SND/EmulsionTarget/TTPoint.h
@@ -47,7 +47,7 @@ class TTPoint : public FairMCPoint {
  private:
   Int_t fPdgCode;
 
-  ClassDef(TTPoint, 3)
+  ClassDefOverride(TTPoint, 3)
 };
 
 #endif  // SND_EMULSIONTARGET_TTPOINT_H_

--- a/SND/EmulsionTarget/TargetPoint.h
+++ b/SND/EmulsionTarget/TargetPoint.h
@@ -47,7 +47,7 @@ class TargetPoint : public FairMCPoint {
  private:
   Int_t fPdgCode;
 
-  ClassDef(TargetPoint, 3)
+  ClassDefOverride(TargetPoint, 3)
 };
 
 #endif  // SND_EMULSIONTARGET_TARGETPOINT_H_

--- a/SND/MTC/MTCDetHit.h
+++ b/SND/MTC/MTCDetHit.h
@@ -70,7 +70,7 @@ class MTCDetHit : public SHiP::DetectorHit {
   Float_t Xch = 0.0, Ych = 0.0, Zch = 0.0;
   Bool_t flag{true};  ///< flag
 
-  ClassDef(MTCDetHit, 6);
+  ClassDefOverride(MTCDetHit, 6);
 };
 
 #endif  // SND_MTC_MTCDETHIT_H_

--- a/SND/MTC/MTCDetPoint.h
+++ b/SND/MTC/MTCDetPoint.h
@@ -46,7 +46,7 @@ class MTCDetPoint : public FairMCPoint {
   }
   Int_t fPdgCode;
 
-  ClassDef(MTCDetPoint, 3)
+  ClassDefOverride(MTCDetPoint, 3)
 };
 
 #endif  // SND_MTC_MTCDETPOINT_H_

--- a/SND/SiliconTarget/SiliconTargetHit.h
+++ b/SND/SiliconTarget/SiliconTargetHit.h
@@ -60,7 +60,7 @@ class SiliconTargetHit : public SHiP::DetectorHit {
   Double_t fZ{0.};
   Bool_t flag{true};
 
-  ClassDef(SiliconTargetHit, 2);
+  ClassDefOverride(SiliconTargetHit, 2);
 };
 
 #endif  // SND_SILICONTARGET_SILICONTARGETHIT_H_

--- a/SND/SiliconTarget/SiliconTargetPoint.h
+++ b/SND/SiliconTarget/SiliconTargetPoint.h
@@ -59,7 +59,7 @@ class SiliconTargetPoint : public FairMCPoint {
  private:
   Int_t fPdgCode;
 
-  ClassDef(SiliconTargetPoint, 2)
+  ClassDefOverride(SiliconTargetPoint, 2)
 };
 
 #endif  // SND_SILICONTARGET_SILICONTARGETPOINT_H_

--- a/TimeDet/TimeDetHit.h
+++ b/TimeDet/TimeDetHit.h
@@ -59,7 +59,7 @@ class TimeDetHit : public SHiP::DetectorHit {
   Bool_t flag{true};  ///< flag
   Float_t t_1, t_2;   ///< TDC on both sides
 
-  ClassDef(TimeDetHit, 4);
+  ClassDefOverride(TimeDetHit, 4);
 };
 
 #endif  // TIMEDET_TIMEDETHIT_H_

--- a/UpstreamTagger/UpstreamTaggerHit.h
+++ b/UpstreamTagger/UpstreamTaggerHit.h
@@ -57,7 +57,7 @@ class UpstreamTaggerHit : public SHiP::DetectorHit {
   Double_t fZ;     ///< Smeared z position (cm)
   Double_t fTime;  ///< Smeared time (ns)
 
-  ClassDef(UpstreamTaggerHit, 2);
+  ClassDefOverride(UpstreamTaggerHit, 2);
 };
 
 #endif  // UPSTREAMTAGGER_UPSTREAMTAGGERHIT_H_

--- a/field/LinkDef.h
+++ b/field/LinkDef.h
@@ -14,5 +14,4 @@
 #pragma link C++ class ShipBFieldMap+;
 #pragma link C++ class ShipCompField+;
 #pragma link C++ class ShipFieldMaker+;
-#pragma link C++ class FairShipFields+;
 #endif

--- a/field/ShipBFieldMap.h
+++ b/field/ShipBFieldMap.h
@@ -77,7 +77,7 @@ class ShipBFieldMap : public TVirtualMagField {
     \param [out] B The x,y,z components of the magnetic field (kGauss = 0.1
     tesla)
   */
-  virtual void Field(const Double_t* position, Double_t* B);
+  void Field(const Double_t* position, Double_t* B) override;
 
   //! Typedef for a vector containing a vector of floats
   typedef std::vector<std::vector<Float_t>> floatArray;
@@ -298,7 +298,7 @@ class ShipBFieldMap : public TVirtualMagField {
   Bool_t IsACopy() const { return isCopy_; }
 
   //! ClassDef for ROOT
-  ClassDef(ShipBFieldMap, 1);
+  ClassDefOverride(ShipBFieldMap, 1);
 
  protected:
  private:

--- a/field/ShipBellField.cxx
+++ b/field/ShipBellField.cxx
@@ -126,7 +126,7 @@ Double_t ShipBellField::GetBz(Double_t x, Double_t y, Double_t z) { return 0.; }
 // -------------------------------------------------------------------------
 
 // -----   Screen output   -------------------------------------------------
-void ShipBellField::Print() {
+void ShipBellField::Print(Option_t*) const {
   cout << "======================================================" << endl;
   cout << "----  " << fTitle << " : " << fName << endl;
   cout << "----" << endl;

--- a/field/ShipBellField.h
+++ b/field/ShipBellField.h
@@ -46,14 +46,14 @@ class ShipBellField : public FairField {
   /** Get components of field at a given point
    ** @param x,y,z   Point coordinates [cm]
    **/
-  virtual Double_t GetBx(Double_t x, Double_t y, Double_t z);
-  virtual Double_t GetBy(Double_t x, Double_t y, Double_t z);
-  virtual Double_t GetBz(Double_t x, Double_t y, Double_t z);
+  Double_t GetBx(Double_t x, Double_t y, Double_t z) override;
+  Double_t GetBy(Double_t x, Double_t y, Double_t z) override;
+  Double_t GetBz(Double_t x, Double_t y, Double_t z) override;
 
   void IncludeTarget(Double_t xy, Double_t z, Double_t l);
 
   /** Screen output **/
-  virtual void Print();
+  void Print(Option_t* = "") const override;
 
  private:
   /** Field parameters **/
@@ -66,7 +66,7 @@ class ShipBellField : public FairField {
   Double_t targetZ0;
   Double_t targetL;
 
-  ClassDef(ShipBellField, 2);
+  ClassDefOverride(ShipBellField, 2);
 };
 
 #endif  // FIELD_SHIPBELLFIELD_H_

--- a/field/ShipCompField.h
+++ b/field/ShipCompField.h
@@ -51,7 +51,7 @@ class ShipCompField : public TVirtualMagField {
     \param [in] position The x,y,z global coordinates of the point
     \param [out] B The x,y,z components of the magnetic field
   */
-  virtual void Field(const Double_t* position, Double_t* B);
+  void Field(const Double_t* position, Double_t* B) override;
 
   //! Get the number of fields in the composite
   /*!
@@ -68,7 +68,7 @@ class ShipCompField : public TVirtualMagField {
   }
 
   //! ClassDef for ROOT
-  ClassDef(ShipCompField, 1);
+  ClassDefOverride(ShipCompField, 1);
 
  protected:
  private:

--- a/field/ShipConstField.cxx
+++ b/field/ShipConstField.cxx
@@ -138,7 +138,7 @@ Double_t ShipConstField::GetBz(Double_t x, Double_t y, Double_t z) {
 // -------------------------------------------------------------------------
 
 // -----   Screen output   -------------------------------------------------
-void ShipConstField::Print() {
+void ShipConstField::Print(Option_t*) const {
   cout << "======================================================" << endl;
   cout << "----  " << fTitle << " : " << fName << endl;
   cout << "----" << endl;

--- a/field/ShipConstField.h
+++ b/field/ShipConstField.h
@@ -60,9 +60,9 @@ class ShipConstField : public FairField {
   /** Get components of field at a given point
    ** @param x,y,z   Point coordinates [cm]
    **/
-  virtual Double_t GetBx(Double_t x, Double_t y, Double_t z);
-  virtual Double_t GetBy(Double_t x, Double_t y, Double_t z);
-  virtual Double_t GetBz(Double_t x, Double_t y, Double_t z);
+  Double_t GetBx(Double_t x, Double_t y, Double_t z) override;
+  Double_t GetBy(Double_t x, Double_t y, Double_t z) override;
+  Double_t GetBz(Double_t x, Double_t y, Double_t z) override;
 
   /** Accessors to field region **/
   Double_t GetXmin() const { return fXmin; }
@@ -78,7 +78,7 @@ class ShipConstField : public FairField {
   Double_t GetBz() const { return fBz; }
 
   /** Screen output **/
-  virtual void Print();
+  void Print(Option_t* = "") const override;
 
  private:
   /** Limits of the field region **/
@@ -94,7 +94,7 @@ class ShipConstField : public FairField {
   Double_t fBy;
   Double_t fBz;
 
-  ClassDef(ShipConstField, 1);
+  ClassDefOverride(ShipConstField, 1);
 };
 
 #endif  // FIELD_SHIPCONSTFIELD_H_

--- a/field/ShipFieldCreator.h
+++ b/field/ShipFieldCreator.h
@@ -22,7 +22,7 @@ class ShipFieldCreator : public FairFieldFactory {
   ~ShipFieldCreator() override;
   FairField* createFairField() override;
   void SetParm() override;
-  ClassDef(ShipFieldCreator, 1);
+  ClassDefOverride(ShipFieldCreator, 1);
 
  protected:
   ShipFieldPar* fFieldPar;

--- a/field/ShipFieldPar.h
+++ b/field/ShipFieldPar.h
@@ -24,10 +24,10 @@ class ShipFieldPar : public FairParGenericSet {
   ~ShipFieldPar();
 
   /** Put parameters **/
-  virtual void putParams(FairParamList* list);
+  void putParams(FairParamList* list) override;
 
   /** Get parameters **/
-  virtual Bool_t getParams(FairParamList* list);
+  Bool_t getParams(FairParamList* list) override;
 
   /** Set parameters from CbmField  **/
   void SetParameters(FairField* field);
@@ -88,7 +88,7 @@ class ShipFieldPar : public FairParGenericSet {
   ShipFieldPar(const ShipFieldPar&) = delete;
   ShipFieldPar& operator=(const ShipFieldPar&) = delete;
 
-  ClassDef(ShipFieldPar, 1);
+  ClassDefOverride(ShipFieldPar, 1);
 };
 
 #endif  // FIELD_SHIPFIELDPAR_H_

--- a/passive/ShipCave.h
+++ b/passive/ShipCave.h
@@ -21,7 +21,7 @@ class ShipCave : public FairModule {
   Double_t world[3];
 
  public:
-  ClassDef(ShipCave, 1)
+  ClassDefOverride(ShipCave, 1)
 };
 
 #endif  // PASSIVE_SHIPCAVE_H_

--- a/passive/ShipGeoCave.h
+++ b/passive/ShipGeoCave.h
@@ -26,7 +26,7 @@ class ShipGeoCave : public FairGeoSet {
   void addRefNodes();
   void write(std::fstream&);
   void print();
-  ClassDef(ShipGeoCave, 0)  // Class for the geometry of CAVE
+  ClassDefOverride(ShipGeoCave, 0)  // Class for the geometry of CAVE
 };
 
 #endif  // PASSIVE_SHIPGEOCAVE_H_  /* !PNDGEOCAVE_H */

--- a/passive/ShipMagnet.h
+++ b/passive/ShipMagnet.h
@@ -19,8 +19,8 @@ class ShipMagnet : public FairModule {
                       Double_t YD = 1., Double_t CT = 1.);
   ShipMagnet();
   ~ShipMagnet() override;
-  void ConstructGeometry();
-  ClassDef(ShipMagnet, 5);
+  void ConstructGeometry() override;
+  ClassDefOverride(ShipMagnet, 5);
 
  protected:
   Int_t fDesign;    // design, 1=circular 5m, 2 = ellipse 5x10, 3 = rectangular

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -25,7 +25,7 @@ class ShipMuonShield : public FairModule {
                  const Bool_t WithConstShieldField, const Bool_t SC_key);
   ShipMuonShield();
   ~ShipMuonShield() override;
-  void ConstructGeometry();
+  void ConstructGeometry() override;
   void SetSNDSpace(Bool_t hole, Double_t hole_dx, Double_t hole_dy);
 
  protected:
@@ -68,7 +68,7 @@ class ShipMuonShield : public FairModule {
                     Double_t Z, Bool_t NotMagnet, Bool_t SC_key);
 
  public:
-  ClassDef(ShipMuonShield, 4)
+  ClassDefOverride(ShipMuonShield, 4)
 };
 
 #endif  // PASSIVE_SHIPMUONSHIELD_H_

--- a/passive/ShipPassiveContFact.h
+++ b/passive/ShipPassiveContFact.h
@@ -19,8 +19,8 @@ class ShipPassiveContFact : public FairContFact {
   ShipPassiveContFact();
   ~ShipPassiveContFact() {}
   FairParSet* createContainer(FairContainer*);
-  ClassDef(ShipPassiveContFact,
-           0)  // Factory for all Passive parameter containers
+  ClassDefOverride(ShipPassiveContFact,
+                   0)  // Factory for all Passive parameter containers
 };
 
 #endif  // PASSIVE_SHIPPASSIVECONTFACT_H_

--- a/passive/ShipTAUMagneticSpectrometer.h
+++ b/passive/ShipTAUMagneticSpectrometer.h
@@ -19,9 +19,9 @@ class ShipTAUMagneticSpectrometer : public FairModule {
       const char* Title = "ShipTAUMagneticSpectrometer");
   ShipTAUMagneticSpectrometer();
   ~ShipTAUMagneticSpectrometer() override;
-  void ConstructGeometry();
+  void ConstructGeometry() override;
   void Initialize();
- ClassDef(ShipTAUMagneticSpectrometer, 1)
+ ClassDefOverride(ShipTAUMagneticSpectrometer, 1)
 
      protected
      : Double_t

--- a/passive/ShipTargetStation.h
+++ b/passive/ShipTargetStation.h
@@ -18,7 +18,7 @@ class ShipTargetStation : public FairModule {
                     const char* Title = "ShipTargetStation");
   ShipTargetStation();
   ~ShipTargetStation() override;
-  void ConstructGeometry();
+  void ConstructGeometry() override;
   void SetLayerPosMat(Float_t d, const std::vector<float>& L,
                       const std::vector<float>& G,
                       const std::vector<std::string>& M) {
@@ -30,7 +30,7 @@ class ShipTargetStation : public FairModule {
     assert(G.size() == fnS);
     fG = G;
   }
-  ClassDef(ShipTargetStation, 6);
+  ClassDefOverride(ShipTargetStation, 6);
 
  protected:
   Double_t fTargetLength;       //

--- a/shipdata/ShipMCTrack.h
+++ b/shipdata/ShipMCTrack.h
@@ -127,7 +127,7 @@ class ShipMCTrack : public TObject {
   /** Index of track in the event **/
   Int_t fTrackID;
 
-  ClassDef(ShipMCTrack, 9);
+  ClassDefOverride(ShipMCTrack, 9);
 };
 
 // ==========   Inline functions   ========================================

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -166,7 +166,7 @@ class ShipStack : public FairGenericStack {
 
   /** Accessors **/
   TParticle* GetParticle(Int_t trackId) const;
-  TClonesArray* GetListOfParticles() { return fParticles; }
+  TClonesArray* GetListOfParticles() override { return fParticles; }
 
  private:
   /** STL stack (FILO) used to handle the TParticles for tracking **/

--- a/shipgen/Generator.h
+++ b/shipgen/Generator.h
@@ -15,6 +15,7 @@
 namespace SHiP {
 class Generator : public FairGenerator {
  public:
+  using FairGenerator::Init;
   Generator() {};
   ~Generator() override;
 

--- a/splitcal/splitcalContFact.h
+++ b/splitcal/splitcalContFact.h
@@ -17,8 +17,8 @@ class splitcalContFact : public FairContFact {
   splitcalContFact();
   ~splitcalContFact() {}
   FairParSet* createContainer(FairContainer*);
-  ClassDef(splitcalContFact,
-           0)  // Factory for all splitcal parameter containers
+  ClassDefOverride(splitcalContFact,
+                   0)  // Factory for all splitcal parameter containers
 };
 
 #endif  // SPLITCAL_SPLITCALCONTFACT_H_

--- a/splitcal/splitcalHit.h
+++ b/splitcal/splitcalHit.h
@@ -91,7 +91,7 @@ class splitcalHit : public SHiP::DetectorHit {
   int _isPrecisionLayer, _nLayer, _nModuleX, _nModuleY, _nStrip, _isUsed;
   bool _isX, _isY;
 
-  ClassDef(splitcalHit, 6);
+  ClassDefOverride(splitcalHit, 6);
 };
 
 #endif  // SPLITCAL_SPLITCALHIT_H_

--- a/strawtubes/strawtubesContFact.h
+++ b/strawtubes/strawtubesContFact.h
@@ -17,8 +17,8 @@ class strawtubesContFact : public FairContFact {
   strawtubesContFact();
   ~strawtubesContFact() {}
   FairParSet* createContainer(FairContainer*);
-  ClassDef(strawtubesContFact,
-           0)  // Factory for all strawtubes parameter containers
+  ClassDefOverride(strawtubesContFact,
+                   0)  // Factory for all strawtubes parameter containers
 };
 
 #endif  // STRAWTUBES_STRAWTUBESCONTFACT_H_

--- a/strawtubes/strawtubesHit.h
+++ b/strawtubes/strawtubesHit.h
@@ -43,7 +43,7 @@ class strawtubesHit : public SHiP::DetectorHit {
  private:
   Bool_t flag{true};  ///< validity flag
 
-  ClassDef(strawtubesHit, 6);
+  ClassDefOverride(strawtubesHit, 6);
 };
 
 #endif  // STRAWTUBES_STRAWTUBESHIT_H_

--- a/veto/vetoContFact.h
+++ b/veto/vetoContFact.h
@@ -17,7 +17,8 @@ class vetoContFact : public FairContFact {
   vetoContFact();
   ~vetoContFact() {}
   FairParSet* createContainer(FairContainer*);
-  ClassDef(vetoContFact, 0)  // Factory for all veto parameter containers
+  ClassDefOverride(vetoContFact,
+                   0)  // Factory for all veto parameter containers
 };
 
 #endif  // VETO_VETOCONTFACT_H_

--- a/veto/vetoHit.h
+++ b/veto/vetoHit.h
@@ -49,7 +49,7 @@ class vetoHit : public SHiP::DetectorHit {
   Double_t ft{-1.};
   Bool_t flag{true};  ///< validity flag
 
-  ClassDef(vetoHit, 2);
+  ClassDefOverride(vetoHit, 2);
 };
 
 #endif  // VETO_VETOHIT_H_

--- a/veto/vetoHitOnTrack.h
+++ b/veto/vetoHitOnTrack.h
@@ -38,7 +38,7 @@ class vetoHitOnTrack : public TObject {
   Float_t fDist;  ///< distance to closest veto hit
   Int_t fHitID;   ///< hit ID
 
-  ClassDef(vetoHitOnTrack, 2);
+  ClassDefOverride(vetoHitOnTrack, 2);
 };
 
 #endif  // VETO_VETOHITONTRACK_H_


### PR DESCRIPTION
Use ClassDefOverride instead of ClassDef for classes inheriting from TObject, fix Print() and Init() virtual hiding in field and generator classes, and remove unused FairShipFields LinkDef entry.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved CI build warnings related to missing override specifiers and virtual method hiding issues.
  * Removed unused field configuration dictionary entry.

* **Chores**
  * Updated internal code to align with modern C++ standards by replacing deprecated macro declarations with override-compatible variants.
  * Standardized method signatures across detector and field components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->