### PR TITLE
fix: update references to removed muon shield configurations

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -170,7 +170,7 @@ jobs:
   #     matrix:
   #       vessel_option: [vacuums, helium]
   #       SND_option: [all]
-  #       muon_shield: [warm_opt, New_HA_Design]
+  #       muon_shield: [TRY_2025]
   #
   #   steps:
   #     - name: Checkout

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -117,7 +117,7 @@ ap.add_argument(
 )
 ap.add_argument(
     "--shieldName",
-    help="Name of the shield in the database. New_HA_Design or warm_opt.",
+    help="Name of the shield in the database.",
     default="TRY_2025",
     choices=["TRY_2025"],
 )

--- a/muonShieldOptimization/study_GammaConv.py
+++ b/muonShieldOptimization/study_GammaConv.py
@@ -41,7 +41,7 @@ ecut = 0.0
 # -------------------------------------------------------------------
 ROOT.gRandom.SetSeed(theSeed)  # this should be propagated via ROOT to Pythia8 and Geant4VMC
 shipRoot_conf.configure()  # load basic libraries, prepare atexit for python
-ship_geo = geometry_config.create_config(Yheight=10, shieldName="warm_opt")
+ship_geo = geometry_config.create_config(Yheight=10, shieldName="TRY_2025")
 
 # -----Timer--------------------------------------------------------
 timer = ROOT.TStopwatch()

--- a/muonShieldOptimization/study_muMSC.py
+++ b/muonShieldOptimization/study_muMSC.py
@@ -42,7 +42,7 @@ ecut = 0.0
 # -------------------------------------------------------------------
 ROOT.gRandom.SetSeed(theSeed)  # this should be propagated via ROOT to Pythia8 and Geant4VMC
 shipRoot_conf.configure()  # load basic libraries, prepare atexit for python
-ship_geo = geometry_config.create_config(Yheight=10, shieldName="warm_opt")
+ship_geo = geometry_config.create_config(Yheight=10, shieldName="TRY_2025")
 
 # -----Timer--------------------------------------------------------
 timer = ROOT.TStopwatch()

--- a/muonShieldOptimization/study_thinTarget.py
+++ b/muonShieldOptimization/study_thinTarget.py
@@ -48,7 +48,7 @@ if theSeed > 900000000:
     theSeed = theSeed % 900000000
 ROOT.gRandom.SetSeed(theSeed)
 shipRoot_conf.configure()  # load basic libraries, prepare atexit for python
-ship_geo = geometry_config.create_config(Yheight=10, shieldName="warm_opt")
+ship_geo = geometry_config.create_config(Yheight=10, shieldName="TRY_2025")
 
 # -----Timer--------------------------------------------------------
 timer = ROOT.TStopwatch()

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -13,7 +13,7 @@ from ShipGeoConfig import AttrDict, Config
 # targetOpt      = 5  # 0=solid   >0 sliced, 5: 5 pieces of tungsten, 4 air slits, 17: molybdenum tungsten interleaved with H20
 # strawOpt       = 0  # 4=aluminium frame 10=steel frame (default)
 
-# Here you can select the MS geometry, if the MS design is using SC magnet change the hybrid to True
+# Here you can select the MS geometry
 # The first row is the length of the magnets
 # The other rows are the transverse dimensions of the magnets:  dXIn[i], dXOut[i] , dYIn[i], dYOut[i], gapIn[i], gapOut[i].
 shield_db = {
@@ -133,7 +133,7 @@ def create_config(
     Yheight: float = 6.0,
     strawDesign: int = 10,
     muShieldGeo=None,
-    shieldName: str = "New_HA_Design",
+    shieldName: str = "TRY_2025",
     nuTargetPassive: int = 1,
     SND: bool = True,
     SND_design=None,
@@ -147,7 +147,7 @@ def create_config(
         Yheight: Height of vacuum tank in meters, default: 6.0
         strawDesign: Straw tube design (4=aluminium frame, 10=steel frame), default: 10
         muShieldGeo: Muon shield geometry file (for experts), default: None
-        shieldName: Name of shield configuration ("warm_opt" or "New_HA_Design"), default: "New_HA_Design"
+        shieldName: Name of shield configuration, default: "TRY_2025"
         nuTargetPassive: Target type (0=with active layers, 1=only passive), default: 1
         SND: Enable SND detector, default: True
         SND_design: SND design options (list of design numbers), default: [2]


### PR DESCRIPTION
Replace remaining references to "warm_opt" and "New_HA_Design" with "TRY_2025", the only supported muon shield configuration since 26.03.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default shield configuration across simulation scripts and geometry settings to use new "TRY_2025" option
  * Refreshed CI workflow matrix configurations
  * Refined command-line argument documentation for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->