### PR TITLE
feat: add angular acceptance cut for HNL and DP generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ it in future.
 
 ### Changed
 * Make artificial retina the baseline option for pattern recognition
+* `nrOfRetries()` in HNL and DP generators now includes geometric acceptance rejections, not only phasespace failures
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ it in future.
 
 ### Added
 
+* Add angular acceptance cut in HNL and DP generators to skip events outside the decay vessel
 * Add FileSummary to run_fixedTarget.py to save all the options for reference (#1140)
 * Add new 2026_04_01_SHiP_MainSpectrometerField_V13.root fieldmap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ it in future.
 
 ### Changed
 * Make artificial retina the baseline option for pattern recognition
-* `nrOfRetries()` in HNL and DP generators now includes geometric acceptance rejections, not only phasespace failures
+* `nrOfRetries()` in HNL and DP generators now counts only production failures; geometric acceptance rejections are tracked separately via `nrOfGeoRejections()`
+* Read vessel end dimensions from veto YAML config instead of hardcoding in `geometry_config.py`
 
 ### Fixed
 

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -459,11 +459,14 @@ if options.pythia8:
         P8gen.SetPaintRadius(options.PaintBeam * u.cm)  # beam painting radius
         P8gen.SetLmin((ship_geo.Chamber1.z - ship_geo.chambers.Tub1length) - ship_geo.target.z0)
         P8gen.SetLmax(ship_geo.TrackStation1.z - ship_geo.target.z0)
-        margin = 10 * u.cm
-        z_end = ship_geo.decayVolume.z0 + ship_geo.decayVolume.length
+        margin = 10 * u.cm  # covers beam smearing + non-projectivity of vessel
+        z_end = ship_geo.decayVolume.z0 + ship_geo.decayVolume.length  # vessel exit z from target
+        # xEndInner/yEndInner are full inner widths; divide by 2 for half-aperture.
+        # Assumes production vertex at target (z=0). Vessel is approximately
+        # projective, so a single angle cut at the exit (widest point) suffices.
         max_theta_x = (ship_geo.decayVolume.xEndInner / 2 + margin) / z_end
         max_theta_y = (ship_geo.decayVolume.yEndInner / 2 + margin) / z_end
-        P8gen.SetMaxTheta(max_theta_x, max_theta_y)
+        P8gen.SetMaxTheta(max_theta_x, max_theta_y)  # slope bounds: |px/pz|, |py/pz|
     if charmonly:
         primGen.SetTarget(0.0, 0.0)  # vertex is set in pythia8Generator
         ut.checkFileExists(inputFile)
@@ -766,9 +769,9 @@ print(" ")
 print("Macro finished successfully.")
 if "P8gen" in globals():
     if HNL:
-        print("number of retries, events without HNL ", P8gen.nrOfRetries())
+        print("number of retries (no HNL or outside vessel acceptance) ", P8gen.nrOfRetries())
     elif options.DarkPhoton:
-        print("number of retries, events without Dark Photons ", P8gen.nrOfRetries())
+        print("number of retries (no DP or outside vessel acceptance) ", P8gen.nrOfRetries())
         print("total number of dark photons (including multiple meson decays per single collision) ", P8gen.nrOfDP())
 
 print("Output file is ", outFile)

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -769,9 +769,11 @@ print(" ")
 print("Macro finished successfully.")
 if "P8gen" in globals():
     if HNL:
-        print("number of retries (no HNL or outside vessel acceptance) ", P8gen.nrOfRetries())
+        print("number of retries (no HNL produced) ", P8gen.nrOfRetries())
+        print("number of geometric rejections (outside vessel acceptance) ", P8gen.nrOfGeoRejections())
     elif options.DarkPhoton:
-        print("number of retries (no DP or outside vessel acceptance) ", P8gen.nrOfRetries())
+        print("number of retries (no DP produced) ", P8gen.nrOfRetries())
+        print("number of geometric rejections (outside vessel acceptance) ", P8gen.nrOfGeoRejections())
         print("total number of dark photons (including multiple meson decays per single collision) ", P8gen.nrOfDP())
 
 print("Output file is ", outFile)

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -459,6 +459,11 @@ if options.pythia8:
         P8gen.SetPaintRadius(options.PaintBeam * u.cm)  # beam painting radius
         P8gen.SetLmin((ship_geo.Chamber1.z - ship_geo.chambers.Tub1length) - ship_geo.target.z0)
         P8gen.SetLmax(ship_geo.TrackStation1.z - ship_geo.target.z0)
+        margin = 10 * u.cm
+        z_end = ship_geo.decayVolume.z0 + ship_geo.decayVolume.length
+        max_theta_x = (ship_geo.decayVolume.xEndInner / 2 + margin) / z_end
+        max_theta_y = (ship_geo.decayVolume.yEndInner / 2 + margin) / z_end
+        P8gen.SetMaxTheta(max_theta_x, max_theta_y)
     if charmonly:
         primGen.SetTarget(0.0, 0.0)  # vertex is set in pythia8Generator
         ut.checkFileExists(inputFile)

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -282,9 +282,11 @@ def create_config(
     c.z = 89.57 * u.m  # absolute position of spectrometer magnet
     c.decayVolume.z = c.z - 31.450 * u.m  # Relative position of decay vessel centre to spectrometer magnet
     c.decayVolume.z0 = c.decayVolume.z - c.decayVolume.length / 2.0
-    # Full inner widths at vessel exit (cm), must match veto_config_{helium,vacuums}.yaml
-    c.decayVolume.xEndInner = 400 * u.cm
-    c.decayVolume.yEndInner = 600 * u.cm
+    veto_yaml = os.path.expandvars(f"$FAIRSHIP/geometry/veto_config_{DecayVolumeMedium}.yaml")
+    with open(veto_yaml) as f:
+        veto_config = yaml.safe_load(f)
+    c.decayVolume.xEndInner = veto_config["xendInner"] * u.cm
+    c.decayVolume.yEndInner = veto_config["yendInner"] * u.cm
 
     c.chambers = AttrDict()
     magnetIncrease = 100.0 * u.cm

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -282,6 +282,10 @@ def create_config(
     c.z = 89.57 * u.m  # absolute position of spectrometer magnet
     c.decayVolume.z = c.z - 31.450 * u.m  # Relative position of decay vessel centre to spectrometer magnet
     c.decayVolume.z0 = c.decayVolume.z - c.decayVolume.length / 2.0
+    c.decayVolume.xStartInner = 100 * u.cm
+    c.decayVolume.xEndInner = 400 * u.cm
+    c.decayVolume.yStartInner = 270 * u.cm
+    c.decayVolume.yEndInner = 600 * u.cm
 
     c.chambers = AttrDict()
     magnetIncrease = 100.0 * u.cm

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -282,9 +282,8 @@ def create_config(
     c.z = 89.57 * u.m  # absolute position of spectrometer magnet
     c.decayVolume.z = c.z - 31.450 * u.m  # Relative position of decay vessel centre to spectrometer magnet
     c.decayVolume.z0 = c.decayVolume.z - c.decayVolume.length / 2.0
-    c.decayVolume.xStartInner = 100 * u.cm
+    # Full inner widths at vessel exit (cm), must match veto_config_{helium,vacuums}.yaml
     c.decayVolume.xEndInner = 400 * u.cm
-    c.decayVolume.yStartInner = 270 * u.cm
     c.decayVolume.yEndInner = 600 * u.cm
 
     c.chambers = AttrDict()

--- a/shipgen/DPPythia8Generator.cxx
+++ b/shipgen/DPPythia8Generator.cxx
@@ -237,7 +237,7 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       if (accepted.empty()) {
         iDP = 0;
         dpvec.clear();
-        fnRetries += 1;
+        fnGeoRejects += 1;
         continue;
       }
       int r = static_cast<int>(gRandom->Uniform(0, accepted.size()));

--- a/shipgen/DPPythia8Generator.cxx
+++ b/shipgen/DPPythia8Generator.cxx
@@ -223,16 +223,25 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
     iDP = dpvec.size();
     fnDPtot += iDP;
     if (iDP == 0) {
-      // fLogger->Info(MESSAGE_ORIGIN,"Event without DP. Retry.");
-      // fPythia->event.list();
-      fnRetries +=
-          1;  // can happen if phasespace does not allow meson to decay to DP
+      fnRetries += 1;
     } else {
-      // for mesons, could have more than one ... but for DY prod, need to take
-      // the last one... int r =  int( gRandom->Uniform(0,iDP) );
-      int r = iDP - 1;
-      // std::cout << " ----> debug 2 " << r  <<  std::endl;
-      int i = dpvec[r];
+      // filter DPs by vessel acceptance
+      std::vector<int> accepted;
+      for (int idx : dpvec) {
+        if (IsInVesselAcceptance(fPythia->event[idx].px(),
+                                 fPythia->event[idx].py(),
+                                 fPythia->event[idx].pz())) {
+          accepted.push_back(idx);
+        }
+      }
+      if (accepted.empty()) {
+        iDP = 0;
+        dpvec.clear();
+        fnRetries += 1;
+        continue;
+      }
+      int r = static_cast<int>(gRandom->Uniform(0, accepted.size()));
+      int i = accepted[r];
       // production vertex
       zp = fPythia->event[i].zProd();
       xp = fPythia->event[i].xProd();
@@ -243,13 +252,6 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       px = fPythia->event[i].px();
       py = fPythia->event[i].py();
       e = fPythia->event[i].e();
-      // check if trajectory can reach the decay vessel
-      if (!IsInVesselAcceptance(px, py, pz)) {
-        iDP = 0;
-        dpvec.clear();
-        fnRetries += 1;
-        continue;
-      }
       // old decay vertex
       // Int_t ida =fPythia->event[i].daughter1();
       std::cout << " Debug: decay product of A: "

--- a/shipgen/DPPythia8Generator.cxx
+++ b/shipgen/DPPythia8Generator.cxx
@@ -243,6 +243,13 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       px = fPythia->event[i].px();
       py = fPythia->event[i].py();
       e = fPythia->event[i].e();
+      // check if trajectory can reach the decay vessel
+      if (!IsInVesselAcceptance(px, py, pz)) {
+        iDP = 0;
+        dpvec.clear();
+        fnRetries += 1;
+        continue;
+      }
       // old decay vertex
       // Int_t ida =fPythia->event[i].daughter1();
       std::cout << " Debug: decay product of A: "

--- a/shipgen/DPPythia8Generator.h
+++ b/shipgen/DPPythia8Generator.h
@@ -108,7 +108,7 @@ class DPPythia8Generator : public SHiP::Generator {
                      // QCD production.
   Double_t fLmin;    // m minimum  decay position z
   Double_t fLmax;    // m maximum decay position z
-  Int_t fnRetries;   // number of events without any DP
+  Int_t fnRetries;   // retries: no DP produced or outside vessel acceptance
   Int_t fnDPtot;  // total number of DP from multiple mesons in single collision
   Double_t fctau;  // dark photon lifetime
   Double_t fFDs;   // correction for Pythia6 to match measured Ds production

--- a/shipgen/DPPythia8Generator.h
+++ b/shipgen/DPPythia8Generator.h
@@ -108,7 +108,7 @@ class DPPythia8Generator : public SHiP::Generator {
                      // QCD production.
   Double_t fLmin;    // m minimum  decay position z
   Double_t fLmax;    // m maximum decay position z
-  Int_t fnRetries;   // retries: no DP produced or outside vessel acceptance
+  Int_t fnRetries;   // retries: no DP produced
   Int_t fnDPtot;  // total number of DP from multiple mesons in single collision
   Double_t fctau;  // dark photon lifetime
   Double_t fFDs;   // correction for Pythia6 to match measured Ds production

--- a/shipgen/Generator.h
+++ b/shipgen/Generator.h
@@ -5,6 +5,7 @@
 #ifndef SHIPGEN_GENERATOR_H_
 #define SHIPGEN_GENERATOR_H_
 
+#include <cmath>
 #include <optional>
 #include <string>
 #include <vector>
@@ -44,9 +45,24 @@ class Generator : public FairGenerator {
     UseExternalFile(inFiles.at(0).c_str(), i);
   }
 
+  void SetMaxTheta(Double_t thetaX, Double_t thetaY) {
+    fMaxThetaX = thetaX;
+    fMaxThetaY = thetaY;
+    fUseVesselAcceptance = true;
+  };
+
  protected:
+  bool IsInVesselAcceptance(Double_t px, Double_t py, Double_t pz) const {
+    if (!fUseVesselAcceptance) return true;
+    if (pz <= 0) return false;
+    return std::abs(px / pz) < fMaxThetaX && std::abs(py / pz) < fMaxThetaY;
+  }
+
   std::optional<std::string> fextFile;
   Int_t firstEvent = 0;
+  Double_t fMaxThetaX = 0;
+  Double_t fMaxThetaY = 0;
+  bool fUseVesselAcceptance = false;
 };
 }  // namespace SHiP
 #endif  // SHIPGEN_GENERATOR_H_

--- a/shipgen/Generator.h
+++ b/shipgen/Generator.h
@@ -52,6 +52,7 @@ class Generator : public FairGenerator {
     fMaxThetaY = thetaY;
     fUseVesselAcceptance = true;
   };
+  Int_t nrOfGeoRejections() const { return fnGeoRejects; }
 
  protected:
   bool IsInVesselAcceptance(Double_t px, Double_t py, Double_t pz) const {
@@ -65,6 +66,7 @@ class Generator : public FairGenerator {
   Double_t fMaxThetaX = 0;
   Double_t fMaxThetaY = 0;
   bool fUseVesselAcceptance = false;
+  Int_t fnGeoRejects = 0;
 };
 }  // namespace SHiP
 #endif  // SHIPGEN_GENERATOR_H_

--- a/shipgen/Generator.h
+++ b/shipgen/Generator.h
@@ -45,6 +45,8 @@ class Generator : public FairGenerator {
     UseExternalFile(inFiles.at(0).c_str(), i);
   }
 
+  /// Set maximum allowed slopes |px/pz| and |py/pz| for vessel acceptance.
+  /// Parameters are tan(theta), not angle in radians.
   void SetMaxTheta(Double_t thetaX, Double_t thetaY) {
     fMaxThetaX = thetaX;
     fMaxThetaY = thetaY;

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -157,7 +157,7 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       if (accepted.empty()) {
         iHNL = 0;
         hnls.clear();
-        fnRetries += 1;
+        fnGeoRejects += 1;
         continue;
       }
       int r = static_cast<int>(gRandom->Uniform(0, accepted.size()));

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -161,6 +161,13 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       px = fPythia->event[i].px();
       py = fPythia->event[i].py();
       e = fPythia->event[i].e();
+      // check if trajectory can reach the decay vessel
+      if (!IsInVesselAcceptance(px, py, pz)) {
+        iHNL = 0;
+        hnls.clear();
+        fnRetries += 1;
+        continue;
+      }
       // new decay vertex
       Double_t LS = gRandom->Uniform(fLmin, fLmax);  // mm, G4 and Pythia8 units
       Double_t p = TMath::Sqrt(px * px + py * py + pz * pz);

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -143,14 +143,25 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
     }
     iHNL = hnls.size();
     if (iHNL == 0) {
-      // fLogger->Info(MESSAGE_ORIGIN,"Event without HNL. Retry.");
-      // fPythia->event.list();
-      fnRetries += 1;  // can happen if phasespace does not allow charm hadron
-                       // to decay to HNL
+      fnRetries += 1;
     } else {
-      int r = static_cast<int>(gRandom->Uniform(0, iHNL));
-      // cout << " ----> debug 2 " << r  <<  endl;
-      int i = hnls[r];
+      // filter HNLs by vessel acceptance
+      std::vector<int> accepted;
+      for (int idx : hnls) {
+        if (IsInVesselAcceptance(fPythia->event[idx].px(),
+                                 fPythia->event[idx].py(),
+                                 fPythia->event[idx].pz())) {
+          accepted.push_back(idx);
+        }
+      }
+      if (accepted.empty()) {
+        iHNL = 0;
+        hnls.clear();
+        fnRetries += 1;
+        continue;
+      }
+      int r = static_cast<int>(gRandom->Uniform(0, accepted.size()));
+      int i = accepted[r];
       // production vertex
       zp = fPythia->event[i].zProd();
       xp = fPythia->event[i].xProd();
@@ -161,13 +172,6 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       px = fPythia->event[i].px();
       py = fPythia->event[i].py();
       e = fPythia->event[i].e();
-      // check if trajectory can reach the decay vessel
-      if (!IsInVesselAcceptance(px, py, pz)) {
-        iHNL = 0;
-        hnls.clear();
-        fnRetries += 1;
-        continue;
-      }
       // new decay vertex
       Double_t LS = gRandom->Uniform(fLmin, fLmax);  // mm, G4 and Pythia8 units
       Double_t p = TMath::Sqrt(px * px + py * py + pz * pz);

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -100,7 +100,7 @@ class HNLPythia8Generator : public SHiP::Generator {
   Bool_t fUseRandom3;  // flag to use TRandom3 (default)
   Double_t fLmin;      // m minimum  decay position z
   Double_t fLmax;      // m maximum decay position z
-  Int_t fnRetries;     // retries: no HNL produced or outside vessel acceptance
+  Int_t fnRetries;     // retries: no HNL produced
   Double_t fctau;      // hnl lifetime
   Double_t fFDs;       // correction for Pythia6 to match measured Ds production
   Double_t fsmearBeam;  // finite beam size

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -100,7 +100,7 @@ class HNLPythia8Generator : public SHiP::Generator {
   Bool_t fUseRandom3;  // flag to use TRandom3 (default)
   Double_t fLmin;      // m minimum  decay position z
   Double_t fLmax;      // m maximum decay position z
-  Int_t fnRetries;     // number of events without any HNL
+  Int_t fnRetries;     // retries: no HNL produced or outside vessel acceptance
   Double_t fctau;      // hnl lifetime
   Double_t fFDs;       // correction for Pythia6 to match measured Ds production
   Double_t fsmearBeam;  // finite beam size


### PR DESCRIPTION
Skip events where the HNL/DP trajectory angle exceeds the decay vessel acceptance. The maximum angles in x and y are derived from the vessel geometry with a 10 cm margin. Events outside acceptance trigger a retry with a new Pythia event, reusing the existing retry loop.

@amagnan @THanae I'm not sure whether we need to account for this in the statistics.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generators now enforce angular/slope acceptance and only produce candidates that can reach the decay vessel.

* **Changed**
  * Retry/end-of-run reporting now separates and reports geometric rejections (outside vessel acceptance).
  * Decay-vessel end dimensions are now read from veto configuration (may change effective vessel extents).

* **Documentation**
  * CHANGELOG updated with these Unreleased entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->