### PR TITLE
Replace elliptical acceptance with rectangular in shipStrawTracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ it in future.
 
 ### Fixed
 
+* Replace obsolete elliptical acceptance cut with rectangular acceptance in track pattern recognition
 * Fix CI build warnings: add missing `override` specifiers, fix `Print()` and `Init()` virtual hiding, remove unused `FairShipFields` LinkDef entry
 
 ### Removed

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -700,7 +700,7 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
         ahit = sTree.strawtubesPoint[i]
 
         # is hit inside acceptance? if not mark the track as bad
-        if ((ahit.GetX() / 245.0) ** 2 + (ahit.GetY() / 495.0) ** 2) >= 1.0:
+        if abs(ahit.GetX()) >= 195.0 or abs(ahit.GetY()) >= 295.0:
             if ahit.GetTrackID() not in trackoutsidestations:
                 trackoutsidestations.append(ahit.GetTrackID())
 

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -12,6 +12,7 @@ import ROOT
 
 # For modules
 import shipDet_conf
+import shipunit as u
 
 # For ShipGeo
 from ShipGeoConfig import load_from_root_file
@@ -693,14 +694,18 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     hits4 = {}
     trackoutsidestations = []
 
+    margin = 5.0 * u.cm
+    x_bound = ShipGeo.strawtubes_geo.width - margin
+    y_bound = ShipGeo.strawtubes_geo.height - margin
+
     for i in range(nHits):
         if i in duplicatestrawhit:
             continue
 
         ahit = sTree.strawtubesPoint[i]
 
-        # is hit inside acceptance? if not mark the track as bad
-        if abs(ahit.GetX()) >= 195.0 or abs(ahit.GetY()) >= 295.0:
+        # is hit inside acceptance (width/height minus margin)?
+        if abs(ahit.GetX()) >= x_bound or abs(ahit.GetY()) >= y_bound:
             if ahit.GetTrackID() not in trackoutsidestations:
                 trackoutsidestations.append(ahit.GetTrackID())
 


### PR DESCRIPTION
NB: Does not affect tracking run as part of reconstruction, only standalone tracking script.

SHiP now has a rectangular acceptance. Use straw tube aperture (200x300 cm) minus 5 cm margin instead of the obsolete ellipse (245x495 cm).

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated track pattern recognition acceptance from an elliptical to a rectangular boundary, improving which hits are classified as in/out of acceptance.
* **Documentation**
  * Added an entry to the Unreleased changelog documenting the acceptance-behavior update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->