### PR TITLE
fix: use stepwise extrapolation in vertex finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ it in future.
 
 ### Fixed
 
+* Fix vertex finding for upstream vertices by using stepwise extrapolation
 * Replace obsolete elliptical acceptance cut with rectangular acceptance in track pattern recognition
 * Fix CI build warnings: add missing `override` specifiers, fix `Print()` and `Init()` virtual hiding, remove unused `FairShipFields` LinkDef entry
 

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -82,6 +82,19 @@ class Task:
         self.chi2(res, self.Vy)
         return
 
+    def _stepwise_extrapolate_to_z(self, extrapolate_fn, current_z, target_z, max_step=500.0):
+        """Extrapolate in steps to avoid RK failures over large distances."""
+        dz_total = target_z - current_z
+        n_steps = max(1, math.ceil(abs(dz_total) / max_step))
+        for istep in range(n_steps):
+            step_z = current_z + dz_total * (istep + 1) / n_steps
+            plane = ROOT.genfit.DetPlane(
+                ROOT.TVector3(0, 0, step_z),
+                ROOT.TVector3(1, 0, 0),
+                ROOT.TVector3(0, 1, 0),
+            )
+            extrapolate_fn(ROOT.genfit.SharedPlanePtr(plane))
+
     def TwoTrackVertex(self) -> None:
         self.fPartArray.clear()
         fittedTracks = getattr(self.sTree, self.fitTrackLoc)
@@ -123,9 +136,37 @@ class Task:
                 if PosDirCharge[t2]["charge"] == c1:
                     continue
                 newPos, doca = self.VertexError(t1, t2, PosDirCharge)
+                # Extrapolate both tracks toward the initial vertex
+                # estimate in steps to avoid long backward extrapolation
+                # through the magnetic field which causes RK failures.
+                rc = True
+                target_z = newPos[2]
+                extrapolatedPosDir = {}
+                for tr in [t1, t2]:
+                    current_z = PosDirCharge[tr]["rep"].getPos(PosDirCharge[tr]["newstate"]).Z()
+                    try:
+                        self._stepwise_extrapolate_to_z(
+                            lambda sp, _tr=tr: PosDirCharge[_tr]["rep"].extrapolateToPlane(
+                                PosDirCharge[_tr]["newstate"], sp
+                            ),
+                            current_z,
+                            target_z,
+                        )
+                    except Exception:
+                        ut.reportError("shipVertex: stepwise plane extrapolation did not work")
+                        rc = False
+                        break
+                    extrapolatedPosDir[tr] = {
+                        "position": PosDirCharge[tr]["rep"].getPos(PosDirCharge[tr]["newstate"]),
+                        "direction": PosDirCharge[tr]["rep"].getDir(PosDirCharge[tr]["newstate"]),
+                        "momentum": PosDirCharge[tr]["rep"].getMom(PosDirCharge[tr]["newstate"]),
+                    }
+                if not rc:
+                    continue
+                # Recompute DOCA from the extrapolated positions
+                newPos, doca = self.VertexError(t1, t2, extrapolatedPosDir)
                 # as we have learned, need iterative procedure
                 dz = 99999.0
-                rc = True
                 step = 0
                 while dz > 0.01:
                     zBefore = newPos[2]
@@ -166,7 +207,6 @@ class Task:
                 #
                 if not rc:
                     continue  # extrapolation failed, makes no sense to continue
-                    # now go for the last step and vertex error
                 scalFac[t1] = (
                     (PosDirCharge[t1]["position"][2] - newPos[2])
                     / PosDirCharge[t1]["direction"][2]
@@ -197,21 +237,19 @@ class Task:
 
                 # print "*********************************** vertex fit precise   ******************************************** "
 
-                detPlane = ROOT.genfit.DetPlane(
-                    ROOT.TVector3(0, 0, HNLPos[2]), ROOT.TVector3(1, 0, 0), ROOT.TVector3(0, 1, 0)
-                )
-                detPlanePtr = ROOT.genfit.SharedPlanePtr(detPlane)
                 st1 = fittedTracks[t1].getFittedState()
                 st2 = fittedTracks[t2].getFittedState()
-                try:
-                    st1.extrapolateToPlane(detPlanePtr)
-                except Exception:
-                    ut.reportError("shipVertex.TwoTrackVertex: extrapolation did not work")
-                    continue
-                try:
-                    st2.extrapolateToPlane(detPlanePtr)
-                except Exception:
-                    ut.reportError("shipVertex.TwoTrackVertex: extrapolation did not work")
+                # Extrapolate to the vertex Z-plane stepwise to avoid
+                # RK failures for long backward extrapolation.
+                rc = True
+                for st in [st1, st2]:
+                    try:
+                        self._stepwise_extrapolate_to_z(st.extrapolateToPlane, st.getPos().Z(), HNLPos[2])
+                    except Exception:
+                        ut.reportError("shipVertex.TwoTrackVertex: extrapolation did not work")
+                        rc = False
+                        break
+                if not rc:
                     continue
                 mom1 = st1.getMom()
                 mom2 = st2.getMom()


### PR DESCRIPTION
The iterative vertex finder and precision fit extrapolate tracks from the straw tracker (Z≈8400 cm) backwards to the decay vertex. 
For upstream vertices (Z≈3500–5500 cm), the single-step backward Runge-Kutta propagation throws numerical exceptions.

Use stepwise plane extrapolation (500 cm steps) in both the DOCA iteration loop and the precision fit stage of `TwoTrackVertex()`.

On an example HNL→µπ sample (2500 events, V21_3000 geometry), this recovers 68 additional vertices, improving vertexing efficiency from 66% to 85% of reconstructible events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upstream vertex finding — stepwise track extrapolation reduces fit failures and improves success rate for distant/long tracks.
* **Refactor**
  * Improved vertex-fitting workflow for more stable and precise vertex position and distance-of-closest-approach estimates, yielding more reliable reconstruction overall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->