### PR TITLE
fix: determine track charge from bending and dual-hypothesis fitting

### DIFF
--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -264,6 +264,7 @@ class ShipDigiReco:
                     theTrack.checkConsistency()
                 except ROOT.genfit.Exception:
                     logger.debug("Track inconsistent after fit for hypothesis %d", try_pdg)
+                    continue
                 try:
                     fittedState = theTrack.getFittedState()
                     fittedState.getMomMag()

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
+import contextlib
 import logging
 from array import array
 
@@ -221,93 +222,74 @@ class ShipDigiReco:
             # Seed state: use PatRec track parameters when available
             posM, momM = self._compute_seed_state(atrack, meas, trackParams)
 
-            # approximate covariance
-            covM = ROOT.TMatrixDSym(6)
-            resolution = self.sigma_spatial
-            if global_variables.withT0:
-                resolution *= 1.4  # worse resolution due to t0 estimate
-            for i in range(3):
-                covM[i][i] = resolution * resolution
-            covM[0][0] = resolution * resolution * 100.0
-            for i in range(3, 6):
-                covM[i][i] = ROOT.TMath.Power(resolution / nM / ROOT.TMath.Sqrt(3), 2)
-                # trackrep
-            rep = ROOT.genfit.RKTrackRep(pdg)
-            # smeared start state
-            stateSmeared = ROOT.genfit.MeasuredStateOnPlane(rep)
-            rep.setPosMomCov(stateSmeared, posM, momM, covM)
-            # create track
-            seedState = ROOT.TVectorD(6)
-            seedCov = ROOT.TMatrixDSym(6)
-            rep.get6DStateCov(stateSmeared, seedState, seedCov)
-            theTrack = ROOT.genfit.Track(rep, seedState, seedCov)
-            hitCov = ROOT.TMatrixDSym(7)
-            hitCov[6][6] = resolution * resolution
-            hitID = 0
-            for m, detID in zip(meas, detIDs):
-                tp = ROOT.genfit.TrackPoint(theTrack)  # note how the point is told which track it belongs to
-                measurement = ROOT.genfit.WireMeasurement(
-                    m, hitCov, detID, hitID, tp
-                )  # the measurement is told which trackpoint it belongs to
-                measurement.setMaxDistance(
-                    global_variables.ShipGeo.strawtubes_geo.outer_straw_diameter / 2.0
-                    - global_variables.ShipGeo.strawtubes_geo.wall_thickness
-                )
-                tp.addRawMeasurement(measurement)  # package measurement in the TrackPoint
-                theTrack.insertPoint(tp)  # add point to Track
-                hitID += 1
-            trackCandidates.append([theTrack, atrack])
+            # Try both charge hypotheses, keep the one with better chi2/NDF
+            best_track = None
+            best_chi2ndf = float("inf")
+            for try_pdg in [pdg, -pdg]:
+                # approximate covariance
+                covM = ROOT.TMatrixDSym(6)
+                resolution = self.sigma_spatial
+                if global_variables.withT0:
+                    resolution *= 1.4  # worse resolution due to t0 estimate
+                for i in range(3):
+                    covM[i][i] = resolution * resolution
+                covM[0][0] = resolution * resolution * 100.0
+                for i in range(3, 6):
+                    covM[i][i] = ROOT.TMath.Power(resolution / nM / ROOT.TMath.Sqrt(3), 2)
+                rep = ROOT.genfit.RKTrackRep(try_pdg)
+                stateSmeared = ROOT.genfit.MeasuredStateOnPlane(rep)
+                rep.setPosMomCov(stateSmeared, posM, momM, covM)
+                seedState = ROOT.TVectorD(6)
+                seedCov = ROOT.TMatrixDSym(6)
+                rep.get6DStateCov(stateSmeared, seedState, seedCov)
+                theTrack = ROOT.genfit.Track(rep, seedState, seedCov)
+                hitCov = ROOT.TMatrixDSym(7)
+                hitCov[6][6] = resolution * resolution
+                hitID = 0
+                for m, detID in zip(meas, detIDs):
+                    tp = ROOT.genfit.TrackPoint(theTrack)
+                    measurement = ROOT.genfit.WireMeasurement(m, hitCov, detID, hitID, tp)
+                    measurement.setMaxDistance(
+                        global_variables.ShipGeo.strawtubes_geo.outer_straw_diameter / 2.0
+                        - global_variables.ShipGeo.strawtubes_geo.wall_thickness
+                    )
+                    tp.addRawMeasurement(measurement)
+                    theTrack.insertPoint(tp)
+                    hitID += 1
+                # Fit this hypothesis
+                try:
+                    theTrack.checkConsistency()
+                except ROOT.genfit.Exception:
+                    continue
+                try:
+                    self.fitter.processTrack(theTrack)
+                except Exception:
+                    continue
+                with contextlib.suppress(ROOT.genfit.Exception):
+                    theTrack.checkConsistency()
+                try:
+                    fittedState = theTrack.getFittedState()
+                    fittedState.getMomMag()
+                except Exception:
+                    continue
+                fitStatus = theTrack.getFitStatus()
+                nmeas = fitStatus.getNdf()
+                if nmeas <= 0:
+                    continue
+                chi2ndf = fitStatus.getChi2() / nmeas
+                if chi2ndf < best_chi2ndf:
+                    best_chi2ndf = chi2ndf
+                    best_track = theTrack
+            if best_track is not None:
+                trackCandidates.append([best_track, atrack])
 
         for entry in trackCandidates:
-            # check
+            # Tracks are already fitted from the dual-hypothesis loop above
             atrack = entry[1]
             theTrack = entry[0]
-            try:
-                theTrack.checkConsistency()
-            except ROOT.genfit.Exception as e:
-                n_prefit_fail += 1
-                logger.warning("Problem with track before fit, not consistent %s %s", atrack, theTrack)
-                logger.warning(e.what())
-                ut.reportError(e)
-            # do the fit
-            try:
-                self.fitter.processTrack(theTrack)  # processTrackWithRep(theTrack,rep,True)
-            except Exception:
-                n_fit_fail += 1
-                if global_variables.debug:
-                    print("genfit failed to fit track")
-                error = "genfit failed to fit track"
-                ut.reportError(error)
-                continue
-            # check
-            try:
-                theTrack.checkConsistency()
-            except ROOT.genfit.Exception as e:
-                n_postfit_fail += 1
-                if global_variables.debug:
-                    print("Problem with track after fit, not consistent", atrack, theTrack)
-                    print(e.what())
-                error = "Problem with track after fit, not consistent"
-                ut.reportError(error)
-            try:
-                fittedState = theTrack.getFittedState()
-                fittedState.getMomMag()
-            except Exception:
-                n_no_state += 1
-                error = "Problem with fittedstate"
-                ut.reportError(error)
-                continue
             fitStatus = theTrack.getFitStatus()
-            try:
-                fitStatus.isFitConverged()
-            except ROOT.genfit.Exception:
-                error = "Fit not converged"
-                ut.reportError(error)
             nmeas = fitStatus.getNdf()
             global_variables.h["nmeas"].Fill(nmeas)
-            if nmeas <= 0:
-                n_no_ndf += 1
-                continue
             chi2 = fitStatus.getChi2() / nmeas
             global_variables.h["chi2"].Fill(chi2)
             # make track persistent

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -240,7 +240,7 @@ class ShipDigiReco:
                 hitCov = ROOT.TMatrixDSym(7)
                 hitCov[6][6] = resolution * resolution
                 hitID = 0
-                for m, detID in zip(meas, detIDs):
+                for m, detID in zip(meas, detIDs, strict=True):
                     tp = ROOT.genfit.TrackPoint(theTrack)
                     measurement = ROOT.genfit.WireMeasurement(m, hitCov, detID, hitID, tp)
                     measurement.setMaxDistance(
@@ -257,7 +257,8 @@ class ShipDigiReco:
                     continue
                 try:
                     self.fitter.processTrack(theTrack)
-                except Exception:
+                except Exception as e:
+                    logger.debug("Failed to processTrack for hypothesis %d: %s", try_pdg, e)
                     continue
                 try:
                     theTrack.checkConsistency()
@@ -266,7 +267,8 @@ class ShipDigiReco:
                 try:
                     fittedState = theTrack.getFittedState()
                     fittedState.getMomMag()
-                except Exception:
+                except Exception as e:
+                    logger.debug("Failed to getFittedState/getMomMag for hypothesis %d: %s", try_pdg, e)
                     continue
                 fitStatus = theTrack.getFitStatus()
                 if not fitStatus.isFitConverged():
@@ -279,12 +281,10 @@ class ShipDigiReco:
                     best_chi2ndf = chi2ndf
                     best_track = theTrack
             if best_track is not None:
-                trackCandidates.append([best_track, atrack])
+                trackCandidates.append((best_track, atrack))
 
-        for entry in trackCandidates:
+        for theTrack, atrack in trackCandidates:
             # Tracks are already fitted from the dual-hypothesis loop above
-            atrack = entry[1]
-            theTrack = entry[0]
             fitStatus = theTrack.getFitStatus()
             nmeas = fitStatus.getNdf()  # guaranteed > 0 by hypothesis loop filter
             global_variables.h["nmeas"].Fill(nmeas)

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -196,7 +196,16 @@ class ShipDigiReco:
         for atrack in hitPosLists:
             if atrack < 0:
                 continue  # these are hits not assigned to MC track because low E cut
-            pdg = 13  # assume all tracks are muons
+            # Determine charge sign from bending between stations 1-2 and 3-4.
+            # The slope difference dk = k_y34 - k_y12 encodes the charge:
+            # dk > 0 → positive charge (mu+, pi+), dk < 0 → negative charge (mu-, pi-)
+            params = trackParams.get(atrack, {})
+            k_y12 = params.get("k_y12")
+            k_y34 = params.get("k_y34")
+            if k_y12 is not None and k_y34 is not None:
+                pdg = -13 if k_y34 > k_y12 else 13
+            else:
+                pdg = 13
             meas = hitPosLists[atrack]
             detIDs = hit_detector_ids[atrack]
             nM = len(meas)

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
-import contextlib
 import logging
 from array import array
 
@@ -188,11 +187,6 @@ class ShipDigiReco:
 
         n_too_few_hits = 0
         n_too_few_stations = 0
-        n_prefit_fail = 0
-        n_fit_fail = 0
-        n_postfit_fail = 0
-        n_no_state = 0
-        n_no_ndf = 0
 
         for atrack in hitPosLists:
             if atrack < 0:
@@ -265,14 +259,18 @@ class ShipDigiReco:
                     self.fitter.processTrack(theTrack)
                 except Exception:
                     continue
-                with contextlib.suppress(ROOT.genfit.Exception):
+                try:
                     theTrack.checkConsistency()
+                except ROOT.genfit.Exception:
+                    logger.debug("Track inconsistent after fit for hypothesis %d", try_pdg)
                 try:
                     fittedState = theTrack.getFittedState()
                     fittedState.getMomMag()
                 except Exception:
                     continue
                 fitStatus = theTrack.getFitStatus()
+                if not fitStatus.isFitConverged():
+                    continue
                 nmeas = fitStatus.getNdf()
                 if nmeas <= 0:
                     continue
@@ -288,7 +286,7 @@ class ShipDigiReco:
             atrack = entry[1]
             theTrack = entry[0]
             fitStatus = theTrack.getFitStatus()
-            nmeas = fitStatus.getNdf()
+            nmeas = fitStatus.getNdf()  # guaranteed > 0 by hypothesis loop filter
             global_variables.h["nmeas"].Fill(nmeas)
             chi2 = fitStatus.getChi2() / nmeas
             global_variables.h["chi2"].Fill(chi2)
@@ -314,17 +312,10 @@ class ShipDigiReco:
             self.fTrackletsArray.push_back(aTracklet)
 
         logger.debug(
-            "findTracks: %d candidates, %d too few hits, %d too few stations, "
-            "%d prefit fail, %d fit fail, %d postfit fail, %d no state, "
-            "%d no NDF, %d fitted tracks saved",
+            "findTracks: %d candidates, %d too few hits, %d too few stations, %d fitted tracks saved",
             len(hitPosLists),
             n_too_few_hits,
             n_too_few_stations,
-            n_prefit_fail,
-            n_fit_fail,
-            n_postfit_fail,
-            n_no_state,
-            n_no_ndf,
             len(self.fGenFitArray),
         )
 


### PR DESCRIPTION
Two changes to improve charge determination in track fitting:

1. **Slope-based charge seeding**: Instead of hardcoding PDG 13 (mu-) for all tracks, use the y-slope difference between stations 1-2 and 3-4 to determine the charge sign from the bending direction. This gives the Kalman fitter a correct initial hypothesis.

2. **Dual-hypothesis fitting**: Fit each track with both charge hypotheses (PDG 13 and -13) and keep the one with better chi2/NDF. This resolves charge ambiguity for tracks where the slope-based determination is unreliable.

On an example HNL→µπ sample (2500 events, V21_3000 geometry), this reduces charge mis-ID from 48 to 19 events. Combined with ShipSoft/FairShip#1156, overall vertexing efficiency improves from 66% to 93% of reconstructible events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Track fitting now evaluates both charge-sign hypotheses for each candidate and automatically selects the best converged fit by chi‑squared per degree of freedom.
  * Removed redundant per-track consistency checks, simplifying the post-fit processing pipeline.
  * Diagnostic logging updated to reflect the new fitting flow and streamlined status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->