### PR TITLE
feat: publish CI plots to GitHub Pages and embed in PR comments

### DIFF
--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -99,17 +99,28 @@ def generate_comment(manifests: list[dict], base_url: str) -> str:
     lines.append(f"**[View all plots]({base_url}/index.html)**")
     lines.append("")
 
+    # Group manifests by job, preserving order
+    jobs: dict[str, list[dict]] = {}
     for manifest in manifests:
-        job = manifest["job"]
-        config = manifest["config"]
         plots = manifest.get("files", [])
         if not plots:
             continue
+        jobs.setdefault(manifest["job"], []).append(manifest)
 
-        lines.append(f"### {job} ({config})")
+    for job, job_manifests in jobs.items():
+        lines.append(f"<details open><summary><h3>{job}</h3></summary>")
         lines.append("")
-        thumbs = " ".join(_html_thumbnail(plot["name"], f"{base_url}/{plot['file']}") for plot in plots)
-        lines.append(thumbs)
+        for manifest in job_manifests:
+            config = manifest["config"]
+            plots = manifest["files"]
+            lines.append(f"<details open><summary><h4>{config}</h4></summary>")
+            lines.append("")
+            thumbs = " ".join(_html_thumbnail(plot["name"], f"{base_url}/{plot['file']}") for plot in plots)
+            lines.append(thumbs)
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+        lines.append("</details>")
         lines.append("")
 
     return "\n".join(lines)

--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -5,9 +5,11 @@
 """Generate an HTML index page and PR comment from rendered plot manifests."""
 
 import argparse
+import html
 import json
 import sys
 from pathlib import Path
+from urllib.parse import quote
 
 
 def collect_manifests(base_dir: Path) -> list[dict]:
@@ -22,7 +24,7 @@ def collect_manifests(base_dir: Path) -> list[dict]:
         manifest = json.loads(manifest_path.read_text())
         rel_dir = manifest_path.parent.relative_to(base_dir)
         for entry in manifest.get("files", []):
-            entry["file"] = str(rel_dir / entry["file"])
+            entry["file"] = (rel_dir / entry["file"]).as_posix()
         manifests.append(manifest)
     return manifests
 
@@ -37,13 +39,17 @@ def generate_html(manifests: list[dict], title: str) -> str:
         if not plots:
             continue
 
-        heading = f"{job} ({config})"
+        heading = html.escape(f"{job} ({config})")
         images = []
         for plot in plots:
+            src = html.escape(plot["file"], quote=True)
+            alt = html.escape(plot["name"], quote=True)
+            name = html.escape(plot["name"])
+            obj_type = html.escape(plot["type"])
             images.append(
-                f'<figure><img src="{plot["file"]}" alt="{plot["name"]}"'
-                f' loading="lazy"><figcaption>{plot["name"]}'
-                f' <span class="type">({plot["type"]})</span>'
+                f'<figure><img src="{src}" alt="{alt}"'
+                f' loading="lazy"><figcaption>{name}'
+                f' <span class="type">({obj_type})</span>'
                 f"</figcaption></figure>"
             )
         sections.append(f"<h2>{heading}</h2>\n<div class='grid'>{''.join(images)}</div>")
@@ -53,7 +59,7 @@ def generate_html(manifests: list[dict], title: str) -> str:
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{title}</title>
+<title>{html.escape(title)}</title>
 <style>
   body {{ font-family: system-ui, sans-serif; margin: 2rem; background: #fafafa; }}
   h1 {{ border-bottom: 2px solid #333; padding-bottom: 0.5rem; }}
@@ -66,10 +72,17 @@ def generate_html(manifests: list[dict], title: str) -> str:
 </style>
 </head>
 <body>
-<h1>{title}</h1>
+<h1>{html.escape(title)}</h1>
 {"".join(sections)}
 </body>
 </html>"""
+
+
+def _md_image(name: str, url: str) -> str:
+    """Format a markdown image link with escaped alt text and URL."""
+    safe_alt = name.replace("]", r"\]")
+    safe_url = quote(url, safe="/:@!$&'*+,;=-._~?#[]")
+    return f"![{safe_alt}]({safe_url})"
 
 
 def generate_comment(manifests: list[dict], base_url: str) -> str:
@@ -91,13 +104,13 @@ def generate_comment(manifests: list[dict], base_url: str) -> str:
         inline = plots[:3]
         rest = plots[3:]
         for plot in inline:
-            lines.append(f"![{plot['name']}]({base_url}/{plot['file']})")
+            lines.append(_md_image(plot["name"], f"{base_url}/{plot['file']}"))
             lines.append("")
         if rest:
             lines.append("<details><summary>More plots</summary>")
             lines.append("")
             for plot in rest:
-                lines.append(f"![{plot['name']}]({base_url}/{plot['file']})")
+                lines.append(_md_image(plot["name"], f"{base_url}/{plot['file']}"))
                 lines.append("")
             lines.append("</details>")
             lines.append("")

--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -52,7 +52,9 @@ def generate_html(manifests: list[dict], title: str) -> str:
                 f' <span class="type">({obj_type})</span>'
                 f"</figcaption></figure>"
             )
-        sections.append(f"<h2>{heading}</h2>\n<div class='grid'>{''.join(images)}</div>")
+        sections.append(
+            f"<details open><summary><h2>{heading}</h2></summary>\n<div class='grid'>{''.join(images)}</div></details>"
+        )
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -63,7 +65,9 @@ def generate_html(manifests: list[dict], title: str) -> str:
 <style>
   body {{ font-family: system-ui, sans-serif; margin: 2rem; background: #fafafa; }}
   h1 {{ border-bottom: 2px solid #333; padding-bottom: 0.5rem; }}
-  h2 {{ color: #555; margin-top: 2rem; }}
+  details {{ margin-top: 2rem; }}
+  summary {{ cursor: pointer; list-style: revert; }}
+  summary h2 {{ display: inline; margin-top: 0; color: #555; }}
   .grid {{ display: grid; grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); gap: 1rem; }}
   figure {{ margin: 0; background: white; border: 1px solid #ddd; border-radius: 4px; padding: 0.5rem; }}
   img {{ width: 100%; height: auto; }}

--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -21,7 +21,11 @@ def collect_manifests(base_dir: Path) -> list[dict]:
     """
     manifests = []
     for manifest_path in sorted(base_dir.rglob("manifest.json")):
-        manifest = json.loads(manifest_path.read_text())
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (json.JSONDecodeError, OSError, ValueError) as e:
+            print(f"WARNING: Skipping {manifest_path}: {e}", file=sys.stderr)
+            continue
         rel_dir = manifest_path.parent.relative_to(base_dir)
         for entry in manifest.get("files", []):
             entry["file"] = (rel_dir / entry["file"]).as_posix()

--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -27,8 +27,18 @@ def collect_manifests(base_dir: Path) -> list[dict]:
             print(f"WARNING: Skipping {manifest_path}: {e}", file=sys.stderr)
             continue
         rel_dir = manifest_path.parent.relative_to(base_dir)
-        for entry in manifest.get("files", []):
+        files = manifest.get("files", [])
+        if not isinstance(files, list):
+            print(f"WARNING: Skipping {manifest_path}: 'files' is not a list", file=sys.stderr)
+            continue
+        valid_entries = []
+        for entry in files:
+            if not isinstance(entry, dict) or "file" not in entry:
+                print(f"WARNING: Skipping malformed entry in {manifest_path}: {entry!r}", file=sys.stderr)
+                continue
             entry["file"] = (rel_dir / entry["file"]).as_posix()
+            valid_entries.append(entry)
+        manifest["files"] = valid_entries
         manifests.append(manifest)
     return manifests
 
@@ -108,12 +118,12 @@ def generate_comment(manifests: list[dict], base_url: str) -> str:
         jobs.setdefault(manifest["job"], []).append(manifest)
 
     for job, job_manifests in jobs.items():
-        lines.append(f"<details open><summary><h3>{job}</h3></summary>")
+        lines.append(f"<details open><summary><h3>{html.escape(job)}</h3></summary>")
         lines.append("")
         for manifest in job_manifests:
             config = manifest["config"]
             plots = manifest["files"]
-            lines.append(f"<details open><summary><h4>{config}</h4></summary>")
+            lines.append(f"<details open><summary><h4>{html.escape(config)}</h4></summary>")
             lines.append("")
             thumbs = " ".join(_html_thumbnail(plot["name"], f"{base_url}/{plot['file']}") for plot in plots)
             lines.append(thumbs)

--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -78,15 +78,15 @@ def generate_html(manifests: list[dict], title: str) -> str:
 </html>"""
 
 
-def _md_image(name: str, url: str) -> str:
-    """Format a markdown image link with escaped alt text and URL."""
-    safe_alt = name.replace("]", r"\]")
-    safe_url = quote(url, safe="/:@!$&'*+,;=-._~?#[]")
-    return f"![{safe_alt}]({safe_url})"
+def _html_thumbnail(name: str, url: str, width: int = 200) -> str:
+    """Format an HTML thumbnail image linking to the full-size version."""
+    safe_alt = html.escape(name, quote=True)
+    safe_url = html.escape(quote(url, safe="/:@!$&'*+,;=-._~?#[]"), quote=True)
+    return f'<a href="{safe_url}"><img src="{safe_url}" alt="{safe_alt}" width="{width}"></a>'
 
 
 def generate_comment(manifests: list[dict], base_url: str) -> str:
-    """Generate a markdown PR comment body."""
+    """Generate a markdown PR comment body with a thumbnail grid."""
     lines = ["<!-- ci-plots-comment -->", "## CI Plots", ""]
     lines.append(f"**[View all plots]({base_url}/index.html)**")
     lines.append("")
@@ -100,20 +100,9 @@ def generate_comment(manifests: list[dict], base_url: str) -> str:
 
         lines.append(f"### {job} ({config})")
         lines.append("")
-        # Show first 3 plots inline, rest in details
-        inline = plots[:3]
-        rest = plots[3:]
-        for plot in inline:
-            lines.append(_md_image(plot["name"], f"{base_url}/{plot['file']}"))
-            lines.append("")
-        if rest:
-            lines.append("<details><summary>More plots</summary>")
-            lines.append("")
-            for plot in rest:
-                lines.append(_md_image(plot["name"], f"{base_url}/{plot['file']}"))
-                lines.append("")
-            lines.append("</details>")
-            lines.append("")
+        for plot in plots:
+            lines.append(_html_thumbnail(plot["name"], f"{base_url}/{plot['file']}"))
+        lines.append("")
 
     return "\n".join(lines)
 

--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+"""Generate an HTML index page and PR comment from rendered plot manifests."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def collect_manifests(base_dir: Path) -> list[dict]:
+    """Find and load all manifest.json files under base_dir.
+
+    Each file entry gets its path prefixed with the manifest's
+    subdirectory relative to base_dir, so paths work from the
+    top-level index.html.
+    """
+    manifests = []
+    for manifest_path in sorted(base_dir.rglob("manifest.json")):
+        manifest = json.loads(manifest_path.read_text())
+        rel_dir = manifest_path.parent.relative_to(base_dir)
+        for entry in manifest.get("files", []):
+            entry["file"] = str(rel_dir / entry["file"])
+        manifests.append(manifest)
+    return manifests
+
+
+def generate_html(manifests: list[dict], title: str) -> str:
+    """Generate a self-contained HTML page from manifests."""
+    sections = []
+    for manifest in manifests:
+        job = manifest["job"]
+        config = manifest["config"]
+        plots = manifest.get("files", [])
+        if not plots:
+            continue
+
+        heading = f"{job} ({config})"
+        images = []
+        for plot in plots:
+            images.append(
+                f'<figure><img src="{plot["file"]}" alt="{plot["name"]}"'
+                f' loading="lazy"><figcaption>{plot["name"]}'
+                f' <span class="type">({plot["type"]})</span>'
+                f"</figcaption></figure>"
+            )
+        sections.append(f"<h2>{heading}</h2>\n<div class='grid'>{''.join(images)}</div>")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; margin: 2rem; background: #fafafa; }}
+  h1 {{ border-bottom: 2px solid #333; padding-bottom: 0.5rem; }}
+  h2 {{ color: #555; margin-top: 2rem; }}
+  .grid {{ display: grid; grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); gap: 1rem; }}
+  figure {{ margin: 0; background: white; border: 1px solid #ddd; border-radius: 4px; padding: 0.5rem; }}
+  img {{ width: 100%; height: auto; }}
+  figcaption {{ text-align: center; padding: 0.25rem; font-size: 0.9rem; }}
+  .type {{ color: #888; }}
+</style>
+</head>
+<body>
+<h1>{title}</h1>
+{"".join(sections)}
+</body>
+</html>"""
+
+
+def generate_comment(manifests: list[dict], base_url: str) -> str:
+    """Generate a markdown PR comment body."""
+    lines = ["<!-- ci-plots-comment -->", "## CI Plots", ""]
+    lines.append(f"**[View all plots]({base_url}/index.html)**")
+    lines.append("")
+
+    for manifest in manifests:
+        job = manifest["job"]
+        config = manifest["config"]
+        plots = manifest.get("files", [])
+        if not plots:
+            continue
+
+        lines.append(f"### {job} ({config})")
+        lines.append("")
+        # Show first 3 plots inline, rest in details
+        inline = plots[:3]
+        rest = plots[3:]
+        for plot in inline:
+            lines.append(f"![{plot['name']}]({base_url}/{plot['file']})")
+            lines.append("")
+        if rest:
+            lines.append("<details><summary>More plots</summary>")
+            lines.append("")
+            for plot in rest:
+                lines.append(f"![{plot['name']}]({base_url}/{plot['file']})")
+                lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Generate HTML index and PR comment from plot manifests."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plot_dir", help="Directory containing plot images and manifests")
+    parser.add_argument("--title", default="CI Plots", help="Page title")
+    parser.add_argument("--base-url", default=".", help="Base URL for image links in comment")
+    parser.add_argument("--output-html", default=None, help="Output HTML path (default: plot_dir/index.html)")
+    parser.add_argument("--output-comment", default=None, help="Output comment path (default: plot_dir/comment.md)")
+    args = parser.parse_args()
+
+    plot_dir = Path(args.plot_dir)
+    manifests = collect_manifests(plot_dir)
+
+    if not manifests:
+        print("No manifests found, nothing to generate.", file=sys.stderr)
+        return 0
+
+    html_path = Path(args.output_html) if args.output_html else plot_dir / "index.html"
+    html_path.write_text(generate_html(manifests, args.title))
+    print(f"Index page written to {html_path}")
+
+    comment_path = Path(args.output_comment) if args.output_comment else plot_dir / "comment.md"
+    comment_path.write_text(generate_comment(manifests, args.base_url))
+    print(f"Comment written to {comment_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/generate_plot_index.py
+++ b/.github/scripts/generate_plot_index.py
@@ -108,8 +108,8 @@ def generate_comment(manifests: list[dict], base_url: str) -> str:
 
         lines.append(f"### {job} ({config})")
         lines.append("")
-        for plot in plots:
-            lines.append(_html_thumbnail(plot["name"], f"{base_url}/{plot['file']}"))
+        thumbs = " ".join(_html_thumbnail(plot["name"], f"{base_url}/{plot['file']}") for plot in plots)
+        lines.append(thumbs)
         lines.append("")
 
     return "\n".join(lines)

--- a/.github/scripts/render_plots.py
+++ b/.github/scripts/render_plots.py
@@ -5,7 +5,9 @@
 """Render ROOT histogram objects to PNG images for CI visualisation."""
 
 import argparse
+import itertools
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -17,6 +19,13 @@ ROOT.gStyle.SetOptStat(111111)
 ROOT.gStyle.SetOptFit(1111)
 
 DRAWABLE_TYPES = (ROOT.TH1, ROOT.TGraph, ROOT.TMultiGraph, ROOT.TEfficiency)
+_SAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+_canvas_counter = itertools.count()
+
+
+def _sanitise_filename(name: str) -> str:
+    """Replace non-alphanumeric characters with underscores."""
+    return _SAFE_CHARS.sub("_", name)
 
 
 def render_object(obj: Any, output_path: Path) -> dict[str, str] | None:
@@ -31,7 +40,7 @@ def render_object(obj: Any, output_path: Path) -> dict[str, str] | None:
     if not isinstance(obj, DRAWABLE_TYPES):
         return None
 
-    canvas = ROOT.TCanvas("c", "", 800, 600)
+    canvas = ROOT.TCanvas(f"c_{next(_canvas_counter)}", "", 800, 600)
 
     if isinstance(obj, ROOT.TH2):
         canvas.SetRightMargin(0.15)
@@ -42,6 +51,7 @@ def render_object(obj: Any, output_path: Path) -> dict[str, str] | None:
         obj.Draw()
 
     canvas.SaveAs(str(output_path))
+    del canvas
     return {"type": obj.ClassName()}
 
 
@@ -66,7 +76,7 @@ def render_directory(
             rendered.extend(render_directory(obj, output_dir, current_path, max_depth - 1))
             continue
 
-        safe_name = current_path.replace("/", "_")
+        safe_name = _sanitise_filename(current_path)
         png_path = output_dir / f"{safe_name}.png"
 
         try:

--- a/.github/scripts/render_plots.py
+++ b/.github/scripts/render_plots.py
@@ -66,9 +66,13 @@ def render_directory(
         return []
 
     rendered = []
+    seen: set[str] = set()
 
     for key in directory.GetListOfKeys():
         obj_name = key.GetName()
+        if obj_name in seen:
+            continue
+        seen.add(obj_name)
         obj = directory.Get(obj_name)
         current_path = f"{path}/{obj_name}" if path else obj_name
 

--- a/.github/scripts/render_plots.py
+++ b/.github/scripts/render_plots.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+"""Render ROOT histogram objects to PNG images for CI visualisation."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import ROOT
+
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(111111)
+ROOT.gStyle.SetOptFit(1111)
+
+DRAWABLE_TYPES = (ROOT.TH1, ROOT.TGraph, ROOT.TMultiGraph, ROOT.TEfficiency)
+
+
+def render_object(obj: Any, output_path: Path) -> dict[str, str] | None:
+    """Render a single ROOT object to PNG.
+
+    Returns metadata dict or None if not drawable.
+    """
+    if isinstance(obj, ROOT.TCanvas):
+        obj.SaveAs(str(output_path))
+        return {"type": obj.ClassName()}
+
+    if not isinstance(obj, DRAWABLE_TYPES):
+        return None
+
+    canvas = ROOT.TCanvas("c", "", 800, 600)
+
+    if isinstance(obj, ROOT.TH2):
+        canvas.SetRightMargin(0.15)
+        obj.Draw("COLZ")
+    elif isinstance(obj, ROOT.TEfficiency):
+        obj.Draw("AP")
+    else:
+        obj.Draw()
+
+    canvas.SaveAs(str(output_path))
+    return {"type": obj.ClassName()}
+
+
+def render_directory(
+    directory: Any,
+    output_dir: Path,
+    path: str = "",
+    max_depth: int = 3,
+) -> list[dict[str, str]]:
+    """Recursively render all drawable objects in a ROOT directory."""
+    if max_depth <= 0:
+        return []
+
+    rendered = []
+
+    for key in directory.GetListOfKeys():
+        obj_name = key.GetName()
+        obj = directory.Get(obj_name)
+        current_path = f"{path}/{obj_name}" if path else obj_name
+
+        if isinstance(obj, ROOT.TDirectory):
+            rendered.extend(render_directory(obj, output_dir, current_path, max_depth - 1))
+            continue
+
+        safe_name = current_path.replace("/", "_")
+        png_path = output_dir / f"{safe_name}.png"
+
+        try:
+            meta = render_object(obj, png_path)
+        except Exception as e:
+            print(f"WARNING: Failed to render {current_path}: {e}", file=sys.stderr)
+            continue
+
+        if meta:
+            rendered.append({"name": obj_name, "root_path": current_path, "file": png_path.name, **meta})
+
+    return rendered
+
+
+def main() -> int:
+    """Render ROOT objects to PNG images."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("inputs", nargs="+", help="ROOT files to render")
+    parser.add_argument("--output-dir", required=True, help="Directory for output PNGs")
+    parser.add_argument("--job", required=True, help="Job name for manifest")
+    parser.add_argument("--config", required=True, help="Configuration label")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    all_rendered: list[dict[str, str]] = []
+
+    for input_path in args.inputs:
+        root_file = ROOT.TFile.Open(input_path)
+        if not root_file or root_file.IsZombie():
+            print(f"WARNING: Cannot open {input_path}", file=sys.stderr)
+            continue
+
+        rendered = render_directory(root_file, output_dir)
+        all_rendered.extend(rendered)
+        root_file.Close()
+
+    manifest = {
+        "job": args.job,
+        "config": args.config,
+        "files": all_rendered,
+    }
+    (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+    print(f"Rendered {len(all_rendered)} plots to {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -458,7 +458,7 @@ jobs:
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
           python FairShip/.github/scripts/render_plots.py \
-            /__w/FairShip/FairShip/*_run_fixedTarget_1/*.root \
+            $GITHUB_WORKSPACE/*_run_fixedTarget_1/*.root \
             --output-dir plots/fixed-target/${{ matrix.version }} \
             --job fixed-target --config "${{ matrix.version }}"
       - name: Upload .root artifacts
@@ -499,7 +499,7 @@ jobs:
           else
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
             TITLE="CI Plots for $SHORT_SHA"
-            BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/plots/master/$SHORT_SHA"
+            BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/plots/master/${{ github.run_id }}-$SHORT_SHA"
           fi
           python3 .github/scripts/generate_plot_index.py all-plots/ \
             --title "$TITLE" --base-url "$BASE_URL"
@@ -514,7 +514,7 @@ jobs:
             DEST="gh-pages-checkout/plots/pr/${{ github.event.pull_request.number }}/${{ github.run_id }}"
           else
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
-            DEST="gh-pages-checkout/plots/master/$SHORT_SHA"
+            DEST="gh-pages-checkout/plots/master/${{ github.run_id }}-$SHORT_SHA"
           fi
           mkdir -p "$DEST"
           cp -r all-plots/* "$DEST/"
@@ -546,7 +546,7 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const existing = comments.find(c => c.body.includes(marker));
+            const existing = comments.find(c => c.body?.includes(marker));
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -566,7 +566,7 @@ jobs:
   ci:
     if: always()
     runs-on: ubuntu-latest
-    needs: [build, run-sim-chain, run-fixed-target]
+    needs: [build, run-sim-chain, run-fixed-target, run-tracking-benchmark]
     steps:
       - name: Check status of all jobs
         run: |

--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -105,24 +105,37 @@ jobs:
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
           python $FAIRSHIP/examples/analysis_example.py -f sim_ci-test.root -r sim_ci-test_rec.root -g geo_ci-test.root
-        # - name: Extract physics metrics
-        #   run: |
-        #     source /cvmfs/ship.cern.ch/$version/setUp.sh
-        #     eval $(alienv load FairShip/latest)
-        #     python FairShip/.github/scripts/extract_physics_metrics.py . -o physics_metrics.json --pretty
-        #
-        # - name: Upload .root artifacts
-        #   uses: actions/upload-artifact@v7
-        #   with:
-        #     name: root-files-${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }}
-        #     path: |
-        #       *.root
-        #
-        # - name: Upload physics metrics
-        #   uses: actions/upload-artifact@v7
-        #   with:
-        #     name: metrics-${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }}
-        #     path: physics_metrics.json
+      - name: Render plots
+        run: |
+          source /cvmfs/ship.cern.ch/$version/setUp.sh
+          eval $(alienv load FairShip/latest)
+          python FairShip/.github/scripts/render_plots.py \
+            recohists.root \
+            --output-dir plots/sim-chain/${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }} \
+            --job sim-chain --config "${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }}"
+      - name: Upload plot images
+        uses: actions/upload-artifact@v7
+        with:
+          name: plots-sim-chain-${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }}
+          path: plots/
+          # - name: Extract physics metrics
+          #   run: |
+          #     source /cvmfs/ship.cern.ch/$version/setUp.sh
+          #     eval $(alienv load FairShip/latest)
+          #     python FairShip/.github/scripts/extract_physics_metrics.py . -o physics_metrics.json --pretty
+          #
+          # - name: Upload .root artifacts
+          #   uses: actions/upload-artifact@v7
+          #   with:
+          #     name: root-files-${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }}
+          #     path: |
+          #       *.root
+          #
+          # - name: Upload physics metrics
+          #   uses: actions/upload-artifact@v7
+          #   with:
+          #     name: metrics-${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }}
+          #     path: physics_metrics.json
   # store-metrics:
   #   runs-on: ubuntu-latest
   #   needs: run-sim-chain
@@ -392,6 +405,14 @@ jobs:
           python $FAIRSHIP/macro/run_tracking_benchmark.py \
             -n 200 --seed 42 --tag ci-benchmark \
             --output-json tracking_metrics.json
+      - name: Render plots
+        run: |
+          source /cvmfs/ship.cern.ch/$version/setUp.sh
+          eval $(alienv load FairShip/latest)
+          python FairShip/.github/scripts/render_plots.py \
+            tracking_benchmark_histos.root \
+            --output-dir plots/tracking-benchmark/${{ matrix.version }} \
+            --job tracking-benchmark --config "${{ matrix.version }}"
       - name: Upload tracking metrics
         uses: actions/upload-artifact@v7
         with:
@@ -399,6 +420,11 @@ jobs:
           path: |
             tracking_metrics.json
             tracking_benchmark_histos.root
+      - name: Upload plot images
+        uses: actions/upload-artifact@v7
+        with:
+          name: plots-tracking-benchmark-${{ matrix.version }}
+          path: plots/
   run-fixed-target:
     runs-on: self-hosted
     needs: [generate-matrix, build]
@@ -427,12 +453,116 @@ jobs:
           source /cvmfs/ship.cern.ch/$version/setUp.sh
           eval $(alienv load FairShip/latest)
           python $FAIRSHIP/macro/run_fixedTarget.py -n 10 -e 10.0 -r 1
+      - name: Render plots
+        run: |
+          source /cvmfs/ship.cern.ch/$version/setUp.sh
+          eval $(alienv load FairShip/latest)
+          python FairShip/.github/scripts/render_plots.py \
+            /__w/FairShip/FairShip/*_run_fixedTarget_1/*.root \
+            --output-dir plots/fixed-target/${{ matrix.version }} \
+            --job fixed-target --config "${{ matrix.version }}"
       - name: Upload .root artifacts
         uses: actions/upload-artifact@v7
         with:
           name: root-files-fixed-target-${{ matrix.version }}
           path: |
             /__w/FairShip/FairShip/*_run_fixedTarget_1/*.root
+      - name: Upload plot images
+        uses: actions/upload-artifact@v7
+        with:
+          name: plots-fixed-target-${{ matrix.version }}
+          path: plots/
+  deploy-plots:
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: [run-tracking-benchmark, run-sim-chain, run-fixed-target]
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Download all plot artefacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: plots-*
+          path: all-plots/
+          merge-multiple: true
+      - name: Generate index page
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TITLE="CI Plots for PR #${{ github.event.pull_request.number }}"
+            BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/plots/pr/${{ github.event.pull_request.number }}/${{ github.run_id }}"
+          else
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
+            TITLE="CI Plots for $SHORT_SHA"
+            BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/plots/master/$SHORT_SHA"
+          fi
+          python3 .github/scripts/generate_plot_index.py all-plots/ \
+            --title "$TITLE" --base-url "$BASE_URL"
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages-checkout
+      - name: Copy plots to gh-pages
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DEST="gh-pages-checkout/plots/pr/${{ github.event.pull_request.number }}/${{ github.run_id }}"
+          else
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
+            DEST="gh-pages-checkout/plots/master/$SHORT_SHA"
+          fi
+          mkdir -p "$DEST"
+          cp -r all-plots/* "$DEST/"
+      - name: Push to gh-pages
+        run: |
+          cd gh-pages-checkout
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add plots/
+          git diff --staged --quiet && echo "No plot changes" && exit 0
+          git commit -m "Add CI plots for ${{ github.sha }}"
+          for attempt in 1 2 3 4 5; do
+            git pull --rebase origin gh-pages && git push origin gh-pages && break
+            echo "Push failed (attempt $attempt), retrying..."
+            sleep $((attempt * 5))
+          done
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- ci-plots-comment -->';
+            const body = fs.readFileSync('all-plots/comment.md', 'utf8');
+
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
   ci:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -111,6 +111,7 @@ jobs:
           eval $(alienv load FairShip/latest)
           python FairShip/.github/scripts/render_plots.py \
             recohists.root \
+            sim_ci-test_ana.root \
             --output-dir plots/sim-chain/${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }} \
             --job sim-chain --config "${{ matrix.version }}-${{ matrix.vessel_option }}-${{ matrix.SND_option }}-${{ matrix.muon_shield }}"
       - name: Upload plot images

--- a/.github/workflows/cleanup-plots.yml
+++ b/.github/workflows/cleanup-plots.yml
@@ -34,16 +34,20 @@ jobs:
             cutoff.setDate(cutoff.getDate() - 30);
 
             for (const prNum of fs.readdirSync(prDir)) {
+              const fullPath = path.join(prDir, prNum);
+              if (!fs.lstatSync(fullPath).isDirectory() || !/^\d+$/.test(prNum)) {
+                continue;
+              }
               try {
                 const {data: pr} = await github.rest.pulls.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  pull_number: parseInt(prNum),
+                  pull_number: parseInt(prNum, 10),
                 });
 
                 if (pr.state === 'closed' && new Date(pr.closed_at) < cutoff) {
                   console.log(`Removing plots for PR #${prNum} (closed ${pr.closed_at})`);
-                  fs.rmSync(path.join(prDir, prNum), {recursive: true});
+                  fs.rmSync(fullPath, {recursive: true});
                 }
               } catch (e) {
                 console.log(`Skipping ${prNum}: ${e.message}`);
@@ -52,7 +56,7 @@ jobs:
       - name: Keep only last 10 master plot directories
         run: |
           if [ -d plots/master ]; then
-            ls -t plots/master | tail -n +11 | while read dir; do
+            ls -1 plots/master | sort -r | tail -n +11 | while read dir; do
               rm -rf "plots/master/$dir"
             done
           fi

--- a/.github/workflows/cleanup-plots.yml
+++ b/.github/workflows/cleanup-plots.yml
@@ -1,0 +1,66 @@
+name: Cleanup old PR plots
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Weekly, Sunday 03:00 UTC
+  workflow_dispatch:
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+      - name: Remove plots for old closed PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const prDir = 'plots/pr';
+
+            if (!fs.existsSync(prDir)) {
+              console.log('No PR plots directory found');
+              return;
+            }
+
+            const cutoff = new Date();
+            cutoff.setDate(cutoff.getDate() - 30);
+
+            for (const prNum of fs.readdirSync(prDir)) {
+              try {
+                const {data: pr} = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: parseInt(prNum),
+                });
+
+                if (pr.state === 'closed' && new Date(pr.closed_at) < cutoff) {
+                  console.log(`Removing plots for PR #${prNum} (closed ${pr.closed_at})`);
+                  fs.rmSync(path.join(prDir, prNum), {recursive: true});
+                }
+              } catch (e) {
+                console.log(`Skipping ${prNum}: ${e.message}`);
+              }
+            }
+      - name: Keep only last 10 master plot directories
+        run: |
+          if [ -d plots/master ]; then
+            ls -t plots/master | tail -n +11 | while read dir; do
+              rm -rf "plots/master/$dir"
+            done
+          fi
+      - name: Push cleanup
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet && echo "Nothing to clean up" && exit 0
+          git commit -m "Clean up old CI plots"
+          git push

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,19 +1,45 @@
-#name: Doxygen GitHub Pages Deploy Action
+name: Doxygen GitHub Pages
 on:
   push:
     branches:
       - master
   workflow_dispatch:
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Install Graphviz
-        run: sudo apt-get install graphviz -y
-        shell: bash
-      - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Install dependencies
+        run: sudo apt-get install -y graphviz doxygen
+      - name: Generate Doxygen
+        run: doxygen doxygen/Doxyfile
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: doxygen/html
-          config_file: doxygen/Doxyfile
+          ref: gh-pages
+          path: gh-pages-checkout
+      - name: Update Doxygen files, preserve plots/
+        run: |
+          cd gh-pages-checkout
+          # Remove everything except plots/, .git, and .nojekyll
+          find . -maxdepth 1 -not -name '.' -not -name '.git' \
+            -not -name 'plots' -not -name '.nojekyll' \
+            -exec rm -rf {} +
+          # Copy new Doxygen output
+          cp -r ../doxygen/html/* .
+          touch .nojekyll
+      - name: Deploy
+        run: |
+          cd gh-pages-checkout
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet && echo "No changes" && exit 0
+          git commit -m "Deploy Doxygen from ${{ github.sha }}"
+          git push


### PR DESCRIPTION
Render ROOT histograms to PNG during CI, deploy to gh-pages under plots/pr/<number>/<run_id>/, and post a comment with embedded images. Doxygen workflow updated to preserve the plots/ directory. Old plot directories cleaned up weekly.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now renders and publishes plot images for simulation, tracking benchmark, and fixed‑target runs.
  * Added a top-level interactive index page grouping plots by job/config, lazy-loading images with captions, and auto-generating a PR comment with preview thumbnails and expandable "More plots" sections.

* **Chores**
  * Workflows updated to generate, aggregate, deploy, comment and clean up plot artifacts; gh-pages deployment made more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->