### PR TITLE
fix: derive track seed from PatRec and hits, not hard-coded position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ it in future.
 ### Fixed
 
 * Fix vertex finding for upstream vertices by using stepwise extrapolation
+* Derive track fit seed from pattern recognition and first hit position instead of hard-coded coordinate (#763)
 * Replace obsolete elliptical acceptance cut with rectangular acceptance in track pattern recognition
 * Fix CI build warnings: add missing `override` specifiers, fix `Print()` and `Init()` virtual hiding, remove unused `FairShipFields` LinkDef entry
 * Remove no-effect statements (unused object creation, bare index accesses) from Python scripts

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -332,19 +332,24 @@ class ShipDigiReco:
 
         When PatRec track parameters (k_y, b_y) are available, use them
         to place the seed at the first hit's Z with the correct Y position
-        and momentum direction. Otherwise fall back to the default seed
-        at the decay vessel centre.
+        and momentum direction. Prefers station 1-2 parameters, falls back
+        to station 3-4, then to a geometry-free default at the first hit.
         """
         params = trackParams.get(atrack)
-        if params and params.get("k_y12") is not None:
-            # Use station 1-2 parameters to seed near the first measurement
-            k_y = params["k_y12"]
-            b_y = params["b_y12"]
-            # Seed Z at the first measurement's Z coordinate
-            z_seed = meas[0][2]  # z is the 3rd element of the TVectorD
+        k_y = None
+        b_y = None
+        if params:
+            if params.get("k_y12") is not None:
+                k_y = params["k_y12"]
+                b_y = params["b_y12"]
+            elif params.get("k_y34") is not None:
+                k_y = params["k_y34"]
+                b_y = params["b_y34"]
+
+        z_seed = meas[0][2]  # z is the 3rd element of the TVectorD
+        if k_y is not None:
             y_seed = k_y * z_seed + b_y
             posM = ROOT.TVector3(0, y_seed, z_seed)
-            # Use slope as py/pz ratio; assume 3 GeV total momentum
             p_total = 3.0 * u.GeV
             pz = p_total / ROOT.TMath.Sqrt(1.0 + k_y * k_y)
             py = k_y * pz
@@ -358,7 +363,7 @@ class ShipDigiReco:
                 pz,
             )
         else:
-            posM = ROOT.TVector3(0, 0, 5812.0)  # decay vessel centre
+            posM = ROOT.TVector3(0, 0, z_seed)
             momM = ROOT.TVector3(0, 0, 3.0 * u.GeV)
         return posM, momM
 

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -339,10 +339,10 @@ class ShipDigiReco:
         k_y = None
         b_y = None
         if params:
-            if params.get("k_y12") is not None:
+            if params.get("k_y12") is not None and params.get("b_y12") is not None:
                 k_y = params["k_y12"]
                 b_y = params["b_y12"]
-            elif params.get("k_y34") is not None:
+            elif params.get("k_y34") is not None and params.get("b_y34") is not None:
                 k_y = params["k_y34"]
                 b_y = params["b_y34"]
 


### PR DESCRIPTION
Use station 3-4 PatRec parameters as fallback when station 1-2 unavailable, and seed at first hit Z instead of hard-coded decay vessel centre. Closes #763.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved track seed derivation to prioritize pattern-recognition parameters and always use the first hit for seed position, yielding more accurate and consistent track reconstruction when slope info is missing.
* **Documentation**
  * Updated changelog with the fix to seed derivation logic for transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->