### PR TITLE
Additional validation output for the testing

### DIFF
--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -73,7 +73,13 @@ parser.add_argument(
 )
 parser.add_argument("-dy", dest="dy", help="Max height of tank", required=False, default=None, type=int)
 parser.add_argument("--Debug", dest="Debug", help="Switch on debugging", required=False, action="store_true")
-
+parser.add_argument(
+    "--validation",
+    dest="validation",
+    help="Print reconstruction validation summary after finishing",
+    required=False,
+    action="store_true",
+)
 options = parser.parse_args()
 vertexing = not options.noVertexing
 
@@ -167,7 +173,7 @@ global_variables.iEvent = 0
 # import reco tasks
 import shipDigiReco
 
-SHiP = shipDigiReco.ShipDigiReco(options.inputFile, outFile, fgeo)
+SHiP = shipDigiReco.ShipDigiReco(options.inputFile, outFile, fgeo, validation=options.validation)
 options.nEvents = min(SHiP.sTree.GetEntries(), options.nEvents)
 # main loop
 for global_variables.iEvent in range(options.firstEvent, options.nEvents):

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -14,6 +14,7 @@ import ROOT
 import rootUtils as ut
 import shipRoot_conf
 import shipunit as u
+import validationTools as validation_tools
 
 
 def _fraction_0_1(value: str) -> float:
@@ -352,6 +353,12 @@ parser.add_argument(
 )
 parser.add_argument(
     "--tag", dest="output_tag", help="Custom tag for output files instead of auto-generated UUID", default=None
+)
+parser.add_argument(
+    "--validation",
+    dest="validation",
+    help="Print an extended simulation validation summary after the run",
+    action="store_true",
 )
 
 
@@ -917,6 +924,7 @@ print("Parameter file is ", parFile)
 print("Geometry file is ", geofile_name)
 print("Real time ", rtime, " s, CPU time ", ctime, "s")
 
+
 # remove empty events
 if options.muonback:
     tmpFile = outFile + "tmp"
@@ -1032,6 +1040,25 @@ if options.command == "Genie":
 
     f_input.Close()
     f_output.Close()
+
+print("=" * 72)
+print("Simulation finished successfully")
+print("=" * 72)
+
+if options.validation:
+    validation_tools.print_simulation_output_summary(
+        ROOT,
+        outFile,
+        options.nEvents,
+        {"HNL": HNL, "DarkPhoton": options.DarkPhoton, "fixedTarget": options.fixedTarget},
+        {
+            "P8gen": globals().get("P8gen"),
+            "MuonBackgen": globals().get("MuonBackgen"),
+            "Ntuplegen": globals().get("Ntuplegen"),
+            "DISgen": globals().get("DISgen"),
+            "Geniegen": globals().get("Geniegen"),
+        },
+    )
 
 # ------------------------------------------------------------------------
 import checkMagFields

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -10,6 +10,7 @@ import rootUtils as ut
 import shipPatRec
 import shipunit as u
 import shipVertex
+import validationTools as validation_tools
 from detectors.MTCDetector import MTCDetector
 from detectors.SBTDetector import SBTDetector
 from detectors.splitcalDetector import splitcalDetector
@@ -23,7 +24,9 @@ logger = logging.getLogger(__name__)
 class ShipDigiReco:
     "convert FairSHiP MC hits / digitized hits to measurements"
 
-    def __init__(self, finput, fout, fgeo) -> None:
+    def __init__(self, finput, fout, fgeo, validation: bool = False) -> None:
+        self.validation = validation
+        self.validation_stats = validation_tools.make_reco_validation_stats() if self.validation else None
         # Open input file (read-only) and get the MC tree
         self.inputFile = ROOT.TFile.Open(finput, "read")
         self.sTree = self.inputFile["cbmsim"]
@@ -107,13 +110,29 @@ class ShipDigiReco:
         shipPatRec.initialize(fgeo)
 
     def reconstruct(self) -> None:
-        self.findTracks()
-        self.findGoodTracks()
+        n_tracks = self.findTracks()
+        n_good_tracks = self.findGoodTracks()
         if hasattr(self, "digiSBT"):
             self.linkVetoOnTracks()
         if global_variables.vertexing:
             # now go for 2-track combinations
+            if self.validation:
+                self.validation_stats["vertexing_calls"] += 1
             self.Vertexing.execute()
+        if self.validation:
+            self.validation_stats["events_reconstructed"] += 1
+            self.validation_stats["fitted_tracks_total"] += n_tracks
+            self.validation_stats["good_tracks_total"] += n_good_tracks
+            if n_tracks > 0:
+                self.validation_stats["events_with_fitted_tracks"] += 1
+            if n_good_tracks > 0:
+                self.validation_stats["events_with_good_tracks"] += 1
+            validation_tools.record_event_stat(self.validation_stats, "event_fitted_tracks", n_tracks)
+            validation_tools.record_event_stat(self.validation_stats, "event_good_tracks", n_good_tracks)
+            if hasattr(self, "digiSBT"):
+                validation_tools.record_event_stat(
+                    self.validation_stats, "event_veto_links", len(self.vetoHitOnTrackArray)
+                )
 
     def digitize(self) -> None:
         self.sTree.t0 = self.random.Rndm() * 1 * u.microsecond
@@ -131,6 +150,8 @@ class ShipDigiReco:
             self.digiMTC.process()
         if self.sTree.GetBranch("splitcalPoint"):
             self.splitcalDetector.process()
+        if self.validation:
+            self.validation_stats["events_digitized"] += 1
 
     def findTracks(self) -> int:
         hitPosLists = {}
@@ -148,12 +169,21 @@ class ShipDigiReco:
         # old procedure, not including estimation of t0
         else:
             self.SmearedHits = self.strawtubes.smearHits(global_variables.withNoStrawSmearing)
+        if self.validation:
+            self.validation_stats["smeared_hits_total"] += len(self.SmearedHits)
+            if len(self.SmearedHits) > 0:
+                self.validation_stats["events_with_hits"] += 1
 
         trackCandidates = []
 
         # Do pattern recognition
         track_hits = shipPatRec.execute(self.SmearedHits, global_variables.ShipGeo, global_variables.patRec)
         logger.debug("PatRec returned %d track candidates", len(track_hits))
+        if self.validation:
+            self.validation_stats["track_candidates_total"] += len(track_hits)
+            if len(track_hits) > 0:
+                self.validation_stats["events_with_candidates"] += 1
+            validation_tools.record_event_stat(self.validation_stats, "event_track_candidates", len(track_hits))
         # Create hitPosLists for track fit
         for i_track in track_hits:
             atrack = track_hits[i_track]
@@ -206,10 +236,18 @@ class ShipDigiReco:
             meas = hitPosLists[atrack]
             detIDs = hit_detector_ids[atrack]
             nM = len(meas)
+            n_stations_crossed = len(stationCrossed[atrack])
+            if self.validation:
+                self.validation_stats["candidate_hits_sum"] += nM
+                self.validation_stats["candidate_hits_sum_sq"] += nM * nM
+                self.validation_stats["candidate_hits_count"] += 1
+                self.validation_stats["candidate_stations_sum"] += n_stations_crossed
+                self.validation_stats["candidate_stations_sum_sq"] += n_stations_crossed * n_stations_crossed
+                self.validation_stats["candidate_stations_count"] += 1
             if nM < 13:
                 n_too_few_hits += 1
                 continue  # not enough hits to make a good trackfit
-            if len(stationCrossed[atrack]) < 3:
+            if n_stations_crossed < 3:
                 n_too_few_stations += 1
                 continue  # not enough stations crossed to make a good trackfit
             if global_variables.debug:
@@ -222,6 +260,8 @@ class ShipDigiReco:
             best_track = None
             best_chi2ndf = float("inf")
             for try_pdg in [pdg, -pdg]:
+                if self.validation:
+                    self.validation_stats["fit_hypotheses_tried"] += 1
                 # approximate covariance
                 covM = ROOT.TMatrixDSym(6)
                 resolution = self.sigma_spatial
@@ -259,26 +299,36 @@ class ShipDigiReco:
                 try:
                     theTrack.checkConsistency()
                 except ROOT.genfit.Exception:
+                    if self.validation:
+                        self.validation_stats["tracks_failed_consistency"] += 1
                     continue
                 try:
                     self.fitter.processTrack(theTrack)
                 except Exception as e:
                     logger.debug("Failed to processTrack for hypothesis %d: %s", try_pdg, e)
+                    if self.validation:
+                        self.validation_stats["tracks_failed_fit"] += 1
                     continue
                 try:
                     theTrack.checkConsistency()
                 except ROOT.genfit.Exception:
                     logger.debug("Track inconsistent after fit for hypothesis %d", try_pdg)
+                    if self.validation:
+                        self.validation_stats["tracks_failed_consistency"] += 1
                     continue
                 try:
                     fittedState = theTrack.getFittedState()
                     fittedState.getMomMag()
                 except Exception as e:
                     logger.debug("Failed to getFittedState/getMomMag for hypothesis %d: %s", try_pdg, e)
+                    if self.validation:
+                        self.validation_stats["tracks_failed_state_access"] += 1
                     continue
                 fitStatus = theTrack.getFitStatus()
                 if not fitStatus.isFitConverged():
                     continue
+                if self.validation:
+                    self.validation_stats["fit_hypotheses_converged"] += 1
                 nmeas = fitStatus.getNdf()
                 if nmeas <= 0:
                     continue
@@ -295,6 +345,13 @@ class ShipDigiReco:
             nmeas = fitStatus.getNdf()  # guaranteed > 0 by hypothesis loop filter
             global_variables.h["nmeas"].Fill(nmeas)
             chi2 = fitStatus.getChi2() / nmeas
+            if self.validation:
+                self.validation_stats["chi2_sum"] += chi2
+                self.validation_stats["chi2_sum_sq"] += chi2 * chi2
+                self.validation_stats["chi2_count"] += 1
+                self.validation_stats["ndf_sum"] += nmeas
+                self.validation_stats["ndf_sum_sq"] += nmeas * nmeas
+                self.validation_stats["ndf_count"] += 1
             global_variables.h["chi2"].Fill(chi2)
             # make track persistent
             # Store pointer - make a copy and let ROOT manage lifetime
@@ -324,6 +381,9 @@ class ShipDigiReco:
             n_too_few_stations,
             len(self.fGenFitArray),
         )
+        if self.validation:
+            self.validation_stats["track_candidates_rejected_hits"] += n_too_few_hits
+            self.validation_stats["track_candidates_rejected_stations"] += n_too_few_stations
 
         # debug
         if global_variables.debug:
@@ -413,7 +473,16 @@ class ShipDigiReco:
         self.vetoHitOnTrackArray.clear()
         for good_track in self.goodTracksVect:
             track = self.fGenFitArray[good_track]
-            self.vetoHitOnTrackArray.push_back(self.findVetoHitOnTrack(track))
+            veto_link = self.findVetoHitOnTrack(track)
+            self.vetoHitOnTrackArray.push_back(veto_link)
+            if self.validation:
+                if veto_link.GetIndex() >= 0:  # Only record real matches
+                    dist = float(veto_link.GetDist())
+                    self.validation_stats["veto_link_distance_sum"] += dist
+                    self.validation_stats["veto_link_distance_sum_sq"] += dist * dist
+                    self.validation_stats["veto_link_distance_count"] += 1
+        if self.validation:
+            self.validation_stats["veto_links_total"] += len(self.vetoHitOnTrackArray)
 
     def fracMCsame(self, trackids):
         track = {}
@@ -435,6 +504,10 @@ class ShipDigiReco:
 
     def finish(self) -> None:
         del self.fitter
+        if self.validation:
+            validation_tools.print_reco_validation_summary(
+                self.validation_stats, has_veto_detector=hasattr(self, "digiSBT")
+            )
         print("finished writing tree")
         self.outputFile.cd()
         self.recoTree.Write()

--- a/python/validationTools.py
+++ b/python/validationTools.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+
+def container_size(container):
+    if container is None:
+        return None
+    try:
+        return len(container)
+    except TypeError:
+        return None
+
+
+def format_mean_std(count, total, total_sq):
+    if count <= 0:
+        return "n/a"
+    mean = total / count
+    variance = max(0.0, total_sq / count - mean * mean)
+    std = variance**0.5
+    return f"{mean:.4g} +- {std:.4g}"
+
+
+def safe_fraction(numerator, denominator):
+    if denominator == 0:
+        return "n/a"
+    return f"{100.0 * numerator / denominator:.2f}%"
+
+
+def print_section(title):
+    print(" ")
+    print(f"[{title}]")
+
+
+def print_kv(label, value, width=28, separator=" : "):
+    print(f"  {label:<{width}}{separator}{value}")
+
+
+def update_numeric_stat(stats, value):
+    stats["count"] += 1
+    stats["sum"] += value
+    stats["sum_sq"] += value * value
+    if stats["min"] is None or value < stats["min"]:
+        stats["min"] = value
+    if stats["max"] is None or value > stats["max"]:
+        stats["max"] = value
+
+
+def format_stat_summary(stats):
+    return (
+        f"{format_mean_std(stats['count'], stats['sum'], stats['sum_sq'])}"
+        f"  [min={stats['min']:.4g}, max={stats['max']:.4g}]"
+    )
+
+
+def make_numeric_stats():
+    return {"count": 0, "sum": 0.0, "sum_sq": 0.0, "min": None, "max": None}
+
+
+def make_reco_validation_stats():
+    return {
+        "events_digitized": 0,
+        "events_reconstructed": 0,
+        "events_with_hits": 0,
+        "events_with_candidates": 0,
+        "events_with_fitted_tracks": 0,
+        "events_with_good_tracks": 0,
+        "smeared_hits_total": 0,
+        "track_candidates_total": 0,
+        "track_candidates_rejected_hits": 0,
+        "track_candidates_rejected_stations": 0,
+        "fit_hypotheses_tried": 0,
+        "fit_hypotheses_converged": 0,
+        "tracks_failed_consistency": 0,
+        "tracks_failed_fit": 0,
+        "tracks_failed_state_access": 0,
+        "fitted_tracks_total": 0,
+        "good_tracks_total": 0,
+        "vertexing_calls": 0,
+        "veto_links_total": 0,
+        "event_track_candidates_sum": 0.0,
+        "event_track_candidates_sum_sq": 0.0,
+        "event_fitted_tracks_sum": 0.0,
+        "event_fitted_tracks_sum_sq": 0.0,
+        "event_good_tracks_sum": 0.0,
+        "event_good_tracks_sum_sq": 0.0,
+        "event_veto_links_sum": 0.0,
+        "event_veto_links_sum_sq": 0.0,
+        "chi2_sum": 0.0,
+        "chi2_sum_sq": 0.0,
+        "chi2_count": 0,
+        "ndf_sum": 0.0,
+        "ndf_sum_sq": 0.0,
+        "ndf_count": 0,
+        "candidate_hits_sum": 0.0,
+        "candidate_hits_sum_sq": 0.0,
+        "candidate_hits_count": 0,
+        "candidate_stations_sum": 0.0,
+        "candidate_stations_sum_sq": 0.0,
+        "candidate_stations_count": 0,
+        "veto_link_distance_sum": 0.0,
+        "veto_link_distance_sum_sq": 0.0,
+        "veto_link_distance_count": 0,
+    }
+
+
+def record_event_stat(stats, key, value):
+    stats[f"{key}_sum"] += value
+    stats[f"{key}_sum_sq"] += value * value
+
+
+def print_reco_validation_summary(stats, has_veto_detector=False):
+    print_section("Reco Validation")
+    for label in [
+        "events_digitized",
+        "events_reconstructed",
+        "events_with_hits",
+        "events_with_candidates",
+        "events_with_fitted_tracks",
+        "events_with_good_tracks",
+        "smeared_hits_total",
+        "track_candidates_total",
+        "track_candidates_rejected_hits",
+        "track_candidates_rejected_stations",
+        "fit_hypotheses_tried",
+        "fit_hypotheses_converged",
+        "tracks_failed_consistency",
+        "tracks_failed_fit",
+        "tracks_failed_state_access",
+        "fitted_tracks_total",
+        "good_tracks_total",
+        "vertexing_calls",
+        "veto_links_total",
+    ]:
+        print_kv(label, stats[label], width=40)
+    if stats["events_reconstructed"] > 0:
+        n_events = stats["events_reconstructed"]
+        print_kv(
+            "track_candidates_per_event",
+            format_mean_std(n_events, stats["event_track_candidates_sum"], stats["event_track_candidates_sum_sq"]),
+            width=40,
+        )
+        print_kv(
+            "fitted_tracks_per_event",
+            format_mean_std(n_events, stats["event_fitted_tracks_sum"], stats["event_fitted_tracks_sum_sq"]),
+            width=40,
+        )
+        print_kv(
+            "good_tracks_per_event",
+            format_mean_std(n_events, stats["event_good_tracks_sum"], stats["event_good_tracks_sum_sq"]),
+            width=40,
+        )
+        if has_veto_detector:
+            print_kv(
+                "veto_links_per_event",
+                format_mean_std(n_events, stats["event_veto_links_sum"], stats["event_veto_links_sum_sq"]),
+                width=40,
+            )
+    if stats["candidate_hits_count"] > 0:
+        print_kv(
+            "hits_per_candidate",
+            format_mean_std(stats["candidate_hits_count"], stats["candidate_hits_sum"], stats["candidate_hits_sum_sq"]),
+            width=40,
+        )
+    if stats["candidate_stations_count"] > 0:
+        print_kv(
+            "stations_per_candidate",
+            format_mean_std(
+                stats["candidate_stations_count"], stats["candidate_stations_sum"], stats["candidate_stations_sum_sq"]
+            ),
+            width=40,
+        )
+    if stats["veto_link_distance_count"] > 0:
+        print_kv(
+            "veto_link_distance",
+            format_mean_std(
+                stats["veto_link_distance_count"], stats["veto_link_distance_sum"], stats["veto_link_distance_sum_sq"]
+            ),
+            width=40,
+        )
+    if stats["chi2_count"] > 0:
+        print_kv(
+            "fit_chi2_over_ndf", format_mean_std(stats["chi2_count"], stats["chi2_sum"], stats["chi2_sum_sq"]), width=40
+        )
+    if stats["ndf_count"] > 0:
+        print_kv("fit_ndf", format_mean_std(stats["ndf_count"], stats["ndf_sum"], stats["ndf_sum_sq"]), width=40)
+    if stats["fit_hypotheses_tried"] > 0:
+        print_kv(
+            "fit_convergence_fraction",
+            f"{100.0 * stats['fit_hypotheses_converged'] / stats['fit_hypotheses_tried']:.2f}%",
+            width=40,
+        )
+    if stats["track_candidates_total"] > 0:
+        print_kv(
+            "candidate_to_fit_fraction",
+            f"{100.0 * stats['fitted_tracks_total'] / stats['track_candidates_total']:.2f}%",
+            width=40,
+        )
+    if stats["fitted_tracks_total"] > 0:
+        print_kv(
+            "good_track_fraction",
+            f"{100.0 * stats['good_tracks_total'] / stats['fitted_tracks_total']:.2f}%",
+            width=40,
+        )
+
+
+def _collect_generator_stats(flags, generators):
+    generator_stats = []
+    p8gen = generators.get("P8gen")
+    if p8gen is not None:
+        if flags["HNL"]:
+            generator_stats.append(("HNL retries", p8gen.nrOfRetries()))
+            generator_stats.append(("Geometry rejections", p8gen.nrOfGeoRejections()))
+            generator_stats.append(("HNL candidates", p8gen.GetCounter("hnl_candidates")))
+            generator_stats.append(("Accepted HNL candidates", p8gen.GetCounter("hnl_accepted_candidates")))
+            generator_stats.append(("Multi-HNL tries", p8gen.GetCounter("hnl_multi_candidate_tries")))
+            generator_stats.append(("Stored decay products", p8gen.GetCounter("hnl_stored_decay_products")))
+        elif flags["DarkPhoton"]:
+            generator_stats.append(("DP retries", p8gen.nrOfRetries()))
+            generator_stats.append(("Geometry rejections", p8gen.nrOfGeoRejections()))
+            generator_stats.append(("Total dark photons", p8gen.nrOfDP()))
+        elif flags["fixedTarget"]:
+            generator_stats.append(("Generated events", p8gen.GetCounter("generated_events")))
+            generator_stats.append(("G4-only events", p8gen.GetCounter("g4only_events")))
+            generator_stats.append(("Charm input pairs", p8gen.GetCounter("charm_input_pairs")))
+            generator_stats.append(("Stored tracks", p8gen.GetCounter("stored_tracks")))
+            generator_stats.append(("Tracked final-state particles", p8gen.GetCounter("tracked_final_state_particles")))
+            generator_stats.append(("Skipped final-state particles", p8gen.GetCounter("skipped_final_state_particles")))
+    muon_back_gen = generators.get("MuonBackgen")
+    if muon_back_gen is not None:
+        generator_stats.append(("Scanned input entries", muon_back_gen.GetCounter("scanned_entries")))
+        generator_stats.append(("Accepted input entries", muon_back_gen.GetCounter("accepted_entries")))
+        generator_stats.append(("Selected muons", muon_back_gen.GetCounter("selected_muons")))
+        generator_stats.append(("Transported tracks", muon_back_gen.GetCounter("transported_tracks")))
+    ntuple_gen = generators.get("Ntuplegen")
+    if ntuple_gen is not None:
+        generator_stats.append(("Scanned ntuple entries", ntuple_gen.GetCounter("scanned_entries")))
+        generator_stats.append(("Accepted ntuple entries", ntuple_gen.GetCounter("accepted_entries")))
+        generator_stats.append(("Rejected ntuple entries", ntuple_gen.GetCounter("rejected_entries")))
+    dis_gen = generators.get("DISgen")
+    if dis_gen is not None:
+        generator_stats.append(("Generated DIS events", dis_gen.GetCounter("generated_events")))
+        generator_stats.append(("Interaction sampling trials", dis_gen.GetCounter("interaction_sampling_trials")))
+        generator_stats.append(("Stored DIS particles", dis_gen.GetCounter("dis_particles_stored")))
+        generator_stats.append(("Stored soft particles", dis_gen.GetCounter("soft_particles_stored")))
+        generator_stats.append(("Skipped soft particles", dis_gen.GetCounter("soft_particles_skipped")))
+    genie_gen = generators.get("Geniegen")
+    if genie_gen is not None:
+        generator_stats.append(("Generated GENIE events", genie_gen.GetCounter("generated_events")))
+        generator_stats.append(("CC events", genie_gen.GetCounter("cc_events")))
+        generator_stats.append(("nu-e elastic events", genie_gen.GetCounter("nue_elastic_events")))
+        generator_stats.append(("Interaction sampling trials", genie_gen.GetCounter("interaction_sampling_trials")))
+        generator_stats.append(("Stored outgoing leptons", genie_gen.GetCounter("outgoing_leptons_stored")))
+        generator_stats.append(("Stored outgoing hadrons", genie_gen.GetCounter("outgoing_hadrons_stored")))
+    return generator_stats
+
+
+def print_simulation_output_summary(ROOT, output_filename, requested_events, flags, generators):
+    generator_stats = _collect_generator_stats(flags, generators)
+    if generator_stats:
+        print_section("Generator Validation")
+        for label, value in generator_stats:
+            print_kv(label, value)
+
+    with ROOT.TFile.Open(output_filename, "READ") as summary_file:
+        if not summary_file or summary_file.IsZombie():
+            print("Could not reopen output file for summary:", output_filename)
+            return
+
+        keys = list(summary_file.GetListOfKeys())
+        print_section("Tree Validation")
+        print_kv("Requested events", requested_events)
+
+        tree = summary_file.Get("cbmsim")
+        if not tree:
+            print("No cbmsim tree found in output file.")
+            return
+
+        n_entries = tree.GetEntries()
+        print_kv("Final cbmsim entries", n_entries)
+        print_kv("Kept fraction", safe_fraction(n_entries, requested_events))
+
+        branch_names = [branch.GetName() for branch in tree.GetListOfBranches()]
+        print_kv("Branches in cbmsim", len(branch_names))
+        print_kv("ROOT objects", len(keys))
+
+        if n_entries <= 0:
+            print("cbmsim tree is empty.")
+            return
+
+        scalar_stats = {}
+        branch_stats = {}
+        track_stats = {
+            "total_tracks": 0,
+            "primary_tracks": 0,
+            "secondary_tracks": 0,
+            "weight_sum": 0.0,
+            "weight_sq_sum": 0.0,
+            "weight_min": None,
+            "weight_max": None,
+            "p": make_numeric_stats(),
+            "energy": make_numeric_stats(),
+            "start_z": make_numeric_stats(),
+            "pdg_counts": {},
+        }
+
+        for branch_name in branch_names:
+            branch_stats[branch_name] = {"total": 0, "nonzero": 0, "max": 0, "sum_sq": 0.0}
+
+        for event_index in range(n_entries):
+            tree.GetEntry(event_index)
+            for branch_name in branch_names:
+                container = getattr(tree, branch_name, None)
+                count = container_size(container)
+                if count is None:
+                    try:
+                        value = float(container)
+                    except (TypeError, ValueError):
+                        continue
+                    if branch_name not in scalar_stats:
+                        scalar_stats[branch_name] = make_numeric_stats()
+                    update_numeric_stat(scalar_stats[branch_name], value)
+                    continue
+
+                stats = branch_stats[branch_name]
+                stats["total"] += count
+                if count > 0:
+                    stats["nonzero"] += 1
+                if count > stats["max"]:
+                    stats["max"] = count
+                stats["sum_sq"] += count * count
+
+                if branch_name == "MCTrack" and count > 0:
+                    for track in container:
+                        track_stats["total_tracks"] += 1
+                        if track.GetMotherId() < 0:
+                            track_stats["primary_tracks"] += 1
+                        else:
+                            track_stats["secondary_tracks"] += 1
+                        weight = float(track.GetWeight())
+                        track_stats["weight_sum"] += weight
+                        track_stats["weight_sq_sum"] += weight * weight
+                        if track_stats["weight_min"] is None or weight < track_stats["weight_min"]:
+                            track_stats["weight_min"] = weight
+                        if track_stats["weight_max"] is None or weight > track_stats["weight_max"]:
+                            track_stats["weight_max"] = weight
+                        update_numeric_stat(track_stats["p"], float(track.GetP()))
+                        update_numeric_stat(track_stats["energy"], float(track.GetEnergy()))
+                        update_numeric_stat(track_stats["start_z"], float(track.GetStartZ()))
+                        pdg = int(track.GetPdgCode())
+                        track_stats["pdg_counts"][pdg] = track_stats["pdg_counts"].get(pdg, 0) + 1
+
+        countable_branches = [
+            name for name, stats in branch_stats.items() if stats["total"] > 0 or stats["nonzero"] > 0
+        ]
+        print_kv("Countable branches", len(countable_branches))
+
+        if track_stats["total_tracks"] > 0:
+            print_section("MCTrack Validation")
+            print_kv("Total tracks", track_stats["total_tracks"])
+            print_kv("Primary tracks", track_stats["primary_tracks"])
+            print_kv("Secondary tracks", track_stats["secondary_tracks"])
+            print_kv("Tracks per event", f"{track_stats['total_tracks'] / n_entries:.4g}")
+            print_kv("Track momentum", format_stat_summary(track_stats["p"]))
+            print_kv("Track energy", format_stat_summary(track_stats["energy"]))
+            print_kv("Track start Z", format_stat_summary(track_stats["start_z"]))
+            top_pdgs = sorted(track_stats["pdg_counts"].items(), key=lambda item: (-item[1], abs(item[0]), item[0]))[
+                :10
+            ]
+            print_kv("Top PDG counts", ", ".join(f"{pdg}:{count}" for pdg, count in top_pdgs))
+
+        if scalar_stats:
+            print_section("Scalar Branch Validation")
+            for branch_name in sorted(scalar_stats):
+                print_kv(branch_name, format_stat_summary(scalar_stats[branch_name]))
+
+        print_section("Branch Multiplicity")
+        for branch_name in sorted(countable_branches):
+            stats = branch_stats[branch_name]
+            active = 100.0 * stats["nonzero"] / n_entries
+            print_kv(
+                branch_name,
+                f"total={stats['total']}, mean/event={format_mean_std(n_entries, stats['total'], stats['sum_sq'])},"
+                f" active={stats['nonzero']}/{n_entries} ({active:5.1f}%), max={stats['max']}",
+                width=22,
+            )

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -376,6 +376,9 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   }
   Pythia8::Pythia* fPythia;
   if (G4only) {
+    IncrementCounter("generated_events");
+    IncrementCounter("g4only_events");
+    IncrementCounter("stored_tracks");
     cpg->AddTrack(2212, 0., 0., fMom, (xOff + dx) / cm, (yOff + dy) / cm,
                   start[2], -1, kTRUE, -1., 0., 1.);
     return kTRUE;
@@ -417,6 +420,7 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     }
     nTree->GetEvent(nEntry);
     nEntry += 1;
+    IncrementCounter("charm_input_pairs");
     // sanity check, count number of p.o.t. on input file.
     Double_t pt = TMath::Sqrt((n_mpx * n_mpx) + (n_mpy * n_mpy));
     // every event appears twice, i.e.
@@ -439,6 +443,7 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     cpg->AddTrack(static_cast<int>(n_mid), n_mpx, n_mpy, n_mpz,
                   (xOff + dx) * cm, (yOff + dy) * cm, zinter * cm, -1, kFALSE,
                   n_mE, 0., wspill, procID);
+    IncrementCounter("stored_tracks");
     // second charm hadron in the event
     nTree->GetEvent(nEntry);
     if (nID1 * n_id > 0) {
@@ -493,6 +498,12 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
         im = -1;
       }
     }
+    IncrementCounter("stored_tracks");
+    if (wanttracking) {
+      IncrementCounter("tracked_final_state_particles");
+    } else {
+      IncrementCounter("skipped_final_state_particles");
+    }
     cpg->AddTrack(id, px, py, pz, x * cm, y * cm, z * cm, im, wanttracking, e,
                   tof, wspill, procID);
     if (withNtuple) {
@@ -508,6 +519,7 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       }
     }
   }
+  IncrementCounter("generated_events");
   return kTRUE;
 }
 // -------------------------------------------------------------------------

--- a/shipgen/Generator.h
+++ b/shipgen/Generator.h
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "FairGenerator.h"
@@ -53,6 +54,16 @@ class Generator : public FairGenerator {
     fUseVesselAcceptance = true;
   };
   Int_t nrOfGeoRejections() const { return fnGeoRejects; }
+  Long64_t GetCounter(const std::string& name) const {
+    auto it = fCounters.find(name);
+    return it == fCounters.end() ? 0 : it->second;
+  }
+  void SetCounter(const std::string& name, Long64_t value) {
+    fCounters[name] = value;
+  }
+  void IncrementCounter(const std::string& name, Long64_t delta = 1) {
+    fCounters[name] += delta;
+  }
 
  protected:
   bool IsInVesselAcceptance(Double_t px, Double_t py, Double_t pz) const {
@@ -67,6 +78,7 @@ class Generator : public FairGenerator {
   Double_t fMaxThetaY = 0;
   bool fUseVesselAcceptance = false;
   Int_t fnGeoRejects = 0;
+  std::unordered_map<std::string, int64_t> fCounters;
 };
 }  // namespace SHiP
 #endif  // SHIPGEN_GENERATOR_H_

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -228,6 +228,9 @@ Bool_t GenieGenerator::OldReadEvent(FairPrimaryGenerator* cpg) {
   // cout << "Info GenieGenerator: neutrino " << neu << "p-rot "<< pout[0] << "
   // fn "<< fn << endl;
   cpg->AddTrack(neu, pout[0], pout[1], pout[2], x, y, z, -1, false);
+  IncrementCounter("generated_events");
+  if (cc) IncrementCounter("cc_events");
+  if (nuel) IncrementCounter("nue_elastic_events");
 
   // second, outgoing lepton
   pout = Rotate(x, y, zrelative, pxl, pyl, pzl);
@@ -239,10 +242,12 @@ Bool_t GenieGenerator::OldReadEvent(FairPrimaryGenerator* cpg) {
     oLPdgCode = 11;
   }
   cpg->AddTrack(oLPdgCode, pout[0], pout[1], pout[2], x, y, z, 0, true);
+  IncrementCounter("outgoing_leptons_stored");
   // last, all others
   for (int i = 0; i < nf; i++) {
     pout = Rotate(x, y, zrelative, pxf[i], pyf[i], pzf[i]);
     cpg->AddTrack(pdgf[i], pout[0], pout[1], pout[2], x, y, z, 0, true);
+    IncrementCounter("outgoing_hadrons_stored");
     // cout << "f " << pdgf[i] << " pz "<< pzf[i] << endl;
   }
 
@@ -379,6 +384,7 @@ Bool_t GenieGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   Double_t y = 0.;
   Double_t z = 0.;
   while (prob2int < gRandom->Uniform(0., 1.)) {
+    IncrementCounter("interaction_sampling_trials");
     // place x,y,z uniform along path
     z = gRandom->Uniform(start[2], end[2]);
     x = txnu * (z - ztarget);
@@ -417,6 +423,9 @@ Bool_t GenieGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       neu, pout[0], pout[1], pout[2], x, y, z, -1, false,
       TMath::Sqrt(pout[0] * pout[0] + pout[1] * pout[1] + pout[2] * pout[2]),
       tof, mparam[0] * mparam[4]);
+  IncrementCounter("generated_events");
+  if (cc) IncrementCounter("cc_events");
+  if (nuel) IncrementCounter("nue_elastic_events");
   if (!fNuOnly) {
     // second, outgoing lepton
     std::vector<double> pp = Rotate(x, y, zrelative, pxl, pyl, pzl);
@@ -429,11 +438,13 @@ Bool_t GenieGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     }
     cpg->AddTrack(oLPdgCode, pp[0], pp[1], pp[2], x, y, z, 0, true, El, tof,
                   mparam[0] * mparam[4]);
+    IncrementCounter("outgoing_leptons_stored");
     // last, all others
     for (int i = 0; i < nf; i++) {
       pp = Rotate(x, y, zrelative, pxf[i], pyf[i], pzf[i]);
       cpg->AddTrack(pdgf[i], pp[0], pp[1], pp[2], x, y, z, 0, true, Ef[i], tof,
                     mparam[0] * mparam[4]);
+      IncrementCounter("outgoing_hadrons_stored");
       // cout << "f " << pdgf[i] << " pz "<< pzf[i] << endl;
     }
     // cout << "Info GenieGenerator Return from GenieGenerator" << endl;

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -141,6 +141,10 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
         hnls.push_back(i);
       }
     }
+    IncrementCounter("hnl_candidates", hnls.size());
+    if (hnls.size() > 1) {
+      IncrementCounter("hnl_multi_candidate_tries");
+    }
     iHNL = hnls.size();
     if (iHNL == 0) {
       fnRetries += 1;
@@ -154,6 +158,7 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
           accepted.push_back(idx);
         }
       }
+      IncrementCounter("hnl_accepted_candidates", accepted.size());
       if (accepted.empty()) {
         iHNL = 0;
         hnls.clear();
@@ -277,6 +282,7 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
     if (fextFile) {
       im += 1;
     }
+    IncrementCounter("hnl_stored_decay_products");
     cpg->AddTrack((Int_t)fPythia->event[k].id(), px, py, pz, xS / cm, yS / cm,
                   zS / cm, im, wanttracking, e, tS / cm / c_light, w);
     // std::cout <<k<< " insert pdg =" <<fPythia->event[k].id() << " pz = " <<

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -127,6 +127,7 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
              << mparam[7] << ", " << mparam[7] * 1.e8;
 
   while (prob2int < gRandom->Uniform(0., 1.)) {
+    IncrementCounter("interaction_sampling_trials");
     zmu = gRandom->Uniform(start[2], end[2]);
     xmu = x - (z - zmu) * txmu;
     ymu = y - (z - zmu) * tymu;
@@ -205,6 +206,7 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       cpg->AddTrack(static_cast<int>((*Part)[0]), (*Part)[1], (*Part)[2],
                     (*Part)[3], xmu, ymu, zmu, 0, true, (*Part)[4], t_DIS, w);
     }
+    IncrementCounter("dis_particles_stored");
     index += 1;
   }
 
@@ -212,6 +214,7 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   for (auto&& softParticle : *dPartSoft) {
     TVectorD* SoftPart = dynamic_cast<TVectorD*>(softParticle);
     if ((*SoftPart)[7] > zmu) {
+      IncrementCounter("soft_particles_skipped");
       continue;
     }  // Soft interactions after the DIS point are not saved
     Double_t t_soft = (*SoftPart)[8] / 1e9;  // Time in seconds
@@ -219,7 +222,10 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
                   (*SoftPart)[2], (*SoftPart)[3], (*SoftPart)[5],
                   (*SoftPart)[6], (*SoftPart)[7], 0, true, (*SoftPart)[4],
                   t_soft, w);
+    IncrementCounter("soft_particles_stored");
   }
+
+  IncrementCounter("generated_events");
 
   return kTRUE;
 }

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -199,6 +199,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   bool found_muon = false;
   while (fn < fNevents) {
     fTree->GetEntry(fn);
+    IncrementCounter("scanned_entries");
     muList.clear();
     moList.clear();
     fn++;
@@ -248,6 +249,8 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
         LOGF(debug, "No muon found %i", fn - 1);
       }
       if (found) {
+        IncrementCounter("accepted_entries");
+        IncrementCounter("selected_muons", muList.size());
         found_muon = true;
         break;
       }
@@ -307,6 +310,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
           break;
         }
       }
+      IncrementCounter("transported_tracks");
       cpg->AddTrack(track->GetPdgCode(), px, py, pz, vx, vy, vz,
                     track->GetMotherId(), wanttracking, e, tof,
                     track->GetWeight(), (TMCProcess)track->GetProcID());
@@ -320,8 +324,11 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       px = pt * TMath::Cos(phi_random);
       py = pt * TMath::Sin(phi_random);
     }
+    IncrementCounter("accepted_entries");
+    IncrementCounter("selected_muons");
     cpg->AddTrack(static_cast<int>(pythiaid), px, py, pz, vx * 100., vy * 100.,
                   vz * 100., -1., false, e, pythiaid, parentid);
+    IncrementCounter("transported_tracks", 2);
     cpg->AddTrack(static_cast<int>(id), px, py, pz, vx * 100., vy * 100.,
                   vz * 100., -1., true, e, tof, w);
   }

--- a/shipgen/NtupleGenerator.cxx
+++ b/shipgen/NtupleGenerator.cxx
@@ -67,6 +67,7 @@ NtupleGenerator::~NtupleGenerator() {
 Bool_t NtupleGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   while (fn < fNevents) {
     fTree->GetEntry(fn);
+    IncrementCounter("scanned_entries");
     fn++;
     if (fn % 10000 == 0) {
       cout << "reading event " << fn << endl;
@@ -75,8 +76,10 @@ Bool_t NtupleGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     Int_t i = Nmeas - 3;
     Float_t r2 = (vx[i] * vx[i] + vy[i] * vy[i]);
     if (procid[Nmeas - 1] == 2 && r2 < 9) {
+      IncrementCounter("accepted_entries");
       break;
     }
+    IncrementCounter("rejected_entries");
   }
   if (fn == fNevents) {
     cout << "No more input events" << endl;


### PR DESCRIPTION
This PR adds lightweight validation summaries to the simulation and reconstruction workflows behind an option --validation flag, so the default behavior and output stay the same.

For run_simScript.py, --validation prints generator- and output-level counters, including a few new internal counters added to the main generators. For ShipReco.py, --validation prints reconstruction counters such as event flow, pattern-recognition yield, fit success/failure counts, and simple per-event averages.

The results are the same, which could be obttained by a loop inside the ROOT file, but does not require an extra command to be run.

Output example:
```
Simulation:

[Generator Validation]
  Scanned input entries        5000
  Accepted input entries       5000
  Selected muons               6148
  Transported tracks           39861
 
[Tree Validation]
  Requested events             5000
  Final cbmsim entries         1931
  Kept fraction                38.62%
  Branches in cbmsim           7
  ROOT objects                 2
  Countable branches           3
 
[MCTrack Validation]
  Total tracks                 14775
  Primary tracks               3817
  Secondary tracks             10958
  Tracks per event             7.651
  Track momentum               125.7 +- 139.4  [min=4.086e-14, max=400]
  Track energy                 nan +- 0  [min=0.1711, max=400]
  Track start Z                17.55 +- 17.17  [min=0.001465, max=124.3]
  Top PDG counts               2212:2866, 2:2649, 1:1913, 2112:1143, 13:1117, -13:1085, 21:950, 223:687, 22:445, 113:401
 
[Branch Multiplicity]
  MCTrack                total=14775, mean/event=7.651 +- 1.957, active=1931/1931 (100.0%), max=15
  UpstreamTaggerPoint    total=688, mean/event=0.3563 +- 0.5243, active=644/1931 ( 33.4%), max=2
  vetoPoint              total=2208, mean/event=1.143 +- 0.3535, active=1931/1931 (100.0%), max=3


Reconstruction:
[Reco Validation]
  events_digitized                         : 4998
  events_reconstructed                     : 4998
  events_with_hits                         : 145
  events_with_candidates                   : 113
  events_with_fitted_tracks                : 113
  events_with_good_tracks                  : 113
  smeared_hits_total                       : 4006
  track_candidates_total                   : 113
  track_candidates_rejected_hits           : 0
  track_candidates_rejected_stations       : 0
  fit_hypotheses_tried                     : 226
  fit_hypotheses_converged                 : 226
  tracks_failed_consistency                : 0
  tracks_failed_fit                        : 0
  tracks_failed_state_access               : 0
  fitted_tracks_total                      : 113
  good_tracks_total                        : 113
  vertexing_calls                          : 4998
  veto_links_total                         : 113
  track_candidates_per_event               : 0.02261 +- 0.1487
  fitted_tracks_per_event                  : 0.02261 +- 0.1487
  good_tracks_per_event                    : 0.02261 +- 0.1487
  veto_links_per_event                     : 0.02261 +- 0.1487
  hits_per_candidate                       : 31.29 +- 1.342
  stations_per_candidate                   : 4 +- 0
  veto_link_distance                       : 25.18 +- 15.04
  fit_chi2_over_ndf                        : 0.8519 +- 0.2505
  fit_ndf                                  : 26.17 +- 1.528
  fit_convergence_fraction                 : 100.00%
  candidate_to_fit_fraction                : 100.00%
  good_track_fraction                      : 100.00%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional --validation flag that prints a formatted end-of-run banner and a detailed post-run validation summary for simulation and reconstruction runs.
  * Reconstruction now supports an on-demand validation mode that emits per-run and per-event reconstruction metrics.

* **Chores**
  * Generation and reconstruction stages collect richer per-event and per-particle telemetry counters.
  * Added a standalone validation utility that aggregates and prints structured simulation output summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->