### PR TITLE
fix: restore chi2 assignment in vertex fit TMinuit callback

### DIFF
--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -276,13 +276,26 @@ class Task:
                 rc = gMinuit.DefineParameter(8, "1/mom2", 1.0 / mom2.Mag(), 0.1, 0, 0)
                 gMinuit.Clear()
                 gMinuit.Migrad()
+                # Check Migrad convergence via mnstat
+                fmin = ctypes.c_double()
+                fedm = ctypes.c_double()
+                errdef = ctypes.c_double()
+                npari = ctypes.c_int()
+                nparx = ctypes.c_int()
+                istat = ctypes.c_int()
+                gMinuit.mnstat(fmin, fedm, errdef, npari, nparx, istat)
+                if istat.value == 0:
+                    ut.reportError(f"shipVertex::Migrad not converged, istat={istat.value}")
+                    continue
                 try:
                     tmp = array("d", [0])
                     err = array("i", [0])
                     gMinuit.mnexcm("HESSE", tmp, -1, err)
-                    # gMinuit.mnexcm( "MINOS", tmp, -1, err )
+                    if err[0] != 0:
+                        ut.reportError(f"shipVertex::HESSE failed, ierflg={err[0]}")
+                        continue
                 except Exception:
-                    ut.reportError("shipVertex::minos does not work")
+                    ut.reportError("shipVertex::HESSE raised exception")
                     continue
                 # get results from TMinuit:
                 emat = array(

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -79,7 +79,7 @@ class Task:
 
     def fcn(self, npar, gin, f, par, iflag) -> None:
         res = self.residuals(self.y_data, par, self.z0)
-        self.chi2(res, self.Vy)
+        f.value = self.chi2(res, self.Vy)
         return
 
     def _stepwise_extrapolate_to_z(self, extrapolate_fn, current_z, target_z, max_step=500.0):


### PR DESCRIPTION
The FCN callback must set f[0] to the objective function value for TMinuit to minimise. Commit 20e9d10c548 changed the correct `f[0] = self.f_chi2(par)` to `f = self.chi2(...)` which merely rebinds the local Python name without updating the underlying buffer that TMinuit reads.

Without it, Migrad receives no function value and the vertex fit cannot converge — the result falls back to the geometric DOCA iteration starting values, degrading resolution and invalidating the reported vertex covariance.

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the optimizer receives and uses computed fit values so minimization reflects actual objective results.
  * Added stronger post-fit validation to detect and skip failed or unstable fits, avoiding propagation of invalid results.
  * Improved HESSE-specific error detection and reporting to make failures clearer and prevent unreliable downstream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->