### PR TITLE
Keep FixedTargetGenerator running if Pythia fails to generate an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ it in future.
 
 ### Fixed
 
+
 * Remove deprecated attribute syntax in the GST TTree copy within GENIE run_simScript option
+* Keep FixedTargetGenerator retrying if Pythia fails to generate an event, until a max number of retries is reached
 * Recompute the two-track DOCA at the chi^2-optimal vertex (`HNLPosFit`) instead of the iterative geometric one. The geometric DOCA was evaluated with tangent-line linearisations at the geometric iteration's converged z and overestimated the line-to-line distance wherever Migrad shifted the vertex; re-extrapolating the genfit states the small residual dz to `HNLPosFit.Z()` recovers a substantial fraction of signal at the standard DOCA preselection cut on HNL signal MC.
 
 ### Removed

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -380,14 +380,31 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
                   start[2], -1, kTRUE, -1., 0., 1.);
     return kTRUE;
   } else if (Option == "Primary") {
+    constexpr int kMaxPythiaRetries = 100;
     if (gRandom->Uniform(0., 1.) < ZoverA) {
-      fPythiaP->next();
+      int retries = 0;
+      while (!fPythiaP->next()) {
+        if (++retries >= kMaxPythiaRetries) {
+          LOG(error) << "PythiaP failed to generate an event after "
+                     << kMaxPythiaRetries << " retries";
+          return kFALSE;
+        }
+        LOG(warning) << "PythiaP failed to generate event, retry " << retries;
+      }
       if (withEvtGen) {
         evtgenP->decay();
       }
       fPythia = fPythiaP;
     } else {
-      fPythiaN->next();
+      int retries = 0;
+      while (!fPythiaN->next()) {
+        if (++retries >= kMaxPythiaRetries) {
+          LOG(error) << "PythiaN failed to generate an event after "
+                     << kMaxPythiaRetries << " retries";
+          return kFALSE;
+        }
+        LOG(warning) << "PythiaN failed to generate event, retry " << retries;
+      }
       if (withEvtGen) {
         evtgenN->decay();
       }


### PR DESCRIPTION
Dear all,
This Pull Request follows the Hackhaton session of the 4th Computing WorkShop. 
Short Recap:
A small fraction of runs, O(1%), crashes with error` cppyy.gbl.std.out_of_range: void FairRunSim::Run`. @mesmith75  found how to reproduce it with a specific seed:
```
python run_fixedTarget.py -o ./ -n 500000 -e 30 -r 320715849 --seed 320715849
```
Debugging, the source of the crash was related not to FairRunSim, but to the pythia event generation:
```
PYTHIA Error in BeamRemnants::setKinematics: no momentum left for beam remnants 
PYTHIA Warning in SimpleSpaceShower::branch: used up beam momentum; retrying parton level 
PYTHIA Error in Pythia::next: partonLevel failed; try again 
PYTHIA Abort from Pythia::next: parton+hadronLevel failed; giving up 
```
This Pull Request modifies FixedTargetGenerator to send a warning message and launch a next pythia event, if the current one exited with error.

Best Wishes,
Antonio

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generator now retries failed event generation attempts up to a limit, avoiding premature stoppage during processing.
* **Documentation**
  * Changelog updated to record that the generator will continue retrying failed event generation until a retry limit is reached.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1175)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->