### PR TITLE
Remove deprecated attribute syntax in the gst TTree copy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ it in future.
 
 ### Fixed
 
+* Remove deprecated attribute syntax in the GST TTree copy within GENIE run_simScript option
 * Recompute the two-track DOCA at the chi^2-optimal vertex (`HNLPosFit`) instead of the iterative geometric one. The geometric DOCA was evaluated with tangent-line linearisations at the geometric iteration's converged z and overestimated the line-to-line distance wherever Migrad shifted the vertex; re-extrapolating the genfit states the small residual dz to `HNLPosFit.Z()` recovers a substantial fraction of signal at the standard DOCA preselection cut on HNL signal MC.
 
 ### Removed

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -875,9 +875,13 @@ if options.mudis:
 if options.command == "Genie":
     # breakpoint()
     # Copy Genie (gst TTree) information to the output file
-    f_input = ROOT.TFile.Open(inputFile[0], "READ")
-    print("check")
+    input_path = inputFile[0] if isinstance(inputFile, (list, tuple)) else inputFile
+    f_input = ROOT.TFile.Open(input_path, "READ")
+    if not f_input or f_input.IsZombie():
+        raise OSError(f"Failed to open GENIE input file: {input_path}")
     gst = f_input["gst"]
+    if not gst:
+        raise KeyError("TTree 'gst' not found in GENIE input file")
 
     selection_string = "(Entry$ >= " + str(options.firstEvent) + ")"
     if (options.firstEvent + options.nEvents) < gst.GetEntries():

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -877,7 +877,7 @@ if options.command == "Genie":
     # Copy Genie (gst TTree) information to the output file
     f_input = ROOT.TFile.Open(inputFile[0], "READ")
     print("check")
-    gst = f_input.gst
+    gst = f_input["gst"]
 
     selection_string = "(Entry$ >= " + str(options.firstEvent) + ")"
     if (options.firstEvent + options.nEvents) < gst.GetEntries():


### PR DESCRIPTION
Dear all,
This is a small fix to remove the Deprecated warning message:
```
run_simScript.py:880: DeprecationWarning: The attribute syntax for TFile is deprecated and will be removed in ROOT 6.34. Please use TFile["gst"] instead of TFile.gst 
gst = f_input.gst
```
I have just followed the suggestion and searched that f_input.gst is not used anywhere else in our code.

## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deprecated attribute usage in GENIE simulation workflow to ensure reliable input tree handling.

* **New Features**
  * Added magnetic field visualization tool.
  * Added geometry overlap detection capability for simulations (Geant4-based).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->