### PR TITLE
Add new field maps and remove incorrect ones

### DIFF
--- a/files/2026_04_01_SHiP_MainSpectrometerField_V13.root
+++ b/files/2026_04_01_SHiP_MainSpectrometerField_V13.root
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e89499a353071a27c807301304e9d41cacc01157b948a59cfe7c3a1bdc68cb44
-size 17434200

--- a/files/2026_04_16_MainSpectrometerField_V21_2000.root
+++ b/files/2026_04_16_MainSpectrometerField_V21_2000.root
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4928dd8020ad674aacf2b72162ef340e11646dcf6131d3e717278be60fdebfeb
-size 17289799

--- a/files/2026_04_16_MainSpectrometerField_V21_3000.root
+++ b/files/2026_04_16_MainSpectrometerField_V21_3000.root
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a0fd7261ea81890251cf96f448787c49bcbe1ad5865b64bc391aaaa2b964071
-size 17397453

--- a/files/2026_05_07_MainSpectrometerField_V13_3500.root
+++ b/files/2026_05_07_MainSpectrometerField_V13_3500.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f66b82d92d6292330eb3b46de959c8db3e38fe17183fa5abba91e92d179cdbbb
+size 17434193

--- a/files/2026_05_07_MainSpectrometerField_V21_2000.root
+++ b/files/2026_05_07_MainSpectrometerField_V21_2000.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c5263f3ba2d45dab08af335ba19e6cc8df56fe22062c6fe9485a2cee092c249
+size 17289811

--- a/files/2026_05_07_MainSpectrometerField_V21_3000.root
+++ b/files/2026_05_07_MainSpectrometerField_V21_3000.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebd16d7a317ac23de9074c3ed7f2dbbfa11264172d2ded0eb75406dbb82fe0f4
+size 17397452


### PR DESCRIPTION
The field maps added in #1137 and #1147 were rotated incorrectly. This should now fix this.

NB: None of these field maps were ever used by default.

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated SHiP MainSpectrometerField configuration files with new versions.
  * Added latest detector field mapping data (May 2024).
  * Removed deprecated field configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->