### PR TITLE
feat: update default spectrometer field map to 2025 MgB2 map

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -221,7 +221,11 @@ parser.add_argument(
 )
 parser.add_argument("--print-fields", help="Print VMC fields and weights information", action="store_true")
 parser.add_argument("--check-overlaps", help="Perform geometry overlap checking", action="store_true")
-parser.add_argument("--field_map", default=None, help="Specify spectrometer field map. Default set in geometry_config.py: 2025_02_12_SHiP_SpectrometerField_ECN3_MgB2")
+parser.add_argument(
+    "--field_map",
+    default=None,
+    help="Specify spectrometer field map. Default set in geometry_config.py: 2025_02_12_SHiP_SpectrometerField_ECN3_MgB2",
+)
 parser.add_argument(
     "--z-offset", dest="z_offset", help="z-offset for the FixedTargetGenerator [mm]", default=-84.0, type=float
 )

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -221,7 +221,7 @@ parser.add_argument(
 )
 parser.add_argument("--print-fields", help="Print VMC fields and weights information", action="store_true")
 parser.add_argument("--check-overlaps", help="Perform geometry overlap checking", action="store_true")
-parser.add_argument("--field_map", default=None, help="Specify spectrometer field map.")
+parser.add_argument("--field_map", default=None, help="Specify spectrometer field map. Default set in geometry_config.py: 2025_02_12_SHiP_SpectrometerField_ECN3_MgB2")
 parser.add_argument(
     "--z-offset", dest="z_offset", help="z-offset for the FixedTargetGenerator [mm]", default=-84.0, type=float
 )

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -224,7 +224,7 @@ parser.add_argument("--check-overlaps", help="Perform geometry overlap checking"
 parser.add_argument(
     "--field_map",
     default=None,
-    help="Specify spectrometer field map. Default set in geometry_config.py: 2025_02_12_SHiP_SpectrometerField_ECN3_MgB2",
+    help="Specify spectrometer field map as files/<name>.root. Default set in geometry_config.py: files/2025_02_12_SHiP_SpectrometerField_ECN3_MgB2.root",
 )
 parser.add_argument(
     "--z-offset", dest="z_offset", help="z-offset for the FixedTargetGenerator [mm]", default=-84.0, type=float

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -325,7 +325,7 @@ def create_config(
     c.Bfield.max = 0  # 1.4361*u.kilogauss  # was 1.15 in EOI
     c.Bfield.y = c.Yheight
     c.Bfield.x = 2.4 * u.m
-    c.Bfield.fieldMap = "files/MainSpectrometerField.root"
+    c.Bfield.fieldMap = "files/2025_02_12_SHiP_SpectrometerField_ECN3_MgB2.root"
     if c.magnetDesign > 3:  # MISIS design
         c.Bfield.YokeWidth = 0.8 * u.m  # full width       200.*cm
         c.Bfield.YokeDepth = 1.4 * u.m  # half length      200 *cm;


### PR DESCRIPTION
Also mention the default in run_simScript.py --field_map help text for discoverability.

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clarified the --field_map command-line option with expanded help text to make selecting a spectrometer field map easier and more descriptive.

* **Configuration Updates**
  * The default spectrometer magnetic field map used for simulations has been updated to a newer field map file; runtime behavior when an explicit field-map option is provided remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->