### PR TITLE
fix(geometry): anchor Chamber1.z to decay vessel start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ it in future.
 ### Fixed
 
 * Recompute the two-track DOCA at the chi^2-optimal vertex (`HNLPosFit`) instead of the iterative geometric one. The geometric DOCA was evaluated with tangent-line linearisations at the geometric iteration's converged z and overestimated the line-to-line distance wherever Migrad shifted the vertex; re-extrapolating the genfit states the small residual dz to `HNLPosFit.Z()` recovers a substantial fraction of signal at the standard DOCA preselection cut on HNL signal MC.
+* Anchor `Chamber1.z` to the decay vessel geometry so the HNL minimum decay length and the muon-DIS start position track the upstream end of the decay vessel; the legacy formula in `geometry_config.py` left both ~1.8 m too far downstream after the March 2025 coordinate-system change, reducing HNL generation acceptance by about 3.6 % of the decay vessel volume.
 
 ### Removed
 

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -317,7 +317,8 @@ def create_config(
         c.TrackStation1 = AttrDict(z=z1)
 
         # positions and lengths of vacuum tube segments (for backward compatibility)
-        c.Chamber1 = AttrDict(z=z4 - 4666.0 * u.cm - magnetIncrease - extraVesselLength)
+        # Chamber1.z is the downstream end of Tub1, so consumers can take z - Tub1length to get the decay-vessel entrance.
+        c.Chamber1 = AttrDict(z=c.decayVolume.z0 + c.chambers.Tub1length)
         c.Chamber6 = AttrDict(z=z4 + 30.0 * u.cm + windowBulge / 2.0)
 
     c.Bfield = AttrDict()


### PR DESCRIPTION
The legacy formula left Chamber1.z about 1.8 m too far downstream after the March 2025 coordinate-system change, so the HNL Lmin cut and the muon-DIS start position lost the first 1.8 m of the decay vessel (around 3.6 % of its volume). Use decayVolume.z0 + chambers.Tub1length, so consumers that subtract Tub1length recover the decay vessel entrance exactly.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected decay chamber geometry alignment following coordinate system updates to resolve upstream/downstream positioning discrepancies affecting HNL generation acceptance.

* **Documentation**
  * Updated changelog documenting the geometry alignment correction and its impact on generation acceptance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->