### PR TITLE
Import basics libs in makeMuonDIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ it in future.
 
 ### Fixed
 
-
+* Import EGPythia6 library from basiclibs in makeMuonDIS
 * Remove deprecated attribute syntax in the GST TTree copy within GENIE run_simScript option
 * Keep FixedTargetGenerator retrying if Pythia fails to generate an event, until a max number of retries is reached
 * Recompute the two-track DOCA at the chi^2-optimal vertex (`HNLPosFit`) instead of the iterative geometric one. The geometric DOCA was evaluated with tangent-line linearisations at the geometric iteration's converged z and overestimated the line-to-line distance wherever Migrad shifted the vertex; re-extrapolating the genfit states the small residual dz to `HNLPosFit.Z()` recovers a substantial fraction of signal at the standard DOCA preselection cut on HNL signal MC.

--- a/muonDIS/makeMuonDIS.py
+++ b/muonDIS/makeMuonDIS.py
@@ -13,6 +13,9 @@ from array import array
 import ROOT as r
 from tabulate import tabulate
 
+r.gROOT.LoadMacro("$VMCWORKDIR/gconfig/basiclibs.C")
+r.basiclibs()
+
 logging.basicConfig(level=logging.INFO)
 PDG = r.TDatabasePDG.Instance()
 PDG.AddParticle("C12", "Carbon-12", 12.0, True, 0, 6.0, "nucleus", 1000060120)


### PR DESCRIPTION
muonDIS/makeMuonDIS.py leads to error due to missing TPythia6 class.
In contrast to the working muonShieldOptimization/makeMuonDIS.py, it does not import the gconfig/basiclibs.C file including the required libEGPythia6 for new ROOT versions.

## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated library initialization sequence in muon DIS generation to properly load required physics libraries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->