### PR TITLE
chore(ci): drop 26.03 from CI matrix

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -20,7 +20,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
-        run: echo 'matrix={"version":["26.02","26.03","26.04"],"vessel_option":["vacuums","helium"],"SND_option":["all"],"muon_shield":["TRY_2025"],"target":["Jun25"]}' >> "$GITHUB_OUTPUT"
+        run: echo 'matrix={"version":["26.02","26.04"],"vessel_option":["vacuums","helium"],"SND_option":["all"],"muon_shield":["TRY_2025"],"target":["Jun25"]}' >> "$GITHUB_OUTPUT"
   build:
     runs-on: self-hosted
     needs: generate-matrix


### PR DESCRIPTION
Idea would be to keep oldest and newest supported stack, building and testing each and every stack takes too much time.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass
