### PR TITLE
fix: prevent double-delete segfaults with ROOT 6.40 PyROOT ownership

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -400,7 +400,9 @@ timer.Start()
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
-run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
+sink = ROOT.FairRootFileSink(outFile)
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 run.SetUserConfig("g4Config.C")  # user configuration file default g4Config.C
 rtdb = run.GetRuntimeDb()
 # -----Create geometry----------------------------------------------
@@ -494,6 +496,7 @@ if options.pythia8:
     # P8gen.SetMom(500.*u.GeV)
     # P8gen.SetId(-211)
     primGen.AddGenerator(P8gen)
+    ROOT.SetOwnership(P8gen, False)  # C++ FairPrimaryGenerator takes ownership
 if options.fixedTarget:
     HNL = False
     P8gen = ROOT.FixedTargetGenerator()
@@ -507,6 +510,7 @@ if options.fixedTarget:
     P8gen.SetHeartBeat(100000)
     P8gen.SetG4only()
     primGen.AddGenerator(P8gen)
+    ROOT.SetOwnership(P8gen, False)  # C++ FairPrimaryGenerator takes ownership
 if options.pythia6:
     # set muon interaction close to decay volume
     primGen.SetTarget(ship_geo.target.z0 + ship_geo.muShield.length, 0.0)
@@ -516,6 +520,7 @@ if options.pythia6:
     P6gen.SetMom(50.0 * u.GeV)
     P6gen.SetTarget("gamma/mu+", "n0")  # default "gamma/mu-","p+"
     primGen.AddGenerator(P6gen)
+    ROOT.SetOwnership(P6gen, False)  # C++ FairPrimaryGenerator takes ownership
 
 # -----EvtCalc--------------------------------------
 if options.evtcalc:
@@ -526,6 +531,7 @@ if options.evtcalc:
     EvtCalcGen.Init(inputFile, options.firstEvent)
     EvtCalcGen.SetPositions(zTa=ship_geo.target.z, zDV=ship_geo.decayVolume.z)
     primGen.AddGenerator(EvtCalcGen)
+    ROOT.SetOwnership(EvtCalcGen, False)  # C++ FairPrimaryGenerator takes ownership
     options.nEvents = (
         EvtCalcGen.GetNevents() if options.nEvents == -1 else min(options.nEvents, EvtCalcGen.GetNevents())
     )
@@ -550,6 +556,7 @@ if options.command == "PG":
         # point source
         myPgun.SetXYZ(options.Vx * u.cm, options.Vy * u.cm, options.Vz * u.cm)
     primGen.AddGenerator(myPgun)
+    ROOT.SetOwnership(myPgun, False)  # C++ FairPrimaryGenerator takes ownership
 # -----muon DIS Background------------------------
 if options.mudis:
     ut.checkFileExists(inputFile)
@@ -564,6 +571,7 @@ if options.mudis:
     DISgen.SetPositions(mu_start, mu_end)
     DISgen.Init(inputFile, options.firstEvent)
     primGen.AddGenerator(DISgen)
+    ROOT.SetOwnership(DISgen, False)  # C++ FairPrimaryGenerator takes ownership
     options.nEvents = DISgen.GetNevents() if options.nEvents == -1 else min(options.nEvents, DISgen.GetNevents())
     print("Generate ", options.nEvents, " with DIS input", " first event", options.firstEvent)
 # -----Neutrino Background------------------------
@@ -575,6 +583,7 @@ if options.command == "Genie":
     Geniegen.Init(inputFile, options.firstEvent)
     Geniegen.SetPositions(ship_geo.target.z0, options.z_start_nu, options.z_end_nu)
     primGen.AddGenerator(Geniegen)
+    ROOT.SetOwnership(Geniegen, False)  # C++ FairPrimaryGenerator takes ownership
     options.nEvents = Geniegen.GetNevents() if options.nEvents == -1 else min(options.nEvents, Geniegen.GetNevents())
     run.SetPythiaDecayer("DecayConfigNuAge.C")
     print("Generate ", options.nEvents, " with Genie input", " first event", options.firstEvent)
@@ -587,6 +596,7 @@ if options.nuradio:
     Geniegen.SetPositions(ship_geo.target.z0, ship_geo.tauMudet.zMudetC, ship_geo.MuonStation3.z)
     Geniegen.NuOnly()
     primGen.AddGenerator(Geniegen)
+    ROOT.SetOwnership(Geniegen, False)  # C++ FairPrimaryGenerator takes ownership
     print("Generate ", options.nEvents, " for nuRadiography", " first event", options.firstEvent)
     #  add tungsten to PDG
     pdg = ROOT.TDatabasePDG.Instance()
@@ -603,6 +613,7 @@ if options.ntuple:
     Ntuplegen = ROOT.NtupleGenerator()
     Ntuplegen.Init(inputFile, options.firstEvent)
     primGen.AddGenerator(Ntuplegen)
+    ROOT.SetOwnership(Ntuplegen, False)  # C++ FairPrimaryGenerator takes ownership
     options.nEvents = Ntuplegen.GetNevents() if options.nEvents == -1 else min(options.nEvents, Ntuplegen.GetNevents())
     print("Process ", options.nEvents, " from input file")
 #
@@ -633,6 +644,7 @@ if options.muonback:
     if options.sameSeed:
         MuonBackgen.SetSameSeed(options.sameSeed)
     primGen.AddGenerator(MuonBackgen)
+    ROOT.SetOwnership(MuonBackgen, False)  # C++ FairPrimaryGenerator takes ownership
     options.nEvents = (
         MuonBackgen.GetNevents() if options.nEvents == -1 else min(options.nEvents, MuonBackgen.GetNevents())
     )
@@ -667,10 +679,12 @@ if options.cosmics:
         sys.exit(0)
     Cosmicsgen.n_EVENTS = options.nEvents
     primGen.AddGenerator(Cosmicsgen)
+    ROOT.SetOwnership(Cosmicsgen, False)  # C++ FairPrimaryGenerator takes ownership
     print("Process ", options.nEvents, " Cosmic events with option ", Opt_high)
 
 #
 run.SetGenerator(primGen)
+ROOT.SetOwnership(primGen, False)  # C++ FairRunSim takes ownership
 # ------------------------------------------------------------------------
 
 # ---Store the visualiztion info of the tracks, this make the output file very large!!
@@ -750,6 +764,7 @@ kParameterMerged = ROOT.kTRUE
 parOut = ROOT.FairParRootFileIo(kParameterMerged)
 parOut.open(parFile)
 rtdb.setOutput(parOut)
+ROOT.SetOwnership(parOut, False)  # C++ FairRuntimeDb takes ownership
 rtdb.saveOutput()
 rtdb.printParamContexts()
 rtdb.print()

--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -210,6 +210,7 @@ def addVMCFields(shipGeo, controlFile: str = "", verbose: bool = False, withVirt
         geom = ROOT.TG4GeometryManager.Instance()
         # Let the geometry know about the fieldMaker object
         geom.SetUserPostDetConstruction(fieldMaker)
+        ROOT.SetOwnership(fieldMaker, False)  # C++ TG4GeometryManager takes ownership
         # Update the fields via the overridden ShipFieldMaker::Construct() function
         geom.ConstructSDandField()
 

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -456,6 +456,7 @@ def configure(run, ship_geo):
                 ship_geo.Yheight / 2.0 * u.m,
             )
         run.SetField(fMagField)
+        ROOT.SetOwnership(fMagField, False)  # C++ FairRunSim takes ownership
 
     exclusionList = []
     # exclusionList = ["strawtubes","TargetTrackers","NuTauTarget",\
@@ -465,6 +466,7 @@ def configure(run, ship_geo):
         if x.GetName() in exclusionList:
             continue
         run.AddModule(x)
+        ROOT.SetOwnership(x, False)  # C++ FairRunSim takes ownership
     # return list of detector elements
     detElements = {}
     for x in run.GetListOfModules():

--- a/python/shipRoot_conf.py
+++ b/python/shipRoot_conf.py
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
-import atexit
 import os
-import sys
 
 import ROOT
 from pythia8_conf_utils import addHNLtoROOT
@@ -48,28 +46,6 @@ def forReadingOldFile() -> None:
     ROOT.gInterpreter.ProcessLine("typedef double Double32_t")
 
 
-# -----prepare python exit-----------------------------------------------
-
-
-def pyExit() -> None:
-    for module in sys.modules:
-        if "ROOT.genfit" in module:
-            x = sys.modules["__main__"]
-            if hasattr(x, "run"):
-                del x.run
-                print("make suicid, until better solution found to ROOT/genfit interference")
-                for f in ROOT.gROOT.GetListOfFiles():
-                    if f.IsWritable() and f.IsOpen():
-                        f.Close()
-                os.system("kill " + str(os.getpid()))
-            if hasattr(x, "fMan"):
-                del x.fMan
-            if hasattr(x, "fRun"):
-                del x.fRun
-            return
-    print("Exit normally")
-
-
 def configure(darkphoton=None) -> None:
     ROOT.gROOT.ProcessLine('#include "' + os.environ["FAIRSHIP"] + '/shipdata/ShipGlobals.h"')
     pdg = ROOT.TDatabasePDG.Instance()
@@ -94,7 +70,6 @@ def configure(darkphoton=None) -> None:
     pdg.AddParticle("chi_2c[3S1(8)]", "chi_2c[3S1(8)]", 3.75620, False, 0.0, 0, "Meson", 9940005)
     pdg.AddParticle("Upsilon[3S1(8)]", "Upsilon[3S1(8)]", 9.66030, False, 0.0, 0, "Meson", 9950003)
 
-    atexit.register(pyExit)
     if darkphoton == 0:
         return  # will be added by pythia8_conf
     if darkphoton:


### PR DESCRIPTION
ROOT 6.40 changes how PyROOT manages C++ object lifetimes. Python-created C++ objects passed to FairRoot methods (AddModule, SetSink, SetGenerator, AddGenerator, SetField, setOutput) could be deleted by both Python's GC and FairRoot's destructor, causing double-free segfaults.

Add explicit ROOT.SetOwnership(obj, False) calls to relinquish Python ownership of all objects whose lifetime is managed by C++ (FairRoot).

Remove the pyExit() atexit workaround in shipRoot_conf.py that was killing the process to avoid genfit/ROOT cleanup crashes — the proper ownership management makes this unnecessary.

CC @siilieva

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced object lifetime management in simulation configuration modules to improve framework stability and prevent resource contention issues during execution.

* **Chores**
  * Removed unused cleanup utilities from startup configuration to reduce code complexity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->