### PR TITLE
chore(ci): add 26.05 to CI, replacing 26.04

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -20,7 +20,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
-        run: echo 'matrix={"version":["26.02","26.04"],"vessel_option":["vacuums","helium"],"SND_option":["all"],"muon_shield":["TRY_2025"],"target":["Jun25"]}' >> "$GITHUB_OUTPUT"
+        run: echo 'matrix={"version":["26.02","26.05"],"vessel_option":["vacuums","helium"],"SND_option":["all"],"muon_shield":["TRY_2025"],"target":["Jun25"]}' >> "$GITHUB_OUTPUT"
   build:
     runs-on: self-hosted
     needs: generate-matrix

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -72,7 +72,11 @@ import shipDet_conf
 
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine
-run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile("output", "recreate")))  # Dummy output file
+import tempfile
+
+sink = ROOT.FairRootFileSink(tempfile.mktemp(suffix=".root"))
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 run.SetUserConfig("g4Config_basic.C")  # geant4 transport not used, only needed for the mag field
 rtdb = run.GetRuntimeDb()
 # -----Create geometry----------------------------------------------
@@ -88,10 +92,12 @@ else:
 sGeo = fgeo["FAIRGeom"]
 geoMat = ROOT.genfit.TGeoMaterialInterface()
 ROOT.genfit.MaterialEffects.getInstance().init(geoMat)
+ROOT.SetOwnership(geoMat, False)  # genfit::MaterialEffects singleton takes ownership
 bfield = ROOT.genfit.FairShipFields()
 bfield.setField(fieldMaker.getGlobalField())
 fM = ROOT.genfit.FieldManager.getInstance()
 fM.init(bfield)
+ROOT.SetOwnership(bfield, False)  # genfit::FieldManager singleton takes ownership
 
 volDict = {}
 i = 0
@@ -424,7 +430,8 @@ def fitSingleGauss(x: str, ba: float | None = None, be: float | None = None) -> 
         myGauss.SetParName(1, "Mean")
         myGauss.SetParName(2, "Sigma")
         myGauss.SetParName(3, "bckgr")
-    h[x].Fit(myGauss, "", "", ba, be)
+    if h[x].GetEntries() > 0:
+        h[x].Fit(myGauss, "", "", ba, be)
 
 
 def match2HNL(p) -> bool:
@@ -465,7 +472,8 @@ def makePlots() -> None:
     h["delPOverPz_proj"] = h["delPOverPz"].ProjectionY()
     ROOT.gStyle.SetOptFit(11111)
     h["delPOverPz_proj"].Draw()
-    h["delPOverPz_proj"].Fit("gaus")
+    if h["delPOverPz_proj"].GetEntries() > 0:
+        h["delPOverPz_proj"].Fit("gaus")
     cv = h["fitresults"].cd(4)
     h["delPOverP2z_proj"] = h["delPOverP2z"].ProjectionY()
     h["delPOverP2z_proj"].Draw()
@@ -482,7 +490,8 @@ def makePlots() -> None:
             h["pi0Mass"].SetXTitle("#gamma #gamma invariant mass   [GeV/c^{2}]")
             h["pi0Mass"].SetYTitle("N/" + str(int(h["pi0Mass"].GetBinWidth(1) * 1000)) + "MeV")
             h["pi0Mass"].Draw()
-            h["pi0Mass"].Fit("gaus", "S", "", 0.08, 0.19)
+            if h["pi0Mass"].GetEntries() > 0:
+                h["pi0Mass"].Fit("gaus", "S", "", 0.08, 0.19)
         cv = h["fitresults2" + x].cd(2)
         h["IP0" + x].SetXTitle("impact parameter to p-target   [cm]")
         h["IP0" + x].SetYTitle("N/1cm")

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -135,13 +135,17 @@ import shipDet_conf
 
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine
-run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile("output", "recreate")))  # Dummy output file
+import tempfile
+
+sink = ROOT.FairRootFileSink(tempfile.mktemp(suffix=".root"))
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 run.SetUserConfig("g4Config_basic.C")  # geant4 transport not used, only needed for creating VMC field
 rtdb = run.GetRuntimeDb()
 # -----Create geometry----------------------------------------------
 modules = shipDet_conf.configure(run, ShipGeo)
 # run.Init()
-fgeo["FAIRGeom"]
+sGeo = fgeo["FAIRGeom"]
 import geomGeant4
 
 if hasattr(ShipGeo.Bfield, "fieldMap"):

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -1172,9 +1172,14 @@ if options.geoFile:
 
 inFile = ROOT.FairFileSource(options.InputFile)
 fRun.SetSource(inFile)
+ROOT.SetOwnership(inFile, False)  # C++ FairRun takes ownership
 if options.OutputFile is None:
-    options.OutputFile = ROOT.TMemFile("event_display_output", "recreate")
-fRun.SetSink(ROOT.FairRootFileSink(options.OutputFile))
+    import tempfile
+
+    options.OutputFile = tempfile.mktemp(suffix=".root")
+sink = ROOT.FairRootFileSink(options.OutputFile)
+fRun.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 
 if options.ParFile:
     rtdb = fRun.GetRuntimeDb()

--- a/macro/inspectGeant4Geo.py
+++ b/macro/inspectGeant4Geo.py
@@ -22,7 +22,11 @@ ShipGeo = load_from_root_file(fgeo, "ShipGeo")
 modules = shipDet_conf.configure(run, ShipGeo)
 run.SetUserConfig("g4Config.C")
 run.SetName("TGeant4")
-run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile("output", "recreate")))
+import tempfile
+
+sink = ROOT.FairRootFileSink(tempfile.mktemp(suffix=".root"))
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 run.Init()
 run.Run(0)
 import geomGeant4

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -257,7 +257,9 @@ timer.Start()
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
-run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
+sink = ROOT.FairRootFileSink(outFile)
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 if args.boostFactor > 1:
     # Turn off UseGeneralProcess to access GammaToMuons directly when cross-sections need to be changed
     os.environ["SET_GENERAL_PROCESS_TO_FALSE"] = "1"
@@ -271,6 +273,7 @@ cave = ROOT.ShipCave("CAVE")
 cave.SetGeometryFileName("caveWithAir.geo")
 
 run.AddModule(cave)
+ROOT.SetOwnership(cave, False)  # C++ FairRunSim takes ownership
 
 TargetStation = ROOT.ShipTargetStation(
     name="TargetStation",
@@ -286,6 +289,7 @@ TargetStation.SetLayerPosMat(
     M=ship_geo.target.slices_material,
 )
 run.AddModule(TargetStation)
+ROOT.SetOwnership(TargetStation, False)  # C++ FairRunSim takes ownership
 
 
 if args.AddPostTargetSensPlane:
@@ -306,6 +310,7 @@ if args.AddPostTargetSensPlane:
     if args.FourDP:
         sensPlanePostT.SetOpt4DP()
     run.AddModule(sensPlanePostT)
+    ROOT.SetOwnership(sensPlanePostT, False)  # C++ FairRunSim takes ownership
 
 
 if args.AddMuonShield or args.AddHadronAbsorberOnly:
@@ -324,6 +329,7 @@ if args.AddMuonShield or args.AddHadronAbsorberOnly:
     )
     # MuonShield.SetSupports(False) # otherwise overlap with sensitive Plane
     run.AddModule(MuonShield)  # needs to be added because of magn hadron shield.
+    ROOT.SetOwnership(MuonShield, False)  # C++ FairRunSim takes ownership
 
 
 sensPlaneHA = ROOT.exitHadronAbsorber()
@@ -353,9 +359,11 @@ if args.FourDP:  # in case a ntuple should be filled with pi0,etas,omega
         sensPlaneT.SetOpt4DP()
 
 run.AddModule(sensPlaneHA)
+ROOT.SetOwnership(sensPlaneHA, False)  # C++ FairRunSim takes ownership
 
 if args.AddCylindricalSensPlane:
     run.AddModule(sensPlaneT)
+    ROOT.SetOwnership(sensPlaneT, False)  # C++ FairRunSim takes ownership
 
 # -----Create PrimaryGenerator--------------------------------------
 primGen = ROOT.FairPrimaryGenerator()
@@ -392,8 +400,10 @@ if args.charm or args.beauty:
     print("--- process heavy flavours ---")
     P8gen.InitForCharmOrBeauty(charmInputFile, args.nev, args.pot, args.nStart)
 primGen.AddGenerator(P8gen)
+ROOT.SetOwnership(P8gen, False)  # C++ FairPrimaryGenerator takes ownership
 #
 run.SetGenerator(primGen)
+ROOT.SetOwnership(primGen, False)  # C++ FairRunSim takes ownership
 
 # -----Initialize simulation run------------------------------------
 run.Init()

--- a/muonShieldOptimization/study_GammaConv.py
+++ b/muonShieldOptimization/study_GammaConv.py
@@ -50,7 +50,9 @@ timer.Start()
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
-run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
+sink = ROOT.FairRootFileSink(outFile)
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 
 boostFactor = 100.0
 if boostFactor > 1:

--- a/muonShieldOptimization/study_muMSC.py
+++ b/muonShieldOptimization/study_muMSC.py
@@ -51,7 +51,9 @@ timer.Start()
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
-run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
+sink = ROOT.FairRootFileSink(outFile)
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 run.SetUserConfig("g4Config.C")  # user configuration file default g4Config.C
 rtdb = run.GetRuntimeDb()
 

--- a/muonShieldOptimization/study_thinTarget.py
+++ b/muonShieldOptimization/study_thinTarget.py
@@ -58,7 +58,9 @@ timer.Start()
 gFairBaseContFact = ROOT.FairBaseContFact()  # required by change to FairBaseContFact to avoid TList::Clear errors
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
-run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
+sink = ROOT.FairRootFileSink(outFile)
+run.SetSink(sink)
+ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
 run.SetUserConfig("g4Config.C")  # user configuration file default g4Config.C
 rtdb = run.GetRuntimeDb()
 

--- a/python/AddDiMuonDecayChannelsToG4.py
+++ b/python/AddDiMuonDecayChannelsToG4.py
@@ -28,5 +28,7 @@ def Initialize(p8):
                     dl.append(ROOT.G4String(""))
             mode = ROOT.G4PhaseSpaceDecayChannel(particleG4.GetParticleName(), bR, mul, dl[0], dl[1], dl[2], dl[3])
             decayTable.Insert(mode)
+            ROOT.SetOwnership(mode, False)  # G4DecayTable takes ownership
         particleG4.SetDecayTable(decayTable)
+        ROOT.SetOwnership(decayTable, False)  # G4ParticleDefinition takes ownership
         particleG4.DumpTable()

--- a/python/SciFiMapping.py
+++ b/python/SciFiMapping.py
@@ -842,7 +842,11 @@ if __name__ == "__main__":
 
     run = ROOT.FairRunSim()
     run.SetName("TGeant4")  # Transport engine
-    run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile("output", "recreate")))  # Output file
+    import tempfile
+
+    sink = ROOT.FairRootFileSink(tempfile.mktemp(suffix=".root"))
+    run.SetSink(sink)
+    ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
     run.SetUserConfig("g4Config_basic.C")  # geant4 transport not used
     rtdb = run.GetRuntimeDb()
     modules = shipDet_conf.configure(run, ship_geo)

--- a/python/convertToACTS.py
+++ b/python/convertToACTS.py
@@ -29,7 +29,11 @@ def main():
     ShipGeo = load_from_root_file(fgeo, "ShipGeo")
     run = ROOT.FairRunSim()
     run.SetName("TGeant4")  # Transport engine
-    run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile("output", "recreate")))  # Dummy output file
+    import tempfile
+
+    sink = ROOT.FairRootFileSink(tempfile.mktemp(suffix=".root"))
+    run.SetSink(sink)
+    ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
     run.SetUserConfig("g4Config_basic.C")  # geant4 transport not used, only needed for creating VMC field
     run.GetRuntimeDb()
     shipDet_conf.configure(run, ShipGeo)

--- a/python/detectors/MTCDetector.py
+++ b/python/detectors/MTCDetector.py
@@ -14,7 +14,7 @@ class MTCDetector(BaseDetector):
         # make SiPM to fibre mapping
         if intree.GetBranch("MTCDetPoint"):
             lsOfGlobals = ROOT.gROOT.GetListOfGlobals()
-            if global_variables.modules["MTC"] not in lsOfGlobals:
+            if not lsOfGlobals.FindObject("MTC"):
                 lsOfGlobals.Add(global_variables.modules["MTC"])
             mapping = SciFiMapping.SciFiMapping(global_variables.modules)
             mapping.make_mapping()

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -462,13 +462,11 @@ def configure(run, ship_geo):
     # exclusionList = ["strawtubes","TargetTrackers","NuTauTarget",\
     #                 "SiliconTarget","Veto","Magnet","MuonShield","TargetStation", "TimeDet", "UpstreamTagger"]
 
+    detElements = {}
     for x in detectorList:
         if x.GetName() in exclusionList:
             continue
         run.AddModule(x)
         ROOT.SetOwnership(x, False)  # C++ FairRunSim takes ownership
-    # return list of detector elements
-    detElements = {}
-    for x in run.GetListOfModules():
         detElements[x.GetName()] = x
     return detElements

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -90,7 +90,9 @@ class ShipDigiReco:
         self.bfield.setField(global_variables.fieldMaker.getGlobalField())
         self.fM = ROOT.genfit.FieldManager.getInstance()
         self.fM.init(self.bfield)
+        ROOT.SetOwnership(self.bfield, False)  # genfit::FieldManager singleton takes ownership
         ROOT.genfit.MaterialEffects.getInstance().init(self.geoMat)
+        ROOT.SetOwnership(self.geoMat, False)  # genfit::MaterialEffects singleton takes ownership
 
         # init fitter, to be done before importing shipPatRec
         # fitter          = ROOT.genfit.KalmanFitter()
@@ -237,6 +239,7 @@ class ShipDigiReco:
                 seedCov = ROOT.TMatrixDSym(6)
                 rep.get6DStateCov(stateSmeared, seedState, seedCov)
                 theTrack = ROOT.genfit.Track(rep, seedState, seedCov)
+                ROOT.SetOwnership(rep, False)  # genfit::Track takes ownership
                 hitCov = ROOT.TMatrixDSym(7)
                 hitCov[6][6] = resolution * resolution
                 hitID = 0
@@ -248,7 +251,9 @@ class ShipDigiReco:
                         - global_variables.ShipGeo.strawtubes_geo.wall_thickness
                     )
                     tp.addRawMeasurement(measurement)
+                    ROOT.SetOwnership(measurement, False)  # TrackPoint takes ownership
                     theTrack.insertPoint(tp)
+                    ROOT.SetOwnership(tp, False)  # genfit::Track takes ownership
                     hitID += 1
                 # Fit this hypothesis
                 try:

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -72,7 +72,11 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method, dy=
     run.SetName("TGeant4")  # Transport engine
     # Create dummy output file as the  input file is updated directly and
     # histograms are written to output file (hists.root by default)
-    run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile("output", "recreate")))
+    import tempfile
+
+    sink = ROOT.FairRootFileSink(tempfile.mktemp(suffix=".root"))
+    run.SetSink(sink)
+    ROOT.SetOwnership(sink, False)  # C++ FairRun takes ownership
     run.SetUserConfig("g4Config_basic.C")  # geant4 transport not used, only needed for the mag field
     run.GetRuntimeDb()
 


### PR DESCRIPTION
## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI build matrix updated to use build version 26.05.

* **Bug Fixes**
  * Stabilized simulation I/O by switching sinks to temporary on-disk outputs and consistent ownership handling to reduce crashes and leaks.
  * Prevented invalid histogram fits by skipping fit operations on empty histograms.
  * Improved robustness in detector/module initialization and generator/setup ownership handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->