### PR TITLE
docs: prepare changelog for 26.05 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,25 @@ it in future.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## 26.05 - 2026-05-25
+
+### Added
+
 * Added ParticleGunGenerator #1183
+* Add time window event overlay script (`macro/make_time_window.py`) for constructing realistic pileup from MC truth events
+* Add `SetStartT` and `GetEventID` accessors to `ShipMCTrack`
+* Add beam smearing and painting support to `DPPythia8Generator`
 
 ### Changed
+
+* Update default spectrometer field map to 2025 MgB2 map (`2025_02_12_SHiP_SpectrometerField_ECN3_MgB2.root`)
+* Replace incorrectly oriented spectrometer field maps with corrected versions (2026_05_07)
 
 ### Fixed
 
@@ -25,8 +41,22 @@ it in future.
 * Keep FixedTargetGenerator retrying if Pythia fails to generate an event, until a max number of retries is reached
 * Recompute the two-track DOCA at the chi^2-optimal vertex (`HNLPosFit`) instead of the iterative geometric one. The geometric DOCA was evaluated with tangent-line linearisations at the geometric iteration's converged z and overestimated the line-to-line distance wherever Migrad shifted the vertex; re-extrapolating the genfit states the small residual dz to `HNLPosFit.Z()` recovers a substantial fraction of signal at the standard DOCA preselection cut on HNL signal MC.
 * Anchor `Chamber1.z` to the decay vessel geometry so the HNL minimum decay length and the muon-DIS start position track the upstream end of the decay vessel; the legacy formula in `geometry_config.py` left both ~1.8 m too far downstream after the March 2025 coordinate-system change, reducing HNL generation acceptance by about 3.6 % of the decay vessel volume.
+* Work around ROOT 6.40 GIL bug that crashes on `TH1::Fit()` warnings by guarding with `GetEntries() > 0`
+* Prevent double-delete segfaults with ROOT 6.40 PyROOT ownership changes by transferring ownership to C++ for objects managed by FairRoot, genfit, and Geant4
+* Guard meson-production chain export for proton-bremsstrahlung mode in `DPPythia8Generator`, fixing duplicated dark photon and spurious Pythia system entry
+* Support both old (2018) and new MuonBack production files by detecting `PlaneHAPoint` branch and setting correct z-offset (#1181)
+* Guard vertex fit against unconverged Migrad and failed HESSE to prevent unreliable vertex positions
+* Restore chi2 assignment in vertex fit TMinuit callback (`f.value` instead of local rebind)
+* Keep ROOT streamers (`+` LinkDef flag) for `MTCDetector` and `strawtubes`, needed for dynamic downcasting via `run.GetListOfModules()`
+* Remove unused ROOT streamers from other detector classes
+* Check if `inputfile` is a list or single string in `run_simScript.py`
+* Show full path format in `--field_map` help text
+* Make sumw cache unique per file and fail fast on unknown Point class in time window overlay script
 
 ### Removed
+
+* Remove duplicate `makeMuonDIS.py` from `muonShieldOptimization/` (canonical version is in `muonDIS/`)
+* Remove incorrectly oriented field maps added in 26.04
 
 ## 26.04 - 2026-04-30
 


### PR DESCRIPTION
Add missing entries for all user-facing commits since 26.04 and move Unreleased section to 26.05 - 2026-05-25.

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issues with generators and ROOT/ownership handling
  * Resolved crashes and improved vertex/DOCA computation
  * Enhanced guard logic stability

* **Changed**
  * Updated spectrometer field maps

* **Removed**
  * Eliminated duplicate scripts and incorrectly oriented field maps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->