### PR TITLE
fix: remove unnecessary libG4clhep loads

### DIFF
--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -1249,7 +1249,6 @@ gEve = ROOT.gEve
 
 if hasattr(ShipGeo, "Bfield"):
     if hasattr(ShipGeo.Bfield, "fieldMap"):
-        ROOT.gSystem.Load("libG4clhep.so")
         ROOT.gSystem.Load("libgeant4vmc.so")
         import geomGeant4
 

--- a/python/shipRoot_conf.py
+++ b/python/shipRoot_conf.py
@@ -13,7 +13,6 @@ if os.environ.get("FAIRSHIP_ROOT", "") == "":
 
 ROOT.gSystem.Load("libPythia6")
 ROOT.gSystem.Load("libpythia8")
-ROOT.gSystem.Load("libG4clhep")
 
 # GenFit 02-03-00 no longer ships rootmap or unified PCM files, so ROOT's
 # autoloading cannot discover genfit classes.  Load the library, point Cling


### PR DESCRIPTION
## Summary
- Remove `ROOT.gSystem.Load("libG4clhep")` from `python/shipRoot_conf.py`
- Remove `ROOT.gSystem.Load("libG4clhep.so")` from `macro/eventDisplay.py`

`libG4clhep` is a Geant4-internal CLHEP wrapper that only exists when Geant4 builds its own bundled CLHEP. In conda-forge/pixi builds, Geant4 links against standalone `libCLHEP` instead, so `libG4clhep` doesn't exist. The explicit loads are unnecessary since dependent libraries (geant4vmc etc.) already resolve CLHEP symbols via the dynamic linker.

## Test plan
- [x] CI simulation test passes without the libG4clhep error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetic field initialization for simulation accuracy.
  * Updated physics simulation library loading to use more current components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->