### PR TITLE
fix: derive project version from git tags

### DIFF
--- a/.github/workflows/build-run.yml
+++ b/.github/workflows/build-run.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           path: FairShip
           lfs: true
+          fetch-depth: 0
       - name: Build
         run: |
           set -o pipefail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,45 @@ if(POLICY CMP0144)
     cmake_policy(SET CMP0144 NEW)
 endif()
 
-project(FairShip VERSION 0.0.0 LANGUAGES CXX)
+# Determine version from git tags (CalVer: year.month[.patch])
+find_package(Git QUIET)
+if(Git_FOUND)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --match "[0-9]*"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE FAIRSHIP_GIT_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE GIT_DESCRIBE_RESULT
+    )
+endif()
+
+if(GIT_DESCRIBE_RESULT EQUAL 0)
+    # Parse: "26.05", "26.05.1", "26.05-12-gabcdef", or "26.05.1-3-gabcdef"
+    string(
+        REGEX MATCH "^[0-9]+\\.[0-9]+(\\.[0-9]+)?"
+        FAIRSHIP_VERSION
+        "${FAIRSHIP_GIT_VERSION}"
+    )
+    if(FAIRSHIP_GIT_VERSION MATCHES "^[0-9.]+-([0-9]+)-g")
+        set(FAIRSHIP_VERSION_TWEAK "${CMAKE_MATCH_1}")
+    endif()
+else()
+    set(FAIRSHIP_VERSION "0.0.0")
+    message(
+        WARNING
+        "Git not found or no tags — using fallback version ${FAIRSHIP_VERSION}"
+    )
+endif()
+
+project(FairShip VERSION ${FAIRSHIP_VERSION} LANGUAGES CXX)
+
+if(FAIRSHIP_VERSION_TWEAK)
+    set(PROJECT_VERSION_TWEAK ${FAIRSHIP_VERSION_TWEAK})
+    set(PROJECT_VERSION "${PROJECT_VERSION}.${PROJECT_VERSION_TWEAK}")
+endif()
+
+message(STATUS "FairShip version: ${PROJECT_VERSION}")
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `VERSION 0.0.0` in `project()` with automatic detection from git tags via `git describe`
- Matches only CalVer tags (`[0-9]*`), ignoring legacy tags like `condDB`
- Dev builds include commits-since-tag as the tweak version component (e.g. `26.05.0.3`)
- Falls back to `0.0.0` with a warning for non-git builds (source tarballs)

## Test plan

- [x] Verify `cmake -S . -B build` prints correct version (e.g. `FairShip version: 26.05.0.3`)
- [x] Verify on a tagged commit the version is clean (e.g. `26.05.0`)
- [x] Verify SOVERSION on built libraries reflects the major version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now derives the FairShip version from git tags using CalVer (year.month[.patch]) with a fallback placeholder; the resolved version is reported during configuration.
  * CI checkout updated to fetch full git history to support version derivation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->