### PR TITLE
fix: load libEGPythia6 in shipRoot_conf

### DIFF
--- a/python/shipRoot_conf.py
+++ b/python/shipRoot_conf.py
@@ -11,6 +11,7 @@ if os.environ.get("FAIRSHIP_ROOT", "") == "":
     print("FairShip environment not found, quitting.")
     quit()
 
+ROOT.gSystem.Load("libEGPythia6")
 ROOT.gSystem.Load("libPythia6")
 ROOT.gSystem.Load("libpythia8")
 


### PR DESCRIPTION
## Summary

- Load `libEGPythia6` explicitly in `shipRoot_conf.py`, consistent with `gconfig/basiclibs.C` and `macro/eventDisplay.py`

`shipRoot_conf.py` loaded `libPythia6` (Fortran) but not `libEGPythia6` (ROOT wrapper containing TPythia6). Scripts importing `shipRoot_conf` that then call `ROOT.TPythia6()` relied on ROOT auto-loading, which is broken by a rootmap naming bug in the ROOTEGPythia6 package (rootmap references non-existent `libTPythia6.so` instead of `libEGPythia6.so`).

Related fixes: ShipSoft/ship-conda-recipes and ShipSoft/shipdist rootmap fixes.

## Test plan

- [ ] Verify `ROOT.TPythia6()` works in scripts importing `shipRoot_conf`