### PR TITLE
docs: add pixi installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [FairShip](#fairship)
     - [Introduction](#introduction)
         - [Branches](#branches)
+    - [Using pixi](#using-pixi)
     - [Build instructions using CVMFS](#build-instructions-using-cvmfs)
     - [Local build, without access to CVMFS](#local-build-without-access-to-cvmfs)
     - [Run instructions](#run-instructions)
@@ -48,6 +49,47 @@ FairRoot. The dependencies of FairShip are tracked and installed using
 All packages are managed in Git and GitHub. Please read [the Git tutorial for
 SHiP](https://github.com/ShipSoft/FairShip/wiki/Git-Tutorial-for-SHiP) first,
 even if you already know Git, as it explains how development is done on GitHub.
+
+## Using pixi
+
+[Pixi](https://pixi.sh) provides pre-built FairShip packages from the [ship](https://prefix.dev/channels/ship) channel, so there is no need to compile anything. This is the quickest way to get started.
+
+1. [Install pixi](https://pixi.sh/latest/#installation) if you haven't already.
+
+2. Clone the FairShip repository (needed for macros and Python scripts):
+    ```bash
+    git clone https://github.com/ShipSoft/FairShip.git
+    cd FairShip
+    ```
+
+3. Add the `ship` channel and install `fairship` into a pixi project:
+    ```bash
+    pixi init my-analysis -c https://prefix.dev/ship -c conda-forge
+    cd my-analysis
+    pixi add fairship
+    ```
+
+4. Run commands inside the environment:
+    ```bash
+    pixi run python ../macro/run_simScript.py --tag my-simulation
+    ```
+
+    Or start a shell with FairShip loaded:
+    ```bash
+    pixi shell
+    python ../macro/run_simScript.py --tag my-simulation
+    ```
+
+You can also use pixi in an existing project by adding the channel and dependency to your `pixi.toml`:
+
+```toml
+[workspace]
+channels = ["https://prefix.dev/ship", "conda-forge"]
+platforms = ["linux-64"]
+
+[dependencies]
+fairship = "*"
+```
 
 ## Build Instructions using CVMFS
 

--- a/README.md
+++ b/README.md
@@ -52,43 +52,47 @@ even if you already know Git, as it explains how development is done on GitHub.
 
 ## Using pixi
 
-[Pixi](https://pixi.sh) provides pre-built FairShip packages from the [ship](https://prefix.dev/channels/ship) channel, so there is no need to compile anything. This is the quickest way to get started.
+[Pixi](https://pixi.sh) manages all dependencies via the `pixi.toml` and
+`activate.sh` already included in this repository. The activation script sets
+`FAIRSHIP` and `GEOMPATH` (among others) to `PIXI_PROJECT_ROOT`, so the pixi
+project root **must** be the FairShip clone itself — it contains the required
+`geometry/` and `files/` directories.
+
+### Build from source (recommended)
 
 1. [Install pixi](https://pixi.sh/latest/#installation) if you haven't already.
 
-2. Clone the FairShip repository (needed for macros and Python scripts):
+2. Clone and build:
     ```bash
     git clone https://github.com/ShipSoft/FairShip.git
     cd FairShip
+    pixi run build
     ```
 
-3. Add the `ship` channel and install `fairship` into a pixi project:
+3. Run commands inside the environment:
     ```bash
-    pixi init my-analysis -c https://prefix.dev/ship -c conda-forge
-    cd my-analysis
-    pixi add fairship
+    pixi run python macro/run_simScript.py --tag my-simulation
     ```
 
-4. Run commands inside the environment:
-    ```bash
-    pixi run python ../macro/run_simScript.py --tag my-simulation
-    ```
-
-    Or start a shell with FairShip loaded:
+    Or start a shell:
     ```bash
     pixi shell
-    python ../macro/run_simScript.py --tag my-simulation
+    python macro/run_simScript.py --tag my-simulation
     ```
 
-You can also use pixi in an existing project by adding the channel and dependency to your `pixi.toml`:
+### Using the pre-built package
 
-```toml
-[workspace]
-channels = ["https://prefix.dev/ship", "conda-forge"]
-platforms = ["linux-64"]
+Pre-built FairShip packages are available from the
+[ship](https://prefix.dev/channels/ship) channel. Because `activate.sh`
+expects `geometry/`, `files/`, and other data directories at
+`PIXI_PROJECT_ROOT`, the simplest approach is to add `fairship` directly to
+the clone:
 
-[dependencies]
-fairship = "*"
+```bash
+git clone https://github.com/ShipSoft/FairShip.git
+cd FairShip
+pixi add fairship
+pixi run python macro/run_simScript.py --tag my-simulation
 ```
 
 ## Build Instructions using CVMFS


### PR DESCRIPTION
## Summary

- Add a new "Using pixi" section to the README, before the build instructions
- Documents how to install pre-built FairShip packages from the [ship](https://prefix.dev/channels/ship) channel on prefix.dev
- Includes `pixi init`/`pixi add` workflow and a `pixi.toml` example

Tested in distrobox (gha-runner): `pixi add fairship` resolves, installs, and FairShip libraries load correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New "Using pixi" guide added to the README and table of contents
  * Describes how to activate the pixi environment and notes the project-root requirement
  * Shows commands to build from source (pixi run build), run macros (pixi run), or drop into a shell (pixi shell)
  * Documents using pre-built packages via pixi add fairship

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/FairShip/pull/1199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->