### PR TITLE
Add CI sim-chain tasks to pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -60,3 +60,39 @@ configure = { cmd = """cmake -S . -B build -G Ninja \
 build = { cmd = "cmake --build build -j$(nproc)", depends-on = ["configure"] }
 install = { cmd = "cmake --install build", depends-on = ["build"] }
 test = { cmd = "ctest --test-dir build --output-on-failure", depends-on = ["build"] }
+
+# --- CI sim-chain tasks ---
+# Mirror the per-step commands in .github/workflows/build-run.yml so the
+# whole sim/reco/ana/benchmark chain is reproducible locally via `pixi run`.
+# Each task is standalone; the CI workflow invokes them in order. Files are
+# tagged `ci-test` (sim chain) and `ci-benchmark` (tracking) so successive
+# steps can find each other's outputs.
+
+[tasks.ci-sim]
+args = [
+  { arg = "vessel", default = "vacuums" },
+  { arg = "snd_design", default = "all" },
+  { arg = "muon_shield", default = "TRY_2025" },
+]
+cmd = "python macro/run_simScript.py --test --debug 2 --{{ vessel }} --SND --SND_design={{ snd_design }} --shieldName {{ muon_shield }} --EvtGenDecayer --tag ci-test"
+
+[tasks.ci-overlap-check]
+cmd = "python python/experimental/check_overlaps.py --geofile geo_ci-test.root | tee overlap.log && ! grep -q Overlap overlap.log"
+
+[tasks.ci-geo-info]
+cmd = "python macro/getGeoInformation.py --geometry geo_ci-test.root --level 2"
+
+[tasks.ci-reco]
+cmd = "python macro/ShipReco.py -f sim_ci-test.root -g geo_ci-test.root --patRec AR --Debug"
+
+[tasks.ci-ana]
+cmd = "python macro/ShipAna.py -f sim_ci-test.root -r sim_ci-test_rec.root -g geo_ci-test.root"
+
+[tasks.ci-analysis-example]
+cmd = "python examples/analysis_example.py -f sim_ci-test.root -r sim_ci-test_rec.root -g geo_ci-test.root"
+
+[tasks.ci-tracking-benchmark]
+cmd = "python macro/run_tracking_benchmark.py -n 200 --seed 42 --tag ci-benchmark --output-json tracking_metrics.json"
+
+[tasks.ci-fixed-target]
+cmd = "python macro/run_fixedTarget.py -n 10 -e 10.0 -r 1"


### PR DESCRIPTION
## Summary

Adds pixi tasks mirroring the per-step commands in
[\`build-run.yml\`](.github/workflows/build-run.yml) so the full
simulation / reconstruction / analysis / benchmark chain can be
reproduced locally via \`pixi run\` and driven from the new
[\`pixi-cmake-build\`](https://github.com/ShipSoft/.github/blob/main/.github/workflows/pixi-cmake-build.yml)
reusable workflow.

New tasks:

| Task | Replaces \`build-run.yml\` step |
|------|-------------------------------|
| \`ci-sim\` | Run Sim |
| \`ci-overlap-check\` | Overlap check |
| \`ci-geo-info\` | Geo information |
| \`ci-reco\` | Run Reco |
| \`ci-ana\` | Run Ana |
| \`ci-analysis-example\` | Run examples |
| \`ci-tracking-benchmark\` | Run tracking benchmark |
| \`ci-fixed-target\` | Run Fixed Target Simulation |

\`ci-sim\` takes positional args (vessel / SND_design / muon_shield),
defaulting to \`vacuums all TRY_2025\` to match the common case in
\`build-run.yml\`. The helium variant is \`pixi run ci-sim helium\`.

## Why now

Prerequisite for retiring \`build-run.yml\` (aliBuild + CVMFS). With
these tasks in place, the upcoming pixi caller workflow can run the
same chain end-to-end without aliBuild.

## Test plan

- [x] \`pixi task list\` shows all 8 new tasks.
- [x] \`pixi run --dry-run ci-sim\` and \`ci-sim helium\` expand to the
      expected commands.
- [ ] Run \`pixi run ci-sim && pixi run ci-overlap-check && pixi run ci-reco && pixi run ci-ana\`
      end-to-end in a pixi env to confirm parity with \`build-run.yml\`.
- [ ] (Follow-up) Wire these tasks into a caller of \`pixi-cmake-build\`
      and run alongside \`build-run.yml\` on one or two PRs.