### PR TITLE
ci: use shared ShipSoft/.github reusable workflows

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,45 +1,11 @@
 name: Doxygen GitHub Pages
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   workflow_dispatch:
-concurrency:
-  group: gh-pages-deploy
-  cancel-in-progress: false
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
-      - name: Install dependencies
-        run: sudo apt-get install -y graphviz doxygen
-      - name: Generate Doxygen
-        run: doxygen doxygen/Doxyfile
-      - name: Checkout gh-pages
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-          path: gh-pages-checkout
-      - name: Update Doxygen files, preserve plots/
-        run: |
-          cd gh-pages-checkout
-          # Remove everything except plots/, .git, and .nojekyll
-          find . -maxdepth 1 -not -name '.' -not -name '.git' \
-            -not -name 'plots' -not -name '.nojekyll' \
-            -exec rm -rf {} +
-          # Copy new Doxygen output
-          cp -r ../doxygen/html/* .
-          touch .nojekyll
-      - name: Deploy
-        run: |
-          cd gh-pages-checkout
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "Deploy Doxygen from ${{ github.sha }}"
-          git push
+    uses: ShipSoft/.github/.github/workflows/doxygen-gh-pages.yml@main
+    with:
+      doxyfile: doxygen/Doxyfile
+      preserve: plots

--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -10,19 +10,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          lfs: true
-      - uses: prefix-dev/setup-pixi@v0.9.6
-      - name: Build
-        run: |
-          pixi run --locked configure
-          pixi run --locked build
-      - name: Test
-        run: pixi run --locked test
-      - name: Simulation test
-        run: pixi run --locked python macro/run_simScript.py --test
-        env:
-          QT_QPA_PLATFORM: offscreen
+    uses: ShipSoft/.github/.github/workflows/pixi-cmake-build.yml@main
+    with:
+      lfs: true
+      tasks: '["configure", "build", "test", "ci-sim"]'
+      env-vars: |
+        QT_QPA_PLATFORM=offscreen

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -1,33 +1,10 @@
 name: Update lock files
-permissions:
-  contents: write
-  pull-requests: write
 on:
   workflow_dispatch:
   schedule:
     - cron: 0 5 1 * *
 jobs:
   pixi-update:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
-        with:
-          run-install: false
-      - name: Update lock files
-        run: |
-          set -o pipefail
-          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update pixi lock file
-          title: Update pixi lock file
-          body-path: diff.md
-          branch: update-pixi
-          base: master
-          labels: pixi
-          delete-branch: true
-          add-paths: pixi.lock
+    uses: ShipSoft/.github/.github/workflows/pixi-lock-update.yml@main
+    with:
+      base: master


### PR DESCRIPTION
## Summary

Replaces three FairShip workflows with thin callers of the reusable
workflows in [\`ShipSoft/.github\`](https://github.com/ShipSoft/.github):

- \`update-lock-files.yml\` → \`pixi-lock-update.yml\` (base=master)
- \`doxygen-gh-pages.yml\` → \`doxygen-gh-pages.yml\`
- \`pixi-build.yml\` → \`pixi-cmake-build.yml\` (now invokes
  \`configure\`, \`build\`, \`test\`, and \`ci-sim\` — the \`--test\` sim is
  subsumed by the more thorough \`ci-sim\` task added in #1209)

End-to-end behaviour is the same; the workflow bodies now live once
centrally so a fix or upgrade only needs to be made there.

## Test plan

- [x] actionlint passes on changed workflows.
- [x] CI run on this PR is green (pixi build + ci-sim).
- [x] Manual \`workflow_dispatch\` of \`update-lock-files\` opens a
      \`pixi update\` PR against \`master\`.