### PR TITLE
fix: keep BranchList TObjStrings alive under ROOT 6.40 PyROOT ownership

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -957,19 +957,25 @@ if options.muonback:
 
     branches = ROOT.TList()
     branches.SetName("BranchList")
-    branches.Add(ROOT.TObjString("MCTrack"))
-    branches.Add(ROOT.TObjString("vetoPoint"))
-    branches.Add(ROOT.TObjString("ShipRpcPoint"))
-    branches.Add(ROOT.TObjString("TargetPoint"))
-    branches.Add(ROOT.TObjString("TTPoint"))
-    branches.Add(ROOT.TObjString("ScoringPoint"))
-    branches.Add(ROOT.TObjString("strawtubesPoint"))
-    branches.Add(ROOT.TObjString("TimeDetPoint"))
-    branches.Add(ROOT.TObjString("MCEventHeader"))
-    branches.Add(ROOT.TObjString("UpstreamTaggerPoint"))
-    branches.Add(ROOT.TObjString("MTCdetPoint"))
-    branches.Add(ROOT.TObjString("SiliconTargetPoint"))
-    branches.Add(ROOT.TObjString("sGeoTracks"))
+    branches.SetOwner(True)
+    for name in (
+        "MCTrack",
+        "vetoPoint",
+        "ShipRpcPoint",
+        "TargetPoint",
+        "TTPoint",
+        "ScoringPoint",
+        "strawtubesPoint",
+        "TimeDetPoint",
+        "MCEventHeader",
+        "UpstreamTaggerPoint",
+        "MTCdetPoint",
+        "SiliconTargetPoint",
+        "sGeoTracks",
+    ):
+        obj = ROOT.TObjString(name)
+        ROOT.SetOwnership(obj, False)  # C++ TList takes ownership
+        branches.Add(obj)
 
     sTree.AutoSave()
     fSink.WriteObject(branches, "BranchList", ROOT.TObject.kSingleKey)


### PR DESCRIPTION
## Summary

Fixes the segfault reported in [shipdist#277](https://github.com/ShipSoft/shipdist/issues/277) when running `macro/run_simScript.py --MuonBack` against ROOT 6.40 (shipped in shipdist 26.05).

ROOT 6.40 changed PyROOT's object lifetime semantics: Python-created C++ temporaries are released as soon as the Python wrapper goes out of scope, even when the only remaining reference is a C++ container such as `TList`. The post-processing block at `macro/run_simScript.py:958` previously inlined the temporaries:

```python
branches.Add(ROOT.TObjString("MCTrack"))
```

so the `TList` ended up holding dangling pointers. `FairRootFileSink::WriteObject` then crashed in `TInstrumentedIsAProxy<TObject>::operator()` while streaming the list at the end of a `--MuonBack` job.

This patch builds the `TObjString` entries in a loop, marks the `TList` as owner, and relinquishes Python ownership of each entry so the `TList` becomes the sole owner — matching the convention established in 58ed4832e (`fix: prevent double-delete segfaults with ROOT 6.40 PyROOT ownership`) for the other Python-owned objects handed to FairRoot.

## Notes

- Only call site in FairShip Python that used `branches.Add(ROOT.TObjString(...))` (verified by `grep -rn TObjString --include='*.py'`).
- Bug only triggers with `--MuonBack` (the only branch that enters `if options.muonback:` post-processing).
- Output file content is unchanged; the crash was at shutdown only.

Closes ShipSoft/shipdist#277.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code efficiency in event processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->