### PR TITLE
style: annotate virtual overrides with override

### DIFF
--- a/Detector/DetectorPoint.h
+++ b/Detector/DetectorPoint.h
@@ -14,7 +14,7 @@ namespace SHiP {
 class DetectorPoint : public FairMCPoint {
  public:
   DetectorPoint() = default;
-  ~DetectorPoint() = default;
+  ~DetectorPoint() override = default;
 
   DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID, TVector3 pos,
                 TVector3 mom, Double_t tof, Double_t length, Double_t eLoss,

--- a/field/FairShipFields.h
+++ b/field/FairShipFields.h
@@ -27,9 +27,9 @@ class FairShipFields : public AbsBField {
   inline void setField(ShipCompField* gField) { gField_ = gField; }
 
   //! return value at position
-  TVector3 get(const TVector3& pos) const;
+  TVector3 get(const TVector3& pos) const override;
   void get(const double& posX, const double& posY, const double& posZ,
-           double& Bx, double& By, double& Bz) const;
+           double& Bx, double& By, double& Bz) const override;
 
  private:
   ShipCompField* gField_{nullptr};

--- a/field/ShipFieldMaker.h
+++ b/field/ShipFieldMaker.h
@@ -68,7 +68,7 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction {
   };
 
   //! Set-up all local and regional fields and assign them to volumes
-  virtual void Construct();
+  void Construct() override;
 
   //! Read an input file to define fields and associated volumes
   /*!

--- a/field/ShipFieldPar.h
+++ b/field/ShipFieldPar.h
@@ -21,7 +21,7 @@ class ShipFieldPar : public FairParGenericSet {
   ShipFieldPar();
 
   /** Destructor **/
-  ~ShipFieldPar();
+  ~ShipFieldPar() override;
 
   /** Put parameters **/
   void putParams(FairParamList* list) override;

--- a/passive/ShipGeoCave.h
+++ b/passive/ShipGeoCave.h
@@ -20,12 +20,12 @@ class ShipGeoCave : public FairGeoSet {
 
  public:
   ShipGeoCave();
-  ~ShipGeoCave() {}
-  const char* getModuleName(Int_t) { return name.Data(); }
-  Bool_t read(std::fstream&, FairGeoMedia*);
-  void addRefNodes();
-  void write(std::fstream&);
-  void print();
+  ~ShipGeoCave() override = default;
+  const char* getModuleName(Int_t) override { return name.Data(); }
+  Bool_t read(std::fstream&, FairGeoMedia*) override;
+  void addRefNodes() override;
+  void write(std::fstream&) override;
+  void print() override;
   ClassDefOverride(ShipGeoCave, 0)  // Class for the geometry of CAVE
 };
 

--- a/passive/ShipPassiveContFact.h
+++ b/passive/ShipPassiveContFact.h
@@ -17,8 +17,8 @@ class ShipPassiveContFact : public FairContFact {
 
  public:
   ShipPassiveContFact();
-  ~ShipPassiveContFact() {}
-  FairParSet* createContainer(FairContainer*);
+  ~ShipPassiveContFact() override = default;
+  FairParSet* createContainer(FairContainer*) override;
   ClassDefOverride(ShipPassiveContFact,
                    0)  // Factory for all Passive parameter containers
 };

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -22,7 +22,7 @@ class PyTr1Rng : public Pythia8::RndmEngine {
   PyTr1Rng() { rng = new TRandom1(gRandom->GetSeed()); };
   ~PyTr1Rng() override {};
 
-  Double_t flat() { return rng->Rndm(); };
+  Double_t flat() override { return rng->Rndm(); };
 
  private:
   TRandom1* rng;  //!
@@ -33,7 +33,7 @@ class PyTr3Rng : public Pythia8::RndmEngine {
   PyTr3Rng() { rng = new TRandom3(gRandom->GetSeed()); };
   ~PyTr3Rng() override {};
 
-  Double_t flat() { return rng->Rndm(); };
+  Double_t flat() override { return rng->Rndm(); };
 
  private:
   TRandom3* rng;  //!

--- a/splitcal/splitcalContFact.h
+++ b/splitcal/splitcalContFact.h
@@ -15,8 +15,8 @@ class splitcalContFact : public FairContFact {
 
  public:
   splitcalContFact();
-  ~splitcalContFact() {}
-  FairParSet* createContainer(FairContainer*);
+  ~splitcalContFact() override = default;
+  FairParSet* createContainer(FairContainer*) override;
   ClassDefOverride(splitcalContFact,
                    0)  // Factory for all splitcal parameter containers
 };

--- a/strawtubes/strawtubesContFact.h
+++ b/strawtubes/strawtubesContFact.h
@@ -15,8 +15,8 @@ class strawtubesContFact : public FairContFact {
 
  public:
   strawtubesContFact();
-  ~strawtubesContFact() {}
-  FairParSet* createContainer(FairContainer*);
+  ~strawtubesContFact() override = default;
+  FairParSet* createContainer(FairContainer*) override;
   ClassDefOverride(strawtubesContFact,
                    0)  // Factory for all strawtubes parameter containers
 };

--- a/veto/vetoContFact.h
+++ b/veto/vetoContFact.h
@@ -15,8 +15,8 @@ class vetoContFact : public FairContFact {
 
  public:
   vetoContFact();
-  ~vetoContFact() {}
-  FairParSet* createContainer(FairContainer*);
+  ~vetoContFact() override = default;
+  FairParSet* createContainer(FairContainer*) override;
   ClassDefOverride(vetoContFact,
                    0)  // Factory for all veto parameter containers
 };

--- a/veto/vetoHitOnTrack.h
+++ b/veto/vetoHitOnTrack.h
@@ -32,7 +32,7 @@ class vetoHitOnTrack : public TObject {
   void SetHitID(Int_t hitID) { fHitID = hitID; }
 
   /*** Output to screen */
-  virtual void Print(const Option_t* opt = "") const { ; }
+  void Print(const Option_t* opt = "") const override { ; }
 
  protected:
   Float_t fDist;  ///< distance to closest veto hit


### PR DESCRIPTION
## Summary

Silences 34 `-Winconsistent-missing-override` warnings emitted by rootcling/clang on the master CI build (run [27147752577](https://github.com/ShipSoft/FairShip/actions/runs/27147752577)) by adding `override` to virtual functions in 11 headers.

This is PR 1 of a small series addressing build warnings — packaged per warning category for easier review.

Files touched (one virtual function group per file):

- `Detector/DetectorPoint.h` — destructor
- `field/FairShipFields.h` — two `get(...) const` overloads
- `field/ShipFieldMaker.h` — `Construct()`
- `field/ShipFieldPar.h` — destructor
- `passive/ShipGeoCave.h` — destructor + 5 `FairGeoSet` overrides
- `passive/ShipPassiveContFact.h` — destructor + `createContainer`
- `shipgen/HNLPythia8Generator.h` — `PyTr1Rng::flat()` and `PyTr3Rng::flat()`
- `splitcal/splitcalContFact.h`, `strawtubes/strawtubesContFact.h`, `veto/vetoContFact.h` — destructor + `createContainer`
- `veto/vetoHitOnTrack.h` — `Print(...)`

Conventions used:
- Empty inline destructors (`~Foo() {}`) rewritten as `~Foo() override = default;` to match the style already in `HNLPythia8Generator.h`.
- Redundant `virtual` keywords on overrides dropped per `modernize-use-override`.

No behavioural change — `override` is a compile-time check only.

## Test plan

- [x] Build clean locally with `pixi run build` — 132/132 steps, zero `-Winconsistent-missing-override` warnings
- [x] `clang-format --dry-run --Werror` clean across the touched headers
- [ ] CI passes (build + run-fixed-target + run-tracking-benchmark + run-sim-chain on both 26.02 and 26.05 legs)