### PR TITLE
build: define fairship conda package via pixi-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release conda package
+# Build the FairShip conda package via `pixi build` and publish it to the
+# prefix.dev/ship channel. Triggered by CalVer release tags (e.g. v26.05.7).
+#
+# This workflow supersedes the hand-written rattler-build recipe that used to
+# live in ship-conda-recipes/recipes/fairship/. The package contents and
+# upload destination remain unchanged from the rattler-build pipeline so
+# downstream consumers see no difference.
+on:
+  push:
+    tags: ['v[0-9]*']
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build only, skip upload'
+        type: boolean
+        default: true
+permissions:
+  contents: read
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@v0.9.6
+        with:
+          locked: true
+      - name: Build conda package
+        run: pixi build --output-dir output
+      - name: Show built artifacts
+        run: ls -la output/
+      - name: Upload to prefix.dev/ship
+        if: github.event_name == 'push' || inputs.dry_run == false
+        env:
+          PREFIX_DEV_API_KEY: ${{ secrets.PREFIX_DEV_API_KEY }}
+        run: |
+          for pkg in output/*.conda; do
+            [ -f "$pkg" ] || continue
+            pixi exec --spec rattler-build -- \
+              rattler-build upload prefix \
+                --api-key "$PREFIX_DEV_API_KEY" \
+                -c ship --skip-existing "$pkg"
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fairship-conda
+          path: output/*.conda
+          if-no-files-found: error

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,6 +3,7 @@ name = "fairship"
 description = "SHiP experiment simulation framework"
 channels = ["https://prefix.dev/ship", "conda-forge"]
 platforms = ["linux-64"]
+preview = ["pixi-build"]
 
 [dependencies]
 # Core HEP packages (conda-forge)
@@ -50,6 +51,73 @@ clang-tools = "*"  # provides clang-tidy
 
 [pypi-dependencies]
 pyrefly = "*"
+
+# --- Conda package definition (consumed by `pixi build`) ---
+# Replaces the hand-written rattler-build recipe formerly in
+# ship-conda-recipes/recipes/fairship/. `pixi build` here emits the
+# same `fairship` .conda for prefix.dev/ship.
+
+[package]
+name = "fairship"
+version = "26.05.7"
+
+[package.build.backend]
+name = "pixi-build-cmake"
+version = "0.*"
+channels = [
+    "https://prefix.dev/pixi-build-backends",
+    "https://prefix.dev/ship",
+    "https://prefix.dev/conda-forge",
+]
+
+[package.build.config]
+# pixi-build-cmake already supplies -GNinja, -DCMAKE_BUILD_TYPE=Release,
+# -DCMAKE_INSTALL_PREFIX=$PREFIX, -DCMAKE_EXPORT_COMPILE_COMMANDS=ON,
+# -DBUILD_SHARED_LIBS=ON. Everything below is FairShip-specific.
+# extra-args are spliced verbatim into a bash command line, so values
+# containing whitespace need embedded shell quotes.
+extra-args = [
+    "-DCMAKE_INSTALL_LIBDIR=lib",
+    "-DCMAKE_CXX_STANDARD=20",
+    "-DGeant4VMC_DIR=$PREFIX/lib/Geant4VMC-6.7.1",
+    '-DCMAKE_CXX_FLAGS="-isystem $PREFIX/include/geant4vmc -isystem $PREFIX/include/Geant4"',
+]
+env = { FAIRROOTPATH = "$PREFIX", ROOT_INCLUDE_PATH = "$PREFIX/include:$PREFIX/include/geant4vmc:$PREFIX/include/Geant4:$PREFIX/include/vmc" }
+
+[package.host-dependencies]
+root = ">=6.38"
+geant4 = ">=11.3"
+geant4-vmc = "==6.7.1"
+geant3 = ">=4.5"
+vmc = ">=2.2"
+fairroot = ">=19.0"
+faircmakemodules = ">=1.0"
+fairlogger = ">=2.3"
+genfit = ">=2.3"
+rootegpythia6 = "*"
+pythia6 = ">=6.4"
+pythia8 = ">=8.312"
+evtgen = ">=2.2"
+fmt = "*"
+gsl = "*"
+xerces-c = "*"
+
+[package.run-dependencies]
+root = ">=6.38"
+geant4 = ">=11.3"
+geant4-vmc = "==6.7.1"
+geant3 = ">=4.5"
+vmc = ">=2.2"
+fairroot = ">=19.0"
+fairlogger = ">=2.3"
+genfit = ">=2.3"
+rootegpythia6 = "*"
+pythia6 = ">=6.4"
+pythia8 = ">=8.312"
+evtgen = ">=2.2"
+fmt = "*"
+gsl = "*"
+xerces-c = "*"
 
 [activation]
 scripts = ["activate.sh"]


### PR DESCRIPTION
## Summary

Replaces the hand-written rattler-build recipe in `ship-conda-recipes/recipes/fairship/` with a pixi-build package definition in this repo's `pixi.toml`. `pixi build` here now produces the same `fairship` .conda for `prefix.dev/ship` that the conda recipe currently does. The CMake flag list and HEP dep stack live in a single file inside this repo instead of being restated across two repos.

- New `[package]`, `[package.build.backend]`, `[package.build.config]`, `[package.host-dependencies]`, `[package.run-dependencies]` tables in `pixi.toml` consumed by `pixi-build-cmake`.
- New `.github/workflows/release.yml` runs `pixi build` on CalVer tags (`v[0-9]*`) and uploads the .conda to `prefix.dev/ship` via `rattler-build upload prefix`. A `PREFIX_DEV_API_KEY` secret is needed before the next tag.
- `hepmc2` is dropped from the package dep list (FairShip no longer uses it after a60bc2e0f).

The dev environment (`[dependencies]`, `[tasks.*]`, `[activation]`) is unchanged. `pixi run configure/build/install` still works exactly as before.

## Bridging plan

`ship-conda-recipes/recipes/fairship/` stays in place under its current SHA pin until the next CalVer release tag. At cutover we:

1. Add `PREFIX_DEV_API_KEY` secret to this repo.
2. Bump `[package].version` in `pixi.toml` and tag the release — `release.yml` fires.
3. In the same window, land a companion PR on `ship-conda-recipes` removing `recipes/fairship/`, the `build-fairship` task in its `pixi.toml`, and the `fairship` entry in `ci/build-order.sh`.

## Test plan

- [x] `pixi build` end-to-end on linux-64 — produces `fairship-26.5.7-hb0f4dca_0.conda` (832 KB). Contents include `lib/libShipData.so`, `share/FairShip/geometry/`, and the full `include/` header set. `info/index.json` `depends` matches the previous `recipe.yaml run:` (minus `hepmc2`).
- [x] `pixi run configure` dry-run shows the dev task unchanged.
- [ ] Confirm that conda's normalization of `26.05.7` → `26.5.7` does not break upgrade ordering against the already-published `26.05.7` package on `prefix.dev/ship`. If it does, set `[package].version = "26.5.7"` (or whatever conda has actually published) before merging.
- [x] Add the `PREFIX_DEV_API_KEY` secret before the next tag.

## Known caveats

- `[package].version` is a string literal in `pixi.toml`, not derived from git. Must be bumped manually before each release tag.
- CMakeLists.txt still derives the SOVERSION from `git describe`, so library filenames (e.g. `libShipData.so.26.05.31`) are independent of `[package].version`. Pre-existing behavior, not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated conda package building and publishing workflow
  * Added conda package build configuration for distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->