### PR TITLE
feat: Introduce TTree input support for simulations and Muons & Matter data import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ it in future.
 
 ### Added
 
+* Add experimental script to import Muons and Matter pkl files
+* Add TTreeGenerator to read M&M ntuples
+
 ### Changed
 
 ### Fixed

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -185,6 +185,7 @@ parser.add_argument(
     action="store_true",
 )
 parser.add_argument("--Ntuple", dest="ntuple", help="Use ntuple as input", action="store_true")
+parser.add_argument("--ttree", help="Use TTree as input", action="store_true")
 parser.add_argument(
     "--MuonBack",
     dest="muonback",
@@ -459,7 +460,18 @@ ship_geo = geometry_config.create_config(
 )
 
 if not options.command:
-    for g in ["pythia8", "evtcalc", "pythia6", "nuradio", "ntuple", "muonback", "mudis", "fixedTarget", "cosmics"]:
+    for g in [
+        "pythia8",
+        "ttree",
+        "evtcalc",
+        "pythia6",
+        "nuradio",
+        "ntuple",
+        "muonback",
+        "mudis",
+        "fixedTarget",
+        "cosmics",
+    ]:
         if getattr(options, g):
             break
     else:
@@ -716,6 +728,18 @@ if options.nuradio:
     # this requires writing a C macro, would have been easier to do directly in python!
     # for i in [431,421,411,-431,-421,-411]:
     # ROOT.gMC.SetUserDecay(i) # Force the decay to be done w/external decayer
+if options.ttree:
+    ut.checkFileExists(inputFile)
+    primGen.SetTarget(0.0, 0.0)
+    generator = ROOT.SHiP.TTreeGenerator()
+    generator.SetTreeName("converted_ntuple")
+    if not generator.Init(inputFile, options.firstEvent):
+        raise RuntimeError(f"Failed to initialize TTreeGenerator from input: {inputFile}")
+    primGen.AddGenerator(generator)
+    ROOT.SetOwnership(generator, False)  # C++ FairPrimaryGenerator takes ownership
+    available_events = max(0, generator.GetNEvents() - options.firstEvent)
+    options.nEvents = available_events if options.nEvents == -1 else min(options.nEvents, available_events)
+    print("Process ", options.nEvents, " from input file")
 if options.ntuple:
     # reading previously processed muon events, [-50m - 50m]
     ut.checkFileExists(inputFile)

--- a/python/experimental/eminem_importer.py
+++ b/python/experimental/eminem_importer.py
@@ -1,0 +1,490 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
+# Collaboration
+"""Convert pickled muon data to ROOT format (TTree or RNTuple).
+
+This script converts pickled muon data to ROOT format, supporting both TTree and RNTuple output formats.
+The input data should be a NumPy array with columns: px, py, pz, x, y, z, id, w.
+
+Usage:
+    python eminem_importer.py input_file.pkl [options]
+
+Example:
+    python eminem_importer.py muons_FullMC.pkl --output converted_data.root --format rntuple
+"""
+
+import argparse
+import gzip
+import json
+import pickle
+import sys
+from pathlib import Path
+
+import numpy as np
+import ROOT
+import shipunit as u
+
+
+def parse_arguments():
+    """
+    Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Convert pickled muon data to ROOT format (TTree or RNTuple)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s muons_FullMC.pkl
+  %(prog)s muons_FullMC.pkl --output my_data.root
+  %(prog)s muons_FullMC.pkl --format rntuple --output my_data.root
+        """,
+    )
+
+    parser.add_argument(
+        "input_file",
+        nargs="?",
+        help="Path to the input pickled data file (.pkl or .pkl.gz)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="converted_from_eminem.root",
+        help="Output ROOT file name (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["ttree", "rntuple"],
+        default="ttree",
+        help="Output format: ttree (default) or rntuple",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--tree-name",
+        default="converted_ntuple",
+        help="Name of the output tree/ntuple (default: %(default)s)",
+    )
+
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+
+    parser.add_argument("--config", help="Path to custom column configuration file (JSON format)")
+
+    parser.add_argument(
+        "--list-config",
+        action="store_true",
+        help="Print the default column configuration and exit",
+    )
+
+    return parser.parse_args()
+
+
+def load_pickled_data(input_file, verbose=False):
+    """
+    Load pickled data from file, handling both compressed and uncompressed files.
+
+    Args:
+        input_file (str): Path to the input pickled file
+        verbose (bool): Enable verbose output
+
+    Returns:
+        numpy.ndarray: Loaded data array
+
+    Raises:
+        FileNotFoundError: If input file doesn't exist
+        Exception: If file cannot be loaded or has wrong format
+    """
+    input_path = Path(input_file)
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_file}")
+
+    if verbose:
+        print(f"Loading data from: {input_file}")
+
+    try:
+        # Try gzip first (files may be gzipped regardless of extension)
+        try:
+            with gzip.open(input_file, "rb") as f:
+                data = pickle.loads(f.read())
+        except gzip.BadGzipFile:
+            with open(input_file, "rb") as f:
+                data = pickle.load(f)
+    except Exception as e:
+        raise RuntimeError(f"Failed to load pickled data: {e}") from e
+
+    if isinstance(data, dict):
+        required = ["px", "py", "pz", "x", "y", "z", "pdg_id", "weight"]
+
+        missing = [k for k in required if k not in data]
+        if missing:
+            raise ValueError(f"Missing keys in dict: {missing}")
+
+        # convert to column stack (ONLY here, once)
+        stacked = np.column_stack(
+            [
+                np.asarray(data["px"]),
+                np.asarray(data["py"]),
+                np.asarray(data["pz"]),
+                np.asarray(data["x"]),
+                np.asarray(data["y"]),
+                np.asarray(data["z"]),
+                np.asarray(data["pdg_id"]),
+                np.asarray(data["weight"]),
+            ]
+        )
+
+        if verbose:
+            print(f"Loaded data shape: {stacked.shape}")
+            print(f"Data type: {stacked.dtype}")
+
+        return stacked
+
+    if verbose:
+        print(f"Loaded data shape: {data.shape}")
+        print(f"Data type: {data.dtype}")
+
+    # Validate data format
+    if len(data.shape) != 2 or data.shape[1] != 8:
+        raise ValueError(f"Expected data with shape (N, 8), got {data.shape}")
+
+    return data
+
+
+def load_custom_config(config_path):
+    """
+    Load custom column configuration from JSON file.
+
+    Args:
+        config_path (str): Path to the configuration file
+
+    Returns:
+        dict: Custom configuration dictionary
+    """
+    try:
+        with open(config_path) as f:
+            custom_config = json.load(f)
+        return custom_config
+    except Exception as e:
+        raise RuntimeError(f"Failed to load configuration file: {e}") from e
+
+
+def parse_custom_config_units(custom_config):
+    """
+    Parse custom configuration and convert string unit representations to shipunit objects.
+
+    Args:
+        custom_config (dict): Custom configuration dictionary
+
+    Returns:
+        dict: Configuration with parsed units
+    """
+    # Common unit mappings for shipunit
+    unit_map = {
+        "m": u.m,
+        "cm": u.cm,
+        "mm": u.mm,
+        "km": u.km,
+        "GeV": u.GeV,
+        "MeV": u.MeV,
+        "keV": u.keV,
+        "eV": u.eV,
+        "s": u.s,
+        "ms": u.ms,
+        "ns": u.ns,
+        "kg": u.kg,
+        "g": u.g,
+        # Add more mappings as needed
+    }
+
+    parsed_config = {}
+    for col_name, col_config in custom_config.items():
+        parsed_col_config = col_config.copy()
+
+        # Parse unit strings to shipunit objects
+        if "unit" in col_config and isinstance(col_config["unit"], str):
+            unit_str = col_config["unit"]
+            if unit_str in unit_map:
+                parsed_col_config["unit"] = unit_map[unit_str]
+            else:
+                print(f"Warning: Unknown unit '{unit_str}' for column '{col_name}', ignoring unit")
+                parsed_col_config.pop("unit", None)
+
+        if "offset_unit" in col_config and isinstance(col_config["offset_unit"], str):
+            offset_unit_str = col_config["offset_unit"]
+            if offset_unit_str in unit_map:
+                parsed_col_config["offset_unit"] = unit_map[offset_unit_str]
+            else:
+                print(f"Warning: Unknown offset unit '{offset_unit_str}' for column '{col_name}', ignoring offset unit")
+                parsed_col_config.pop("offset_unit", None)
+
+        parsed_config[col_name] = parsed_col_config
+
+    return parsed_config
+
+
+def print_default_config():
+    """Print the default configuration in JSON format."""
+    config = get_column_config()
+
+    # Convert to JSON-serializable format
+    json_config = {}
+    for col_name, col_config in config.items():
+        json_col_config = {}
+        for key, value in col_config.items():
+            if key == "unit" or key == "offset_unit":
+                # Convert units to string representation
+                if value is not None:
+                    # Try to get a reasonable string representation
+                    if hasattr(value, "_name"):
+                        json_col_config[key] = value._name
+                    else:
+                        json_col_config[key] = str(value)
+                else:
+                    json_col_config[key] = None
+            else:
+                json_col_config[key] = value
+        json_config[col_name] = json_col_config
+
+    print("Default column configuration:")
+    print(json.dumps(json_config, indent=2))
+
+
+def get_column_config(custom_config_path=None):
+    """
+    Define column configuration with transformations and units.
+
+    Args:
+        custom_config_path (str, optional): Path to custom configuration file
+
+    Returns:
+        dict: Column configuration dictionary
+    """
+    # Load custom configuration if provided
+    if custom_config_path:
+        try:
+            custom_config = load_custom_config(custom_config_path)
+            # Parse string unit representations back to shipunit objects
+            return parse_custom_config_units(custom_config)
+        except Exception as e:
+            print(f"Error: Could not load custom config: {e}")
+            sys.exit(1)
+
+    # Default configuration for each column
+    # Each column can have: index, unit, offset, scale_factor, description
+    config = {
+        "px": {
+            "index": 0,
+            "unit": u.GeV,  # Momentum in GeV
+            "description": "Momentum x-component",
+            "type": "float64",
+        },
+        "py": {
+            "index": 1,
+            "unit": u.GeV,  # Momentum in GeV
+            "description": "Momentum y-component",
+            "type": "float64",
+        },
+        "pz": {
+            "index": 2,
+            "unit": u.GeV,  # Momentum in GeV
+            "description": "Momentum z-component",
+            "type": "float64",
+        },
+        "x": {
+            "index": 3,
+            "unit": u.m,  # Position in meters
+            "description": "Position x-coordinate",
+            "type": "float64",
+        },
+        "y": {
+            "index": 4,
+            "unit": u.m,  # Position in meters
+            "description": "Position y-coordinate",
+            "type": "float64",
+        },
+        "z": {
+            "index": 5,
+            "unit": u.m,  # Position in meters
+            "offset": -68.500,  # Apply z-offset
+            "offset_unit": u.m,
+            "description": "Position z-coordinate (with detector offset)",
+            "type": "float64",
+        },
+        "id": {
+            "index": 6,
+            "description": "Particle ID",
+            "type": "int32",
+        },
+        "w": {
+            "index": 7,
+            "description": "Weight",
+            "type": "float64",
+        },
+    }
+
+    return config
+
+
+def apply_column_transformation(data_column, config):
+    """
+    Apply transformations to a data column based on its configuration.
+
+    Args:
+        data_column (numpy.ndarray): Raw data column
+        config (dict): Column configuration
+
+    Returns:
+        numpy.ndarray or shipunit quantity: Transformed data column
+    """
+    result = data_column.copy()
+
+    # Apply scale factor if specified
+    if "scale_factor" in config:
+        result = result * config["scale_factor"]
+
+    # Apply offset (before units if both are present)
+    if "offset" in config:
+        offset = config["offset"]
+        if config.get("offset_unit") is not None:
+            # If we have units, we need to handle the offset carefully
+            if config.get("unit") is not None:
+                # Both result and offset will have units
+                result = result * config["unit"] + offset * config["offset_unit"]
+            else:
+                # Only offset has units
+                result = result + offset * config["offset_unit"]
+        else:
+            # No units for offset
+            result = result + offset
+
+    # Apply units (if not already applied above)
+    if config.get("unit") is not None and "offset" not in config:
+        result = result * config["unit"]
+
+    if "type" in config:
+        result = result.astype(config["type"])
+
+    return result
+
+
+def create_root_dataframe(data, verbose=False, custom_config_path=None):
+    """
+    Create ROOT RDataFrame from numpy data using configuration-driven approach.
+
+    Args:
+        data (numpy.ndarray): Input data array with columns [px, py, pz, x, y, z, id, w]
+        verbose (bool): Enable verbose output
+        custom_config_path (str, optional): Path to custom configuration file
+
+    Returns:
+        ROOT.RDataFrame: ROOT dataframe with the converted data
+    """
+    if verbose:
+        print("Creating ROOT RDataFrame...")
+
+    # Get column configuration
+    column_config = get_column_config(custom_config_path)
+
+    # Create dataframe dictionary using configuration
+    df_dict = {}
+
+    for col_name, config in column_config.items():
+        # Extract raw data column
+        raw_data = data[:, config["index"]]
+
+        # Apply transformations
+        transformed_data = apply_column_transformation(raw_data, config)
+
+        # Store in dictionary
+        df_dict[col_name] = transformed_data
+
+        if verbose:
+            print(f"  {col_name}: {config.get('description', 'No description')}")
+            if config.get("unit"):
+                print(f"    Unit: {config['unit']}")
+            if config.get("offset"):
+                offset_unit = config.get("offset_unit", "")
+                print(f"    Offset: {config['offset']} {offset_unit}")
+            if config.get("scale_factor"):
+                print(f"    Scale factor: {config['scale_factor']}")
+
+    df = ROOT.RDF.FromNumpy(df_dict)
+
+    if verbose:
+        print(f"Created RDataFrame with {df.Count().GetValue()} entries")
+
+    return df
+
+
+def save_root_file(df, output_file, tree_name, output_format, verbose=False):
+    """
+    Save ROOT dataframe to file in specified format.
+
+    Args:
+        df (ROOT.RDataFrame): Input dataframe
+        output_file (str): Output file path
+        tree_name (str): Name of the tree/ntuple
+        output_format (str): Output format ('ttree' or 'rntuple')
+        verbose (bool): Enable verbose output
+    """
+    if verbose:
+        print(f"Saving to {output_file} in {output_format} format...")
+
+    # Set up snapshot options
+    opts = ROOT.RDF.RSnapshotOptions()
+
+    if output_format == "rntuple":
+        opts.fOutputFormat = ROOT.RDF.ESnapshotOutputFormat.kRNTuple
+        if verbose:
+            print("Using RNTuple format")
+    else:
+        # TTree is the default format
+        if verbose:
+            print("Using TTree format")
+
+    # Save the data
+    df.Snapshot(tree_name, output_file, "", opts)
+
+    if verbose:
+        print(f"Successfully saved data to {output_file}")
+
+
+def main():
+    """Convert pickled muon data to ROOT format (TTree or RNTuple)."""
+    args = parse_arguments()
+
+    # Handle special options
+    if args.list_config:
+        print_default_config()
+        return
+
+    if not args.input_file:
+        print("Error: input_file is required unless --list-config is used", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        # Load the pickled data
+        data = load_pickled_data(args.input_file, args.verbose)
+
+        # Create ROOT dataframe
+        df = create_root_dataframe(data, args.verbose, args.config)
+
+        # Save to ROOT file
+        save_root_file(df, args.output, args.tree_name, args.format, args.verbose)
+
+        print("Conversion completed successfully!")
+        print(f"Input: {args.input_file}")
+        print(f"Output: {args.output} ({args.format} format)")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shipgen/CMakeLists.txt
+++ b/shipgen/CMakeLists.txt
@@ -6,7 +6,7 @@ ship_add_library(
   SOURCES Generator.cxx Pythia8Generator.cxx Pythia6Generator.cxx tPythia6Generator.cxx
           HNLPythia8Generator.cxx DPPythia8Generator.cxx GenieGenerator.cxx
           NtupleGenerator.cxx MuonBackGenerator.cxx CosmicsGenerator.cxx
-          MuDISGenerator.cxx FixedTargetGenerator.cxx EvtCalcGenerator.cxx
+          MuDISGenerator.cxx FixedTargetGenerator.cxx EvtCalcGenerator.cxx TTreeGenerator.cxx
           TEvtGenDecayer.cxx BeamSmearingUtils.cxx MeanMaterialBudget.cxx
           ParticleGunGenerator.cxx
   LINKDEF LinkDef.h

--- a/shipgen/LinkDef.h
+++ b/shipgen/LinkDef.h
@@ -22,5 +22,6 @@
 #pragma link C++ class FixedTargetGenerator - ;
 #pragma link C++ class ParticleGunGenerator - ;
 #pragma link C++ class EvtCalcGenerator - ;
+#pragma link C++ class SHiP::TTreeGenerator - ;
 #pragma link C++ class TEvtGenDecayer - ;
 #endif

--- a/shipgen/TTreeGenerator.cxx
+++ b/shipgen/TTreeGenerator.cxx
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
+// Collaboration
+
+#include "TTreeGenerator.h"
+
+#include "FairLogger.h"
+
+namespace SHiP {
+
+TTreeGenerator::TTreeGenerator()
+    : Generator(),
+      fInputFile(nullptr),
+      fInputTree(nullptr),
+      fTreeName("events"),
+      fNEvents(0),
+      fCurrentEvent(0),
+      fPx(0),
+      fPy(0),
+      fPz(0),
+      fX(0),
+      fY(0),
+      fZ(0),
+      fPdgId(0),
+      fWeight(1.0) {}
+
+TTreeGenerator::~TTreeGenerator() {
+  if (fInputFile) {
+    fInputFile->Close();
+    delete fInputFile;
+  }
+}
+
+Bool_t TTreeGenerator::Init(const char* fileName) { return Init(fileName, 0); }
+
+Bool_t TTreeGenerator::Init(const char* fileName, int startEvent) {
+  if (startEvent < 0) {
+    LOG(ERROR) << "TTreeGenerator: startEvent must be >= 0, got " << startEvent;
+    return kFALSE;
+  }
+  fInputFile = TFile::Open(fileName, "READ");
+  if (!fInputFile || fInputFile->IsZombie()) {
+    LOG(ERROR) << "TTreeGenerator: Cannot open file " << fileName;
+    return kFALSE;
+  }
+
+  fInputTree = dynamic_cast<TTree*>(fInputFile->Get(fTreeName.Data()));
+  if (!fInputTree) {
+    LOG(ERROR) << "TTreeGenerator: Cannot find tree " << fTreeName.Data()
+               << " in file " << fileName;
+    return kFALSE;
+  }
+
+  fNEvents = fInputTree->GetEntries();
+  if (startEvent >= fNEvents) {
+    LOG(ERROR) << "TTreeGenerator: startEvent " << startEvent
+               << " is out of range for " << fNEvents << " entries";
+    return kFALSE;
+  }
+  fCurrentEvent = startEvent;
+  LOG(INFO) << "TTreeGenerator: Found " << fNEvents
+            << " events in tree, starting at " << startEvent;
+
+  if (!InitBranches()) {
+    return kFALSE;
+  }
+
+  return kTRUE;
+}
+
+Bool_t TTreeGenerator::ReadEvent(FairPrimaryGenerator* primGen) {
+  if (!fInputTree || fCurrentEvent >= fNEvents) {
+    return kFALSE;
+  }
+  if (fInputTree->GetEntry(fCurrentEvent) <= 0) {
+    LOG(ERROR) << "TTreeGenerator: Failed to read entry " << fCurrentEvent;
+    return kFALSE;
+  }
+
+  // Position in cm, momentum in GeV/c
+  primGen->AddTrack(fPdgId, fPx, fPy, fPz, fX, fY, fZ, -1, true, 0., 0.,
+                    fWeight);
+
+  fCurrentEvent++;
+
+  return kTRUE;
+}
+
+Bool_t TTreeGenerator::InitBranches() {
+  if (!fInputTree) return kFALSE;
+
+  bool ok = true;
+
+  ok &= (fInputTree->SetBranchAddress("px", &fPx) >= 0);
+  ok &= (fInputTree->SetBranchAddress("py", &fPy) >= 0);
+  ok &= (fInputTree->SetBranchAddress("pz", &fPz) >= 0);
+
+  ok &= (fInputTree->SetBranchAddress("x", &fX) >= 0);
+  ok &= (fInputTree->SetBranchAddress("y", &fY) >= 0);
+  ok &= (fInputTree->SetBranchAddress("z", &fZ) >= 0);
+
+  ok &= (fInputTree->SetBranchAddress("id", &fPdgId) >= 0);
+  ok &= (fInputTree->SetBranchAddress("w", &fWeight) >= 0);
+
+  if (!ok) {
+    LOG(ERROR) << "TTreeGenerator: failed to bind one or more branches";
+  }
+
+  return ok ? kTRUE : kFALSE;
+}
+
+}  // namespace SHiP

--- a/shipgen/TTreeGenerator.h
+++ b/shipgen/TTreeGenerator.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
+// Collaboration
+
+#ifndef SHIPGEN_TTREEGENERATOR_H_
+#define SHIPGEN_TTREEGENERATOR_H_
+
+#include "FairPrimaryGenerator.h"
+#include "Generator.h"
+#include "TFile.h"
+#include "TString.h"
+#include "TTree.h"
+
+class FairPrimaryGenerator;
+
+namespace SHiP {
+
+/**
+ * @class TTreeGenerator
+ * @brief A FairRoot generator that reads particle data from ROOT TTrees
+ *
+ * The expected TTree structure contains the following branches:
+ * - px, py, pz: Particle momentum components (GeV/c)
+ * - x, y, z: Particle position coordinates (cm)
+ * - id: PDG particle identification code
+ * - w: Event weight factor
+ */
+class TTreeGenerator : public Generator {
+ public:
+  TTreeGenerator();
+  ~TTreeGenerator() override;
+
+  using Generator::Init;
+  Bool_t Init(const char* fileName, int startEvent) override;
+  Bool_t Init(const char* fileName) override;
+  Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
+
+  Long64_t GetNEvents() const { return fNEvents; }
+  Long64_t GetCurrentEvent() const { return fCurrentEvent; }
+  void SetTreeName(const char* treeName) { fTreeName = treeName; }
+
+ private:
+  TFile* fInputFile;  //!< Input ROOT file pointer
+  TTree* fInputTree;  //!< Input TTree pointer
+  TString fTreeName;  //!< Name of the TTree to read
+
+  Long64_t fNEvents;       //!< Total number of events in the tree
+  Long64_t fCurrentEvent;  //!< Current event index (0-based)
+
+  Double_t fPx;      //!< Particle momentum x-component (GeV/c)
+  Double_t fPy;      //!< Particle momentum y-component (GeV/c)
+  Double_t fPz;      //!< Particle momentum z-component (GeV/c)
+  Double_t fX;       //!< Particle position x-coordinate (cm)
+  Double_t fY;       //!< Particle position y-coordinate (cm)
+  Double_t fZ;       //!< Particle position z-coordinate (cm)
+  Int_t fPdgId;      //!< PDG particle identification code
+  Double_t fWeight;  //!< Event weight factor
+
+  Bool_t InitBranches();
+};
+
+}  // namespace SHiP
+
+#endif  // SHIPGEN_TTREEGENERATOR_H_


### PR DESCRIPTION
## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run simulations from ROOT TTree inputs via a new ttree mode and event generator.
  * Experimental importer to convert pickled muon/matter datasets into ROOT output (TTree or RNTuple) with configurable column mappings.

* **Documentation**
  * Changelog updated to list the new importer and TTree generator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->