### PR TITLE
fix(simulation): MuonBack shutdown segfault from FairRootFileSink double-free (#1226)

### DIFF
--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -147,6 +147,30 @@ jobs:
         with:
           name: plots-fixed-target
           path: plots/
+  run-muonback:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@v0.9.6
+        with:
+          cache: true
+      - uses: actions/download-artifact@v8
+        with:
+          name: build
+          path: build/
+      - name: MuonBack smoke
+        run: pixi run --locked ci-sim-muonback
+      - name: Upload .root artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: root-files-muonback
+          path: sim_ci-muonback.root
   static-analysis:
     if: github.event_name == 'pull_request'
     needs: build
@@ -313,7 +337,7 @@ jobs:
   ci:
     if: always()
     runs-on: ubuntu-latest
-    needs: [build, run-sim-chain, run-fixed-target, run-tracking-benchmark]
+    needs: [build, run-sim-chain, run-fixed-target, run-tracking-benchmark, run-muonback]
     steps:
       - name: Check status of all jobs
         run: |

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -979,6 +979,7 @@ if options.muonback:
     t = fin["cbmsim"]
     fout = ROOT.TFile(tmpFile, "recreate")
     fSink = ROOT.FairRootFileSink(fout)
+    ROOT.SetOwnership(fout, False)  # FairRootFileSink's unique_ptr now owns fout
 
     sTree = t.CloneTree(0)
     nEvents = 0

--- a/pixi.toml
+++ b/pixi.toml
@@ -103,6 +103,9 @@ cmd = "python macro/run_tracking_benchmark.py -n 200 --seed 42 --tag ci-benchmar
 [tasks.ci-fixed-target]
 cmd = "python macro/run_fixedTarget.py -n 10 -e 10.0 -r 1"
 
+[tasks.ci-sim-muonback]
+cmd = "python macro/run_simScript.py -n 5 -i 100 -f tests/data/muonback_smoke.root -S 42 -s 42 --MuonBack --FollowMuon --FastMuon --tag ci-muonback"
+
 # --- CI plot rendering tasks ---
 # Wrap .github/scripts/render_plots.py for each per-job output set. The
 # CI workflow invokes these after the corresponding sim/reco step. The

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -31,7 +31,12 @@ using ShipUnit::mm;
 
 // -----   Default constructor   -------------------------------------------
 MuonBackGenerator::MuonBackGenerator()
-    : MCTrack_vec(nullptr), vetoPoints_vec(nullptr), fUseSTL(false) {
+    : MCTrack(nullptr),
+      vetoPoints(nullptr),
+      MCTrack_vec(nullptr),
+      vetoPoints_vec(nullptr),
+      fUseSTL(false),
+      fTree(nullptr) {
   followMuons = true;
 }
 // -------------------------------------------------------------------------
@@ -191,10 +196,12 @@ Bool_t MuonBackGenerator::Init(const char* fileName, const int startEvent) {
 }
 // -----   Destructor   ----------------------------------------------------
 MuonBackGenerator::~MuonBackGenerator() {
-  if (!fUseSTL) {
-    delete MCTrack;
-    delete vetoPoints;
-  }
+  delete MCTrack;
+  MCTrack = nullptr;
+  delete vetoPoints;
+  vetoPoints = nullptr;
+  delete fTree;
+  fTree = nullptr;
 }
 // -------------------------------------------------------------------------
 Bool_t MuonBackGenerator::checkDiMuon(Int_t muIndex) {
@@ -382,8 +389,3 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
 
 // -------------------------------------------------------------------------
 Int_t MuonBackGenerator::GetNevents() { return fNevents; }
-void MuonBackGenerator::CloseFile() {
-  fInputFile->Close();
-  fInputFile->Delete();
-  delete fInputFile;
-}

--- a/shipgen/MuonBackGenerator.h
+++ b/shipgen/MuonBackGenerator.h
@@ -33,7 +33,6 @@ class MuonBackGenerator : public SHiP::Generator {
   Bool_t Init(const std::vector<std::string>&) override;
 
   Int_t GetNevents();
-  void CloseFile();
   void FollowAllParticles() { followMuons = false; };
   void SetSmearBeam(Double_t sb) { fsmearBeam = sb; };
   void SetPaintRadius(Double_t r) { fPaintBeam = r; };
@@ -52,9 +51,8 @@ class MuonBackGenerator : public SHiP::Generator {
   TClonesArray* vetoPoints;                //!
   std::vector<ShipMCTrack>* MCTrack_vec;   //!
   std::vector<vetoPoint>* vetoPoints_vec;  //!
-  Bool_t fUseSTL;     //! flag to indicate if using STL vectors
-  TFile* fInputFile;  //!
-  TChain* fTree;      //!
+  Bool_t fUseSTL;  //! flag to indicate if using STL vectors
+  TChain* fTree;   //!
   int fNevents;
   float f_zOffset;  //!
   int fn;

--- a/tests/data/muonback_smoke.root
+++ b/tests/data/muonback_smoke.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b899bf9d90f38e5521791ffe666ca269f281294854fd2ee680e07707c1fa5e8c
+size 64474

--- a/tests/data/skim_muonback_smoke.py
+++ b/tests/data/skim_muonback_smoke.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+"""Create a tiny pythia8-Geant4 muon-back skim for the ci-sim-muonback smoke test.
+
+Reads the full muon-back background sample (via xrootd with a Kerberos token,
+or the public HTTPS link), copies the first N entries of the pythia8-Geant4
+TTree into tests/data/muonback_smoke.root, and exits. Re-run only if the
+sample format changes.
+"""
+
+import argparse
+from pathlib import Path
+
+import ROOT
+import shipRoot_conf
+
+shipRoot_conf.configure()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        help="Input file (HTTPS public link or root:// URL)",
+        required=True,
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).with_name("muonback_smoke.root"),
+        help="Output skim file",
+    )
+    parser.add_argument(
+        "--entries",
+        type=int,
+        default=200,
+        help="Number of entries to copy from the pythia8-Geant4 tree",
+    )
+    args = parser.parse_args()
+
+    src = ROOT.TFile.Open(args.source, "READ")
+    if not src or src.IsZombie():
+        raise SystemExit(f"Failed to open source: {args.source}")
+    tree = src.Get("pythia8-Geant4") or src.Get("cbmsim")
+    if not tree:
+        raise SystemExit("Neither pythia8-Geant4 nor cbmsim tree found in source")
+
+    out = ROOT.TFile.Open(str(args.output), "RECREATE")
+    if not out or out.IsZombie():
+        raise SystemExit(f"Failed to open output: {args.output}")
+    skim = tree.CopyTree("", "", args.entries, 0)
+    skim.Write()
+    out.Close()
+    src.Close()
+    print(f"Wrote {args.entries} entries to {args.output} ({args.output.stat().st_size} B)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **Fix #1226**: `MuonBack` post-processing in `run_simScript.py` constructed `FairRootFileSink(fout)` with a Python-owned `TFile`. `FairRootFileSink` stores the file in `std::unique_ptr<TFile>`, so at interpreter shutdown both Python and the sink deleted the same pointer, producing the segfault printed right after `Simulation finished successfully`. Relinquishing Python ownership immediately after passing `fout` to the sink resolves the crash. The harmless `QThreadStorage` lines from Geant4's Qt teardown remain; they were a coincident symptom, not the cause.
- **MuonBackGenerator cleanup**: `MCTrack` / `vetoPoints` / `fTree` were left uninitialised by the default constructor while the destructor unconditionally `delete`d the legacy raw pointers. Initialise everything to `nullptr`, add `delete fTree` (also closes the leaked `TChain` and its remote file handles), and drop the dead `fInputFile` member + `CloseFile()` method left behind by the chain-based refactor. This is a latent bug for the `pythia8-Geant4` ntuple input path that wasn't triggered by the `cbmsim`-format reproducer.
- **CI gap fix**: the existing `ci-sim` only covers the Pythia8+EvtGen path. Add a tiny 64 KB `cbmsim` skim (Git LFS, plus the script used to produce it), a `ci-sim-muonback` pixi task, and a `run-muonback` GitHub Actions job so this code path is exercised on every PR.

## Test plan

- [x] `pixi run ci-sim-muonback` — local smoke against the committed skim
- [x] Exact `--remote-input` HTTPS command from issue #1226 (`-n 5 -i 100`, otherwise identical) — clean exit, no `*** Break ***`
- [x] `pixi run ci-sim` — regression check on the Pythia8+EvtGen path
- [x] `run-muonback` GitHub Actions job (will run on this PR)

Closes #1226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI automation to run a muon-back smoke simulation and report its status in the overall workflow.
* **Tests**
  * Added a reproducible muon-back smoke test task, updated test data, and a small utility to produce trimmed test inputs.
* **Refactor**
  * Improved muon-back generator memory handling and simplified its public interface.
* **Bug Fixes**
  * Fixed temporary file ownership/cleanup in the simulation post-processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->