### PR TITLE
ci: resurrect static-analysis-push on master

### DIFF
--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -200,8 +200,14 @@ jobs:
       - name: Find C++ files
         id: files
         run: |
-          CPP_FILES=$(find . -not -path './cmake/*' -not -path './build/*' \
-            \( -name '*.cxx' -o -name '*.h' -o -name '*.cpp' -o -name '*.cc' -o -name '*.hxx' -o -name '*.hpp' \) | tr '\n' ' ')
+          CPP_FILES=$(find . \
+            -path ./.git -prune -o \
+            -path ./.pixi -prune -o \
+            -path ./.direnv -prune -o \
+            -path ./.github -prune -o \
+            -path ./build -prune -o \
+            -path ./cmake -prune -o \
+            -type f \( -name '*.cxx' -o -name '*.h' -o -name '*.cpp' -o -name '*.cc' -o -name '*.hxx' -o -name '*.hpp' \) -print | tr '\n' ' ')
           echo "cpp=$CPP_FILES" >> "$GITHUB_OUTPUT"
       - name: clang-tidy
         if: steps.files.outputs.cpp != ''
@@ -211,7 +217,7 @@ jobs:
         run: pixi run --locked ci-clang-tidy
       - name: pyrefly
         continue-on-error: true
-        run: pixi run --locked -- pyrefly check --output-format=github
+        run: pixi run --locked -- pyrefly check --output-format=github python macro
   deploy-plots:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ ignore-words-list = 'Millepede,Gaus,gaus,dYIn,te,KNO,kno'
 [tool.pyrefly]
 python-version = "3.12"
 search-path = ["python", "stubs"]
+project-excludes = [".pixi/**", "build/**", ".direnv/**"]
 
 replace-imports-with-any = [
     "rootUtils", "rootUtils.*",


### PR DESCRIPTION
## Summary

The `static-analysis-push` job has been silently broken on master since the pixi migration. Both steps were soft-failing under `continue-on-error: true`:

- **clang-tidy**: bash aborted with *Argument list too long* before it ran. The `find` only pruned `./cmake/` and `./build/`, so it scooped up the entire `.pixi/envs/default/include/**` tree (thousands of conda env headers) and produced a `CPP_FILES` value larger than the shell argument limit.
- **pyrefly**: died on a symlink loop in `.pixi/envs/default/include/event/event/event/…` (xrootd headers) with *Too many levels of symbolic links*.

You can see this on every recent master run, e.g. run [27371184728](https://github.com/ShipSoft/FairShip/actions/runs/27371184728) where both steps fail at the very first second.

## Changes

1. `.github/workflows/pixi-build.yml` — switch the C++ discovery `find` to a `-prune` form that short-circuits descent into `.pixi`, `.direnv`, `.git`, `.github`, `build`, `cmake`. File count drops from tens of thousands to ~170.
2. `.github/workflows/pixi-build.yml` — pass explicit Python source roots (`python macro`) to the push-mode `pyrefly check` so it never visits the conda env.
3. `pyproject.toml` — add `project-excludes = [".pixi/**", "build/**", ".direnv/**"]` under `[tool.pyrefly]` so a developer running bare `pyrefly check` from the repo root also avoids the symlink loop. (Note: pyrefly ignores `project_excludes` when files/paths are passed on the CLI, so this is for local DX only; the CI invocation is also covered by the explicit-paths change above.)

`continue-on-error: true` is kept for now so a real regression doesn't immediately turn master red — revisit after a few clean runs.

## Notes for reviewers

- The `-prune ./.github` line excludes any future C++ tooling under `.github/`. Currently there's none, but worth flagging.
- This is PR 1 of 3 addressing CI static-analysis health; PR-B narrows the clang-tidy header filter, PR-C handles the leftover splitcalCluster `ClassDef` → `ClassDefOverride`.

## Test plan

- [x] Local find produces 167 in-repo C++ files (vs ~50k previously)
- [x] `pyrefly check --output-format=github python macro` completes, surfaces 168 pre-existing type errors (no symlink-loop crash)
- [ ] CI on this PR: `static-analysis-push` job runs both steps to completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow by refining C++ file discovery to exclude non-source directories.
  * Enhanced static analysis configuration by specifying directories to exclude from code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->