### PR TITLE
ci: scope clang-tidy to repo headers and pin its include path

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: '^(?!.*/(\.pixi|\.direnv|build|cmake)/).*\.(h|hpp|hxx)$'
 # disable clang-analyzer-core.UndefinedBinaryOperatorResult
 #   ROOT throws lots of them in their headers
 # Bugprone:

--- a/pixi.toml
+++ b/pixi.toml
@@ -124,7 +124,7 @@ cmd = "python .github/scripts/render_plots.py *_run_fixedTarget_1/*.root --outpu
 # expansion.
 
 [tasks.ci-clang-tidy]
-cmd = "bash -c 'set -o pipefail; echo $CPP_FILES | xargs -P $(nproc) clang-tidy -p build/ 2>&1 | python .github/scripts/annotate_build.py'"
+cmd = "bash -c 'set -o pipefail; GCC_INC=$(x86_64-conda-linux-gnu-gcc -print-file-name=include); echo $CPP_FILES | xargs -P $(nproc) clang-tidy -p build/ --extra-arg-before=-isystem$GCC_INC 2>&1 | python .github/scripts/annotate_build.py'"
 
 [tasks.ci-pyrefly]
 cmd = "pyrefly check --output-format=github $PY_FILES"


### PR DESCRIPTION
## Summary

Cleans up the two reasons clang-tidy was producing noisy or broken PR annotations:

### 1. `HeaderFilterRegex: '.*'` is too broad

clang-tidy was reporting warnings against every header it transitively included — including everything under `.pixi/envs/*` (ROOT, Geant4VMC, conda toolchain). PR #1225's `static-analysis` check accumulated 18 annotations, *all* in headers we don't own (`vmc/TMCManagerStack.h`, `TMath.h`, `TRandom.h`).

Tighten to a negative lookahead that excludes anything under `.pixi`, `.direnv`, `build`, `cmake`:

```yaml
HeaderFilterRegex: '^(?!.*/(\.pixi|\.direnv|build|cmake)/).*\.(h|hpp|hxx)$'
```

clang-tidy's `<regex>` uses ECMAScript flavor, which supports lookahead.

### 2. `'stdarg.h'/'stddef.h' file not found`

Every translation unit emitted a `clang-diagnostic-error: 'stdarg.h' file not found` (also visible on PR #1225). Root cause: `clang-tools` (LLVM 22.1) doesn't ship its libclang builtin headers in a discoverable location, and the `compile_commands.json` records the conda-forge gcc driver, whose internal include path is normally injected implicitly. Without a compiler driver in the loop, clang-tidy couldn't find the toolchain's freestanding headers.

Fix in `pixi.toml` `[tasks.ci-clang-tidy]`: ask the gcc driver for its include directory and pass it as `-isystem`:

```toml
cmd = "bash -c 'set -o pipefail; GCC_INC=\$(x86_64-conda-linux-gnu-gcc -print-file-name=include); echo \$CPP_FILES | xargs -P \$(nproc) clang-tidy -p build/ --extra-arg-before=-isystem\$GCC_INC 2>&1 | python .github/scripts/annotate_build.py'"
```

`x86_64-conda-linux-gnu-gcc -print-file-name=include` resolves to `…/lib/gcc/x86_64-conda-linux-gnu/<ver>/include`, which is where the conda toolchain stores `stdarg.h`, `stddef.h`, etc.

## After

Running locally on splitcalCluster.cxx:

- before: 1 clang-diagnostic-error (stddef.h missing), 60 non-user-code warnings reported, 2 in-repo warnings reported
- after: 0 errors, 61 non-user-code warnings suppressed by the new regex, 2 in-repo `modernize-use-equals-default` warnings cleanly surfaced

## Notes

- This is PR 2 of 3 addressing CI static-analysis health (PR-A #1228 fixes the file discovery; PR-C addresses the splitcalCluster `ClassDef` warning).
- If a future clang-tools refresh drops ECMAScript lookahead support, fall back to an explicit subdirectory allowlist.
- After this lands, in-tree warnings previously drowned out by `.pixi/` noise may surface — that's the intent; address them in follow-ups.

## Test plan

- [x] `CPP_FILES=splitcal/splitcalCluster.cxx pixi run --locked ci-clang-tidy` — 0 errors, 2 in-repo warnings
- [x] `CPP_FILES=strawtubes/strawtubes.cxx pixi run --locked ci-clang-tidy` — 0 errors, 2 in-repo warnings, 80 non-user suppressed
- [ ] CI on this PR: static-analysis check shows only repo-internal annotations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved static analysis configuration and compiler include path setup for development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->