### PR TITLE
style: use ClassDefOverride in splitcalCluster

### DIFF
--- a/splitcal/splitcalCluster.h
+++ b/splitcal/splitcalCluster.h
@@ -80,7 +80,7 @@ class splitcalCluster : public TObject {
   std::vector<int> _hitIndices;
   std::vector<double> _hitWeights;
 
-  ClassDef(splitcalCluster, 4);
+  ClassDefOverride(splitcalCluster, 4);
 };
 
 #endif  // SPLITCAL_SPLITCALCLUSTER_H_


### PR DESCRIPTION
## Summary

Removes the last four `-Winconsistent-missing-override` warnings emitted by rootcling on every master build (latest [27371184728](https://github.com/ShipSoft/FairShip/actions/runs/27371184728)):

```
input_line_9:336:3: warning: 'CheckTObjectHashConsistency' overrides ... [-Winconsistent-missing-override]
input_line_9:336:3: warning: 'IsA' overrides ... [-Winconsistent-missing-override]
input_line_9:336:3: warning: 'ShowMembers' overrides ... [-Winconsistent-missing-override]
input_line_9:336:3: warning: 'Streamer' overrides ... [-Winconsistent-missing-override]
```

They come from rootcling generating the `G__splitcal` dictionary: `ClassDef` produces overrides of `TObject::IsA()`, `::Streamer()`, etc., without the `override` keyword.

PR #1213 swept the rest of the tree to `ClassDefOverride`; `splitcalCluster` was the only remaining TObject-derived header still using plain `ClassDef`.

## Note on ShipFieldMaker.h

`field/ShipFieldMaker.h` also still uses plain `ClassDef`, but it inherits from `TG4VUserPostDetConstruction`, whose `IsA()`/`Streamer()` are not virtual. Switching it to `ClassDefOverride` causes rootcling to error out with *only virtual member functions can be marked override*. Leaving it on `ClassDef` is correct — the build is silent there.

## Test plan

- [x] `pixi run --locked build` — zero `-Winconsistent-missing-override` warnings (was 4)
- [x] Build completes 132/132 steps
- [x] No behavioural change — `ClassDefOverride` is the same macro with `override` on the generated TObject virtuals

This is PR 3 of 3 addressing CI static-analysis health alongside PR #1228 (workflow find/pyrefly) and the upcoming clang-tidy header-filter PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal class registration mechanism for improved framework compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->