### PR TITLE
ci: drop annotations for diagnostics in third-party trees

### DIFF
--- a/.github/scripts/annotate_build.py
+++ b/.github/scripts/annotate_build.py
@@ -7,9 +7,10 @@
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 
-def parse_compiler_output(line):
+def parse_compiler_output(line: str) -> dict[str, Any] | None:
     """
     Parse GCC/Clang compiler output line.
 
@@ -128,6 +129,13 @@ def main() -> None:
 
         # Try to parse as compiler output
         parsed = parse_compiler_output(line)
+
+        # Drop diagnostics in third-party / generated trees. clang-tidy's
+        # HeaderFilterRegex only filters check warnings, not compiler
+        # diagnostics, so clang-diagnostic-* errors from conda gcc intrinsic
+        # headers (.pixi/envs/.../include/ia32intrin.h etc.) leak through.
+        if parsed and any(seg in parsed["file"] for seg in ("/.pixi/", "/.direnv/", "/build/", "/cmake/")):
+            parsed = None
 
         if parsed:
             # Create and output annotation


### PR DESCRIPTION
## Summary

clang-tidy's `HeaderFilterRegex` (added in #1229) filters check-based warnings but **not** compiler diagnostics. Errors that clang's own frontend emits — like `use of undeclared identifier '__builtin_ia32_bsrsi'` against the conda gcc intrinsic headers (`ia32intrin.h`, `adxintrin.h`, `cmpccxaddintrin.h`, `lwpintrin.h`, `movdirintrin.h`, `cetintrin.h`) — still slip through. On the most recent master run ([27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759)) there were ~20 such failure annotations, all in `.pixi/envs/default/lib/gcc/.../include/`. They eat into the 50-annotation GitHub cap and obscure the real signal from in-tree code.

## Change

Filter at the annotation layer where we already have the resolved file path. In `.github/scripts/annotate_build.py`, drop any diagnostic whose file lies under `/.pixi/`, `/.direnv/`, `/build/` or `/cmake/`. clang-tidy still prints the original line to stderr for log fidelity; we just don't surface it as a PR/master annotation.

## Test

Smoke test with a synthetic mix of inputs:

```text
.pixi/.../ia32intrin.h:41:10: error: ... [clang-diagnostic-error]      → dropped
.pixi/.../TMath.h:287:20: note: ...                                    → dropped
Detector/DetectorPoint.cxx:11:45: warning: ... [perf-...]              → kept
build/foo/G__Bar.cxx:99:1: error: bogus generated-code error           → dropped
```

After the filter, `Annotation Summary` reports `Errors: 0, Warnings: 1, Notices: 0` and only the `DetectorPoint.cxx` annotation is emitted.

## Notes

This is PR 1 in a follow-up series cleaning up the lints surfaced by the now-functioning `static-analysis-push` job (per-category PRs to come for `modernize-use-equals-default`, `modernize-use-nullptr`, `performance-unnecessary-value-param`, …).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build diagnostics from third-party and generated sources are now filtered out from compilation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->