### PR TITLE
style: use nullptr instead of NULL or 0 for pointer literals

### DIFF
--- a/UpstreamTagger/UpstreamTagger.cxx
+++ b/UpstreamTagger/UpstreamTagger.cxx
@@ -47,14 +47,14 @@ using std::endl;
 UpstreamTagger::UpstreamTagger()
     : Detector("UpstreamTagger", kTRUE, kUpstreamTagger),
       det_zPos(0),
-      UpstreamTagger_fulldet(0),
-      scoringPlaneUBText(0) {}
+      UpstreamTagger_fulldet(nullptr),
+      scoringPlaneUBText(nullptr) {}
 
 UpstreamTagger::UpstreamTagger(const char* name, Bool_t active)
     : Detector(name, active, kUpstreamTagger),
       det_zPos(0),
-      UpstreamTagger_fulldet(0),
-      scoringPlaneUBText(0) {}
+      UpstreamTagger_fulldet(nullptr),
+      scoringPlaneUBText(nullptr) {}
 
 Bool_t UpstreamTagger::ProcessHits(FairVolume* vol) {
   /** This method is called from the MC stepping */

--- a/field/ShipFieldMaker.cxx
+++ b/field/ShipFieldMaker.cxx
@@ -725,7 +725,7 @@ void ShipFieldMaker::setAllRegionFields() {
     Double_t scale = theInfo.scale_;
 
     // Find the volume
-    TGeoVolume* theVol(0);
+    TGeoVolume* theVol(nullptr);
     if (gGeoManager) {
       theVol = gGeoManager->FindVolumeFast(volName.Data());
     }
@@ -844,7 +844,7 @@ void ShipFieldMaker::setAllLocalFields() {
     TString fieldName = theInfo.fieldName_;
     Double_t scale = theInfo.scale_;
 
-    TGeoVolume* theVol(0);
+    TGeoVolume* theVol(nullptr);
     if (gGeoManager) {
       theVol = gGeoManager->FindVolumeFast(volName.Data());
     }
@@ -993,7 +993,7 @@ void ShipFieldMaker::getTransformation(const TString& volName,
   theInfo.theta_ = 0.0;
   theInfo.psi_ = 0.0;
 
-  TGeoMatrix* theMatrix(0);
+  TGeoMatrix* theMatrix(nullptr);
 
   TGeoVolume* topVolume = gGeoManager->GetTopVolume();
   if (!topVolume) {
@@ -1008,7 +1008,7 @@ void ShipFieldMaker::getTransformation(const TString& volName,
   }
 
   // Find the geometry node that matches the required name
-  theNode_ = 0;
+  theNode_ = nullptr;
   gotNode_ = kFALSE;
   this->findNode(topVolume, volName);
 
@@ -1080,8 +1080,8 @@ void ShipFieldMaker::findNode(TGeoVolume* aVolume, const TString& volName) {
 }
 
 TVirtualMagField* ShipFieldMaker::getVolumeField(const TString& volName) const {
-  TVirtualMagField* theField(0);
-  TGeoVolume* theVol(0);
+  TVirtualMagField* theField(nullptr);
+  TGeoVolume* theVol(nullptr);
   if (gGeoManager) {
     theVol = gGeoManager->FindVolumeFast(volName.Data());
   }
@@ -1114,7 +1114,7 @@ Bool_t ShipFieldMaker::gotField(const TString& name) const {
 }
 
 TVirtualMagField* ShipFieldMaker::getField(const TString& name) const {
-  TVirtualMagField* theField(0);
+  TVirtualMagField* theField(nullptr);
 
   // Iterate over the internal map and see if we have a match
   SFMap::const_iterator iter;
@@ -1179,7 +1179,7 @@ void ShipFieldMaker::plotField(Int_t type, const TVector3& xAxis,
     theHist[icomponent] =
         TH2D(Form("theHist[%i]", icomponent), titles[icomponent].data(), Nx,
              xMin, xMax, Ny, yMin, yMax);
-    theHist[icomponent].SetDirectory(0);
+    theHist[icomponent].SetDirectory(nullptr);
     if (type == 0) {
       // x-y
       theHist[icomponent].SetXTitle("x (cm)");

--- a/muonShieldOptimization/pyFairModule.cxx
+++ b/muonShieldOptimization/pyFairModule.cxx
@@ -9,13 +9,13 @@
 
 void call_python_method(PyObject* self, const char* method) {
   // check arguments
-  if (0 == self || 0 == method) {
+  if (nullptr == self || nullptr == method) {
     throw std::runtime_error("Invalid Python object and method");
   }
   // call Python
   PyObject* r = PyObject_CallMethod(self, const_cast<char*>(method),
                                     const_cast<char*>(""));
-  if (0 == r) {
+  if (nullptr == r) {
     PyErr_Print();
     return;
   }

--- a/passive/ShipGeoCave.cxx
+++ b/passive/ShipGeoCave.cxx
@@ -38,7 +38,7 @@ Bool_t ShipGeoCave::read(std::fstream& fin, FairGeoMedia* media) {
   }
   const Int_t maxbuf = 256;
   char buf[maxbuf];
-  FairGeoNode* volu = 0;
+  FairGeoNode* volu = nullptr;
   FairGeoMedium* medium;
   Bool_t rc = kTRUE;
   do {
@@ -81,7 +81,7 @@ Bool_t ShipGeoCave::read(std::fstream& fin, FairGeoMedia* media) {
     masterNodes->Add(new FairGeoNode(*volu));
   } else {
     delete volu;
-    volu = 0;
+    volu = nullptr;
     rc = kFALSE;
   }
   return rc;

--- a/passive/ShipPassiveContFact.cxx
+++ b/passive/ShipPassiveContFact.cxx
@@ -55,5 +55,5 @@ FairParSet* ShipPassiveContFact::createContainer(FairContainer* c) {
    }
    return p;
  */
-  return 0;
+  return nullptr;
 }

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -268,7 +268,7 @@ void ShipStack::UpdateTrackIndex(TRefArray* detList) {
     track.SetMotherId((*fIndexIter).second);
   }
 
-  if (fDetList == 0) {
+  if (fDetList == nullptr) {
     // Now iterate through all active detectors
     fDetIter = detList->MakeIterator();
     fDetIter->Reset();

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -134,7 +134,7 @@ class ShipStack : public FairGenericStack {
   void FillTrackArray() override;
 
   /** Update the track index in the MCTracks and MCPoints **/
-  void UpdateTrackIndex(TRefArray* detArray = 0) override;
+  void UpdateTrackIndex(TRefArray* detArray = nullptr) override;
 
   /** Resets arrays and stack and deletes particles and tracks **/
   void Reset() override;

--- a/shipgen/DPPythia8Generator.cxx
+++ b/shipgen/DPPythia8Generator.cxx
@@ -32,7 +32,7 @@ DPPythia8Generator::DPPythia8Generator() {
   fLmax = 12000. * cm;  // mm maximum decay position z
   fFDs = 7.7 / 10.4;  // correction for Pythia6 to match measured Ds production
   fpbrem = kFALSE;
-  fpbremPDF = 0;
+  fpbremPDF = nullptr;
   fsmearBeam = 8 * mm;  // default value for smearing beam (8 mm)
   fPaintBeam = 5 * cm;  // default value for painting beam (5 cm)
   fdy = kFALSE;

--- a/shipgen/MeanMaterialBudget.cxx
+++ b/shipgen/MeanMaterialBudget.cxx
@@ -80,7 +80,7 @@ double MeanMaterialBudget(std::span<const double, 3> start,
   dir[2] = (end[2] - start[2]) * invlen;
 
   // Initialise start point and direction
-  TGeoNode* currentnode = 0;
+  TGeoNode* currentnode = nullptr;
   TGeoNode* startnode = gGeoManager->InitTrack(start.data(), dir);
   if (!startnode) {
     LOG(error) << "MeanMaterialBudget: start point out of geometry: x "

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -39,9 +39,9 @@ Bool_t MuDISGenerator::Init(const char* fileName, const int startEvent) {
     return kFALSE;
   }
 
-  iMuon = 0;
-  dPart = 0;
-  dPartSoft = 0;
+  iMuon = nullptr;
+  dPart = nullptr;
+  dPartSoft = nullptr;
   fInputFile = TFile::Open(fileName, "READ");
   if (!fInputFile || fInputFile->IsZombie()) {
     LOG(error) << "MuDISGenerator: error opening input file " << fileName;

--- a/strawtubes/strawtubesContFact.cxx
+++ b/strawtubes/strawtubesContFact.cxx
@@ -47,5 +47,5 @@ FairParSet* strawtubesContFact::createContainer(FairContainer* c) {
    }
    return p;
  */
-  return 0;
+  return nullptr;
 }

--- a/veto/vetoContFact.cxx
+++ b/veto/vetoContFact.cxx
@@ -47,5 +47,5 @@ FairParSet* vetoContFact::createContainer(FairContainer* c) {
    }
    return p;
  */
-  return 0;
+  return nullptr;
 }


### PR DESCRIPTION
## Summary

Sweeps the 27 `modernize-use-nullptr` findings on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759): `NULL` or `0` used as null-pointer constants across `field/ShipFieldMaker.cxx`, `UpstreamTagger/UpstreamTagger.cxx`, `muonShieldOptimization/pyFairModule.cxx`, the `*ContFact.cxx` files, `passive/ShipGeoCave.cxx`, `passive/ShipPassiveContFact.cxx`, `shipdata/ShipStack.{cxx,h}`, `shipgen/{DPPythia8Generator,MeanMaterialBudget,MuDISGenerator}.cxx`.

## Approach

`clang-tidy --fix --checks='-*,modernize-use-nullptr'` applied 26 sites mechanically. `shipdata/ShipStack.h:137`'s default-argument `TRefArray* detArray = 0` was hand-edited because clang-tidy doesn't write to headers by default in this configuration.

## Test plan

- [x] `pixi run --locked build` — clean (53/53 incremental, 0 warnings)
- [x] `CPP_FILES=<all-touched> pixi run --locked ci-clang-tidy` reports 0 `modernize-use-nullptr` findings on the modified files
- [x] No behavioural change — `nullptr` and `(T*)0` are the same value but `nullptr` survives overload resolution against integer types

Per-category clean-up series following #1228, #1229, #1230.