### PR TITLE
cleanup: drop unused speedOfLight constants

### DIFF
--- a/TimeDet/TimeDetHit.cxx
+++ b/TimeDet/TimeDetHit.cxx
@@ -19,10 +19,6 @@
 using std::cout;
 using std::endl;
 
-namespace {
-constexpr Double_t speedOfLight = 29.9792458;  // TMath::C() * 100 / 1e9, cm/ns
-}  // namespace
-
 // -----   Default constructor   --------------
 TimeDetHit::TimeDetHit() : SHiP::DetectorHit() {}
 

--- a/splitcal/splitcalHit.cxx
+++ b/splitcal/splitcalHit.cxx
@@ -26,9 +26,6 @@
 using std::cout;
 using std::endl;
 
-namespace {
-constexpr Double_t speedOfLight = 29.9792458;  // TMath::C() * 100 / 1e9, cm/ns
-}  // namespace
 // -----   Default constructor   -------------------------------------------
 splitcalHit::splitcalHit() : SHiP::DetectorHit() {}
 // -----   Standard constructor   ------------------------------------------


### PR DESCRIPTION
## Summary

`constexpr Double_t speedOfLight = 29.9792458;` in `TimeDet/TimeDetHit.cxx:23` and `splitcal/splitcalHit.cxx:30` is never read by either translation unit. The anonymous namespace only narrowed the unused-variable diagnostic to file scope. clang-tidy flagged both as `clang-diagnostic-unused-const-variable` on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759).

Delete the constants and their empty anonymous-namespace wrappers.

## Test plan

- [x] `pixi run --locked build` — clean (133/133, 0 warnings)
- [x] grep confirms no other references to `speedOfLight` in either file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal constants from detector and calorimeter subsystems throughout the codebase to enhance code cleanliness and maintainability. These routine cleanup activities reduce technical debt and improve overall code quality across multiple components. The modifications are purely internal and do not affect any user-visible functionality, performance characteristics, or system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->