### PR TITLE
style: replace using-namespace ShipUnit with using-declarations

### DIFF
--- a/SND/SiliconTarget/SiliconTarget.cxx
+++ b/SND/SiliconTarget/SiliconTarget.cxx
@@ -23,7 +23,8 @@
 #include "FairVolume.h"
 #include "TVirtualMC.h"
 
-using namespace ShipUnit;
+using ShipUnit::mm;
+using ShipUnit::um;
 
 SiliconTarget::SiliconTarget()
     : Detector("SiliconTarget", kTRUE, kSiliconTarget) {}


### PR DESCRIPTION
## Summary

`SND/SiliconTarget/SiliconTarget.cxx:26` was the last `using namespace …` flagged by clang-tidy (`google-build-using-namespace`) on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759). A grep across the file showed only `mm` and `um` from `ShipUnit` are referenced, so import those two symbols explicitly instead of pulling in the whole namespace.

## Test plan

- [x] `pixi run --locked build` — clean
- [x] grep confirms no other ShipUnit symbols used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code organization improvements with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->