### PR TITLE
fix: use size_t for ShipMuonShield corner-index loop

### DIFF
--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -243,8 +243,8 @@ void ShipMuonShield::CreateMagnet(
   std::ranges::transform(cornersCLBA, cornersCRTA.begin(), std::negate{});
   std::ranges::transform(cornersTL, cornersBR.begin(), std::negate{});
   // Need to change order as corners need to be defined clockwise
-  for (int i = 0; i < 8; ++i) {
-    int j = (11 - i) % 8;
+  for (std::size_t i = 0; i < 8; ++i) {
+    const std::size_t j = (11 - i) % 8;
     cornersCLTA[2 * j] = cornersCLBA[2 * i];
     cornersCLTA[2 * j + 1] = -cornersCLBA[2 * i + 1];
     cornersTR[2 * j] = -cornersTL[2 * i];


### PR DESCRIPTION
## Summary

`passive/ShipMuonShield.cxx:246` reorders an 8-element corner array. Loop counter `i` and derived `j` were `int`, so the four `cornersCLTA[2*j]` / `cornersCLBA[2*i]` subscripts each triggered `bugprone-implicit-widening-of-multiplication-result` on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759): `int * int` promoted to `size_type` (`unsigned long`) for the subscript.

With `N == 8` there's no actual overflow risk, but the diagnostic is correct — use the natural index type.

## Change

Promote `i` and `j` to `std::size_t`; the rest of the body is unchanged.

## Test plan

- [x] `pixi run --locked build` clean
- [x] `CPP_FILES=passive/ShipMuonShield.cxx pixi run --locked ci-clang-tidy` reports 0 `bugprone-implicit-widening` findings on this file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code robustness through modernized patterns, maintaining full compatibility with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->