### PR TITLE
fix(exitHadronAbsorber): chain Initialize through immediate parent

### DIFF
--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -84,7 +84,7 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
 }
 
 void exitHadronAbsorber::Initialize() {
-  FairDetector::Initialize();
+  SHiP::Detector<vetoPoint>::Initialize();
   TSeqCollection* fileList = gROOT->GetListOfFiles();
   fout = dynamic_cast<TFile*>(fileList->At(0));
   // book hists for Genie neutrino momentum distribution


### PR DESCRIPTION
## Summary

`exitHadronAbsorber : public SHiP::Detector<vetoPoint>`'s `Initialize` override directly called `FairDetector::Initialize()`, skipping its own parent `SHiP::Detector<vetoPoint>::Initialize` — which today just forwards to `FairDetector::Initialize()`, but is a definition that could grow setup logic this override would silently bypass.

clang-tidy flagged the call site as `bugprone-parent-virtual-call` on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759); the diagnostic message itself suggested `SHiP::Detector` as the intended base. Route through the immediate base.

## Test plan

- [x] `pixi run --locked build` clean
- [x] `CPP_FILES=muonShieldOptimization/exitHadronAbsorber.cxx pixi run --locked ci-clang-tidy` reports 0 `bugprone-parent-virtual-call` findings on this file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected detector initialization logic to use the appropriate base class initialization routine, ensuring proper setup of detector components during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->