### PR TITLE
style: import TObject::Print overload via using-declaration

### DIFF
--- a/shipdata/ShipParticle.h
+++ b/shipdata/ShipParticle.h
@@ -34,6 +34,7 @@ class ShipParticle : public TObject {
   ShipParticle& operator=(const ShipParticle& particle) = default;
 
   /**  Output to screen  **/
+  using TObject::Print;
   void Print(Int_t iTrack = 0) const;
 
   /**  Accessors - particle properties  **/

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -145,6 +145,7 @@ class ShipStack : public FairGenericStack {
   /** Output to screen
    **@param iVerbose: 0=events summary, 1=track info
    **/
+  using TObject::Print;
   virtual void Print(Int_t iVerbose = 0) const;
 
   /** Modifiers  **/

--- a/shipgen/DPPythia8Generator.h
+++ b/shipgen/DPPythia8Generator.h
@@ -35,6 +35,7 @@ class DPPythia8Generator : public SHiP::Generator {
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*) override;
   void SetParameters(char*);
+  using TObject::Print;
   void Print();
   void List(int id) { fPythia->particleData.list(id); };
 

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -50,6 +50,7 @@ class HNLPythia8Generator : public SHiP::Generator {
   /** public method ReadEvent **/
   Bool_t ReadEvent(FairPrimaryGenerator*) override;
   void SetParameters(char*);
+  using TObject::Print;
   void Print() { fPythia->settings.listAll(); };
   void List(int id) { fPythia->particleData.list(id); };
 

--- a/splitcal/splitcalCluster.h
+++ b/splitcal/splitcalCluster.h
@@ -22,6 +22,7 @@ class splitcalCluster : public TObject {
   ~splitcalCluster() override;
 
   /** Methods **/
+  using TObject::Print;
   virtual void Print() const;
 
   void SetEtaPhiE(double& eta, double& phi, double& e) {


### PR DESCRIPTION
## Summary

Five classes hide the inherited `TObject::Print(Option_t* = "") const` with their own `Print(Int_t)` or no-arg `Print()` signatures, triggering `clang-diagnostic-overloaded-virtual` on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759):

- `shipdata/ShipParticle.h:37`
- `shipdata/ShipStack.h:148`
- `shipgen/DPPythia8Generator.h:38`
- `shipgen/HNLPythia8Generator.h:53`
- `splitcal/splitcalCluster.h:25`

Each now adds `using TObject::Print;` to bring the inherited overload back into scope alongside the class's own `Print`.

## Test plan

- [x] `pixi run --locked build` clean (0 warnings)
- [x] `CPP_FILES=… pixi run --locked ci-clang-tidy` reports 0 `clang-diagnostic-overloaded-virtual` findings on these TUs
- [x] No behavioural change for the classes' own `Print()` calls; restores the base overload that callers using a `TObject*` were silently relying on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved class hierarchy consistency across multiple modules to ensure proper method inheritance and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->