### PR TITLE
fix: remove throwing static initializers

### DIFF
--- a/field/ShipFieldCreator.cxx
+++ b/field/ShipFieldCreator.cxx
@@ -17,7 +17,13 @@ using std::endl;
 
 static ShipFieldCreator gShipFieldCreator;
 
-ShipFieldCreator::ShipFieldCreator() : FairFieldFactory(), fFieldPar(nullptr) {}
+// Marked noexcept so the static `gShipFieldCreator` registration cannot trip
+// bugprone-throwing-static-initialization. FairFieldFactory's own ctor sets a
+// static pointer and never throws in practice; if that ever changes, the
+// resulting std::terminate is preferable to silently calling a destructor we
+// can't reach.
+ShipFieldCreator::ShipFieldCreator() noexcept
+    : FairFieldFactory(), fFieldPar(nullptr) {}
 
 ShipFieldCreator::~ShipFieldCreator() = default;
 

--- a/field/ShipFieldCreator.h
+++ b/field/ShipFieldCreator.h
@@ -18,7 +18,7 @@ class FairField;
 
 class ShipFieldCreator : public FairFieldFactory {
  public:
-  ShipFieldCreator();
+  ShipFieldCreator() noexcept;
   ~ShipFieldCreator() override;
   FairField* createFairField() override;
   void SetParm() override;

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -27,7 +27,7 @@ using ShipUnit::cm;
 using ShipUnit::mm;
 const Double_t c_light = 2.99792458e+10;  // speed of light in cm/sec (c_light
                                           // = 2.99792458e+8 * m/s)
-const Double_t mbarn = 1E-3 * 1E-24 * TMath::Na();  // cm^2 * Avogadro
+constexpr Double_t mbarn = 1E-3 * 1E-24 * TMath::Na();  // cm^2 * Avogadro
 
 // -----   Default constructor   -------------------------------------------
 FixedTargetGenerator::FixedTargetGenerator() {

--- a/shipgen/ParticleGunGenerator.cxx
+++ b/shipgen/ParticleGunGenerator.cxx
@@ -17,47 +17,58 @@
 #include "TH2.h"
 #include "TH3.h"
 
-static const std::map<std::string, ModelSpec> kVertexModels = {
-    {"gaussian",
-     {5, "Gaus(X), Gaus(Y), Point(Z)",
-      [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
-        p.X = (pars[1] > 0) ? gRandom->Gaus(pars[0], pars[1]) : pars[0];
-        p.Y = (pars[3] > 0) ? gRandom->Gaus(pars[2], pars[3]) : pars[2];
-        p.Z = pars[4];
-      }}},
-    {"exponential",
-     {5, "Exp(X), Exp(Y), Point(Z)",
-      [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
-        p.X = (gRandom->Uniform() > 0.5)
+// Function-local static maps so std::map's allocations happen lazily on
+// first use rather than during dynamic initialisation, where the bad_alloc
+// would propagate out as an uncatchable exception
+// (bugprone-throwing-static-initialization).
+static const std::map<std::string, ModelSpec>& kVertexModels() {
+  static const std::map<std::string, ModelSpec> models = {
+      {"gaussian",
+       {5, "Gaus(X), Gaus(Y), Point(Z)",
+        [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
+          p.X = (pars[1] > 0) ? gRandom->Gaus(pars[0], pars[1]) : pars[0];
+          p.Y = (pars[3] > 0) ? gRandom->Gaus(pars[2], pars[3]) : pars[2];
+          p.Z = pars[4];
+        }}},
+      {"exponential",
+       {5, "Exp(X), Exp(Y), Point(Z)",
+        [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
+          p.X =
+              (gRandom->Uniform() > 0.5)
                   ? gRandom->Exp(pars[1]) + pars[0]
                   : -gRandom->Exp(pars[1]) +
                         pars[0];  // Make this symmetric about a specified point
-        p.Y = (gRandom->Uniform() > 0.5) ? gRandom->Exp(pars[3]) + pars[2]
-                                         : -gRandom->Exp(pars[3]) + pars[2];
-        p.Z = pars[4];
-      }}},
-    {"uniform",
-     {5, "Uniform(X), Uniform(Y), Point(Z)",
-      [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
-        p.X = (pars[1] > 0) ? gRandom->Uniform(pars[0] - pars[1] / 2.,
-                                               pars[0] + pars[1] / 2.)
-                            : pars[1];
-        p.Y = (pars[3] > 0) ? gRandom->Uniform(pars[2] - pars[3] / 2.,
-                                               pars[2] + pars[3] / 2.)
-                            : pars[2];
-        p.Z = pars[4];
-      }}},
-};
+          p.Y = (gRandom->Uniform() > 0.5) ? gRandom->Exp(pars[3]) + pars[2]
+                                           : -gRandom->Exp(pars[3]) + pars[2];
+          p.Z = pars[4];
+        }}},
+      {"uniform",
+       {5, "Uniform(X), Uniform(Y), Point(Z)",
+        [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
+          p.X = (pars[1] > 0) ? gRandom->Uniform(pars[0] - pars[1] / 2.,
+                                                 pars[0] + pars[1] / 2.)
+                              : pars[1];
+          p.Y = (pars[3] > 0) ? gRandom->Uniform(pars[2] - pars[3] / 2.,
+                                                 pars[2] + pars[3] / 2.)
+                              : pars[2];
+          p.Z = pars[4];
+        }}},
+  };
+  return models;
+}
 
-static const std::map<int, ModelSpec> kMomentumModels = {
-    {1,
-     {6, "Gaus(Px), Gaus(Py), Landau(Pz)",
-      [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
-        p.Px = (pars[1] > 0) ? gRandom->Gaus(pars[0], pars[1]) : pars[0];
-        p.Py = (pars[3] > 0) ? gRandom->Gaus(pars[2], pars[3]) : pars[2];
-        p.Pz = (pars[5] > 0) ? gRandom->Landau(pars[4], pars[5]) : pars[4];
-      }}},
-};
+static const std::map<int, ModelSpec>& kMomentumModels() {
+  static const std::map<int, ModelSpec> models = {
+      {1,
+       {6, "Gaus(Px), Gaus(Py), Landau(Pz)",
+        [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
+          p.Px = (pars[1] > 0) ? gRandom->Gaus(pars[0], pars[1]) : pars[0];
+          p.Py = (pars[3] > 0) ? gRandom->Gaus(pars[2], pars[3]) : pars[2];
+          p.Pz = (pars[5] > 0) ? gRandom->Landau(pars[4], pars[5]) : pars[4];
+        }}},
+  };
+  return models;
+}
 
 ParticleGunGenerator::ParticleGunGenerator() : SHiP::Generator() {
   SetPhiRange();
@@ -137,7 +148,7 @@ void ParticleGunGenerator::LoadHistoFromFile(
 }
 
 Bool_t ParticleGunGenerator::Init() {
-  const auto& vertexSpec = kVertexModels.at(fVertexModel);
+  const auto& vertexSpec = kVertexModels().at(fVertexModel);
 
   if (static_cast<int>(fVertexPars.size()) != vertexSpec.expectedPars) {
     throw std::runtime_error(
@@ -321,8 +332,8 @@ void ParticleGunGenerator::OverrideFromHistogram(ParticleGunParticle& p) {
 
 void ParticleGunGenerator::SetMomentumModel(int modelNo,
                                             std::vector<Double32_t> pars) {
-  auto it = kMomentumModels.find(modelNo);
-  if (it == kMomentumModels.end()) {
+  auto it = kMomentumModels().find(modelNo);
+  if (it == kMomentumModels().end()) {
     LOG(fatal) << "ParticleGunGenerator: unknown momentum model " << modelNo;
     throw std::runtime_error("ParticleGunGenerator: unknown momentum model " +
                              std::to_string(modelNo));
@@ -351,8 +362,8 @@ void ParticleGunGenerator::SetVertexModel(const std::string& model,
   std::string lower = model;
   std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
 
-  auto it = kVertexModels.find(lower);
-  if (it == kVertexModels.end()) {
+  auto it = kVertexModels().find(lower);
+  if (it == kVertexModels().end()) {
     LOG(fatal) << "ParticleGunGenerator: unknown vertex model " << model;
     throw std::runtime_error("ParticleGunGenerator: unknown vertex model " +
                              model);
@@ -376,23 +387,23 @@ void ParticleGunGenerator::SetVertexModel(const std::string& model,
 }
 
 void ParticleGunGenerator::GenVertexModel(ParticleGunParticle& p) {
-  kVertexModels.at(fVertexModel).generate(p, fVertexPars);
+  kVertexModels().at(fVertexModel).generate(p, fVertexPars);
 }
 
 void ParticleGunGenerator::GenMomentumModel(ParticleGunParticle& p) {
-  kMomentumModels.at(fMomentumModel).generate(p, fMomentumPars);
+  kMomentumModels().at(fMomentumModel).generate(p, fMomentumPars);
 }
 
 void ParticleGunGenerator::PrintVertexModels() {
   LOG(info) << "Available vertex models:";
-  for (const auto& [id, spec] : kVertexModels)
+  for (const auto& [id, spec] : kVertexModels())
     LOG(info) << "  Model " << id << " (" << spec.expectedPars
               << " pars): " << spec.description;
 }
 
 void ParticleGunGenerator::PrintMomentumModels() {
   LOG(info) << "Available momentum models:";
-  for (const auto& [id, spec] : kMomentumModels)
+  for (const auto& [id, spec] : kMomentumModels())
     LOG(info) << "  Model " << id << " (" << spec.expectedPars
               << " pars): " << spec.description;
 }

--- a/shipgen/Pythia8Generator.cxx
+++ b/shipgen/Pythia8Generator.cxx
@@ -21,7 +21,7 @@ const Double_t cm = 10.;                  // pythia units are mm
 const Double_t c_light = 2.99792458e+10;  // speed of light in cm/sec (c_light
                                           // = 2.99792458e+8 * m/s)
 Int_t counter = 0;
-const Double_t mbarn = 1E-3 * 1E-24 * TMath::Na();  // cm^2 * Avogadro
+constexpr Double_t mbarn = 1E-3 * 1E-24 * TMath::Na();  // cm^2 * Avogadro
 
 // -----   Default constructor   -------------------------------------------
 Pythia8Generator::Pythia8Generator() {


### PR DESCRIPTION
## Summary

Five static-storage variables tripped `bugprone-throwing-static-initialization` on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759). The dynamic-init throw paths are uncatchable and force `std::terminate` before `main()` runs — fail-fast at .so load is better than a silent abort with no diagnostic.

### Per-site changes

| File | Variable | Fix |
|---|---|---|
| `field/ShipFieldCreator.cxx:18` | `gShipFieldCreator` | mark ctor `noexcept` — body only chains `FairFieldFactory()`'s ctor (which assigns a static pointer) and nulls one member; commits to never throwing |
| `shipgen/FixedTargetGenerator.cxx:30`, `shipgen/Pythia8Generator.cxx:24` | `mbarn` | promote `const` → `constexpr`; `TMath::Na()` is already `constexpr`, so the expression collapses to a compile-time literal — no throw site at all |
| `shipgen/ParticleGunGenerator.cxx:20,52` | `kVertexModels`, `kMomentumModels` | wrap each `static const std::map<…>` in a function returning a const-reference to a function-local static. `std::map` allocations now happen on first call (where `bad_alloc` is recoverable) rather than at .so load. All 9 call sites updated from `kVertexModels.X` to `kVertexModels().X` |

## Test plan

- [x] `pixi run --locked build` clean (133/133, 0 warnings)
- [x] `CPP_FILES=… pixi run --locked ci-clang-tidy` reports 0 `bugprone-throwing-static-initialization` findings
- [x] No behavioural change for callers — `kVertexModels()` returns the same map; `noexcept` widens the contract but doesn't change runtime behaviour; `constexpr mbarn` is bit-for-bit identical to the previous `const`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked the default field creator constructor as non-throwing to improve robustness during initialization.
  * Switched cross-section conversion constants to compile-time `constexpr` values for both fixed-target and Pythia8 generation.

* **Refactor**
  * Updated the particle gun generator to use lazy, accessor-based initialization for vertex and momentum model lists, with lookups and validations routed through the new accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->