### PR TITLE
perf: pass non-trivial parameters by const reference

### DIFF
--- a/Detector/DetectorPoint.cxx
+++ b/Detector/DetectorPoint.cxx
@@ -8,9 +8,10 @@
 
 // -----   Standard constructor  ----------------
 SHiP::DetectorPoint::DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID,
-                                   const TVector3& pos, const TVector3& mom, Double_t tof,
-                                   Double_t length, Double_t eLoss,
-                                   Int_t pdgcode, const TVector3& Lpos, const TVector3& Lmom)
+                                   const TVector3& pos, const TVector3& mom,
+                                   Double_t tof, Double_t length,
+                                   Double_t eLoss, Int_t pdgcode,
+                                   const TVector3& Lpos, const TVector3& Lmom)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss, eventID),
       fPdgCode(pdgcode),
       fLpos{Lpos.X(), Lpos.Y(), Lpos.Z()},
@@ -18,9 +19,9 @@ SHiP::DetectorPoint::DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID,
 
 // -----   Standard constructor  ----------------
 SHiP::DetectorPoint::DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID,
-                                   const TVector3& pos, const TVector3& mom, Double_t tof,
-                                   Double_t length, Double_t eLoss,
-                                   Int_t pdgcode)
+                                   const TVector3& pos, const TVector3& mom,
+                                   Double_t tof, Double_t length,
+                                   Double_t eLoss, Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss, eventID),
       fPdgCode(pdgcode),
       fLpos{pos.X(), pos.Y(), pos.Z()},

--- a/Detector/DetectorPoint.cxx
+++ b/Detector/DetectorPoint.cxx
@@ -8,9 +8,9 @@
 
 // -----   Standard constructor  ----------------
 SHiP::DetectorPoint::DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID,
-                                   TVector3 pos, TVector3 mom, Double_t tof,
+                                   const TVector3& pos, const TVector3& mom, Double_t tof,
                                    Double_t length, Double_t eLoss,
-                                   Int_t pdgcode, TVector3 Lpos, TVector3 Lmom)
+                                   Int_t pdgcode, const TVector3& Lpos, const TVector3& Lmom)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss, eventID),
       fPdgCode(pdgcode),
       fLpos{Lpos.X(), Lpos.Y(), Lpos.Z()},
@@ -18,7 +18,7 @@ SHiP::DetectorPoint::DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID,
 
 // -----   Standard constructor  ----------------
 SHiP::DetectorPoint::DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID,
-                                   TVector3 pos, TVector3 mom, Double_t tof,
+                                   const TVector3& pos, const TVector3& mom, Double_t tof,
                                    Double_t length, Double_t eLoss,
                                    Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss, eventID),

--- a/Detector/DetectorPoint.h
+++ b/Detector/DetectorPoint.h
@@ -17,12 +17,13 @@ class DetectorPoint : public FairMCPoint {
   ~DetectorPoint() override = default;
 
   DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID, const TVector3& pos,
-                const TVector3& mom, Double_t tof, Double_t length, Double_t eLoss,
-                Int_t pdgCode, const TVector3& Lpos, const TVector3& Lmom);
+                const TVector3& mom, Double_t tof, Double_t length,
+                Double_t eLoss, Int_t pdgCode, const TVector3& Lpos,
+                const TVector3& Lmom);
 
   DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID, const TVector3& pos,
-                const TVector3& mom, Double_t tof, Double_t length, Double_t eLoss,
-                Int_t pdgCode);
+                const TVector3& mom, Double_t tof, Double_t length,
+                Double_t eLoss, Int_t pdgCode);
 
   /** Copy constructor **/
   DetectorPoint(const DetectorPoint& point) = default;

--- a/Detector/DetectorPoint.h
+++ b/Detector/DetectorPoint.h
@@ -16,12 +16,12 @@ class DetectorPoint : public FairMCPoint {
   DetectorPoint() = default;
   ~DetectorPoint() override = default;
 
-  DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID, TVector3 pos,
-                TVector3 mom, Double_t tof, Double_t length, Double_t eLoss,
-                Int_t pdgCode, TVector3 Lpos, TVector3 Lmom);
+  DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID, const TVector3& pos,
+                const TVector3& mom, Double_t tof, Double_t length, Double_t eLoss,
+                Int_t pdgCode, const TVector3& Lpos, const TVector3& Lmom);
 
-  DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID, TVector3 pos,
-                TVector3 mom, Double_t tof, Double_t length, Double_t eLoss,
+  DetectorPoint(Int_t eventID, Int_t trackID, Int_t detID, const TVector3& pos,
+                const TVector3& mom, Double_t tof, Double_t length, Double_t eLoss,
                 Int_t pdgCode);
 
   /** Copy constructor **/

--- a/SND/EmulsionTarget/TTPoint.cxx
+++ b/SND/EmulsionTarget/TTPoint.cxx
@@ -12,8 +12,9 @@ using std::endl;
 TTPoint::TTPoint() : FairMCPoint() {}
 // -------------------------------------------------------------------------
 
-TTPoint::TTPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
-                 Double_t tof, Double_t length, Double_t eLoss, Int_t pdgcode)
+TTPoint::TTPoint(Int_t trackID, Int_t detID, const TVector3& pos,
+                 const TVector3& mom, Double_t tof, Double_t length,
+                 Double_t eLoss, Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
       fPdgCode(pdgcode) {}
 

--- a/SND/EmulsionTarget/TTPoint.cxx
+++ b/SND/EmulsionTarget/TTPoint.cxx
@@ -12,7 +12,7 @@ using std::endl;
 TTPoint::TTPoint() : FairMCPoint() {}
 // -------------------------------------------------------------------------
 
-TTPoint::TTPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
+TTPoint::TTPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
                  Double_t tof, Double_t length, Double_t eLoss, Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
       fPdgCode(pdgcode) {}

--- a/SND/EmulsionTarget/TTPoint.h
+++ b/SND/EmulsionTarget/TTPoint.h
@@ -29,8 +29,8 @@ class TTPoint : public FairMCPoint {
               Bool_t emTop, Bool_t emBot,Bool_t emCESTop, Bool_t emCESBot,
      Bool_t tt, Int_t nPlate, Int_t nColumn, Int_t nRow, Int_t nWall);*/
 
-  TTPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom, Double_t tof,
-          Double_t length, Double_t eLoss, Int_t pdgCode);
+  TTPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
+          Double_t tof, Double_t length, Double_t eLoss, Int_t pdgCode);
 
   /** Destructor **/
   ~TTPoint() override;

--- a/SND/EmulsionTarget/TTPoint.h
+++ b/SND/EmulsionTarget/TTPoint.h
@@ -29,7 +29,7 @@ class TTPoint : public FairMCPoint {
               Bool_t emTop, Bool_t emBot,Bool_t emCESTop, Bool_t emCESBot,
      Bool_t tt, Int_t nPlate, Int_t nColumn, Int_t nRow, Int_t nWall);*/
 
-  TTPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t tof,
+  TTPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom, Double_t tof,
           Double_t length, Double_t eLoss, Int_t pdgCode);
 
   /** Destructor **/

--- a/SND/EmulsionTarget/TargetPoint.cxx
+++ b/SND/EmulsionTarget/TargetPoint.cxx
@@ -25,7 +25,7 @@ fEmCESBot(emCESBot),fTT(tt), fNPlate(nPlate),fNColumn(nColumn),
 fNRow(nRow),fNWall(nWall) {  }
 */
 
-TargetPoint::TargetPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
+TargetPoint::TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
                          Double_t tof, Double_t length, Double_t eLoss,
                          Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),

--- a/SND/EmulsionTarget/TargetPoint.cxx
+++ b/SND/EmulsionTarget/TargetPoint.cxx
@@ -25,9 +25,9 @@ fEmCESBot(emCESBot),fTT(tt), fNPlate(nPlate),fNColumn(nColumn),
 fNRow(nRow),fNWall(nWall) {  }
 */
 
-TargetPoint::TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
-                         Double_t tof, Double_t length, Double_t eLoss,
-                         Int_t pdgcode)
+TargetPoint::TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
+                         const TVector3& mom, Double_t tof, Double_t length,
+                         Double_t eLoss, Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
       fPdgCode(pdgcode) {}
 

--- a/SND/EmulsionTarget/TargetPoint.h
+++ b/SND/EmulsionTarget/TargetPoint.h
@@ -29,8 +29,9 @@ class TargetPoint : public FairMCPoint {
               Bool_t emTop, Bool_t emBot,Bool_t emCESTop, Bool_t emCESBot,
      Bool_t tt, Int_t nPlate, Int_t nColumn, Int_t nRow, Int_t nWall);*/
 
-  TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
-              Double_t tof, Double_t length, Double_t eLoss, Int_t pdgCode);
+  TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
+              const TVector3& mom, Double_t tof, Double_t length,
+              Double_t eLoss, Int_t pdgCode);
 
   /** Destructor **/
   ~TargetPoint() override;

--- a/SND/EmulsionTarget/TargetPoint.h
+++ b/SND/EmulsionTarget/TargetPoint.h
@@ -29,7 +29,7 @@ class TargetPoint : public FairMCPoint {
               Bool_t emTop, Bool_t emBot,Bool_t emCESTop, Bool_t emCESBot,
      Bool_t tt, Int_t nPlate, Int_t nColumn, Int_t nRow, Int_t nWall);*/
 
-  TargetPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
+  TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
               Double_t tof, Double_t length, Double_t eLoss, Int_t pdgCode);
 
   /** Destructor **/

--- a/SND/MTC/MTCDetPoint.cxx
+++ b/SND/MTC/MTCDetPoint.cxx
@@ -12,9 +12,9 @@ using std::endl;
 MTCDetPoint::MTCDetPoint() : FairMCPoint() {}
 // -------------------------------------------------------------------------
 
-MTCDetPoint::MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
-                         Double_t tof, Double_t length, Double_t eLoss,
-                         Int_t pdgcode)
+MTCDetPoint::MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
+                         const TVector3& mom, Double_t tof, Double_t length,
+                         Double_t eLoss, Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
       fPdgCode(pdgcode) {}
 

--- a/SND/MTC/MTCDetPoint.cxx
+++ b/SND/MTC/MTCDetPoint.cxx
@@ -12,7 +12,7 @@ using std::endl;
 MTCDetPoint::MTCDetPoint() : FairMCPoint() {}
 // -------------------------------------------------------------------------
 
-MTCDetPoint::MTCDetPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
+MTCDetPoint::MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
                          Double_t tof, Double_t length, Double_t eLoss,
                          Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),

--- a/SND/MTC/MTCDetPoint.h
+++ b/SND/MTC/MTCDetPoint.h
@@ -24,7 +24,7 @@ class MTCDetPoint : public FairMCPoint {
    *@param eLoss    Energy deposit [GeV]
    **/
 
-  MTCDetPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
+  MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
               Double_t tof, Double_t length, Double_t eLoss, Int_t pdgcode);
 
   /** Destructor **/

--- a/SND/MTC/MTCDetPoint.h
+++ b/SND/MTC/MTCDetPoint.h
@@ -24,8 +24,9 @@ class MTCDetPoint : public FairMCPoint {
    *@param eLoss    Energy deposit [GeV]
    **/
 
-  MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
-              Double_t tof, Double_t length, Double_t eLoss, Int_t pdgcode);
+  MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
+              const TVector3& mom, Double_t tof, Double_t length,
+              Double_t eLoss, Int_t pdgcode);
 
   /** Destructor **/
   ~MTCDetPoint() override;

--- a/SND/SiliconTarget/SiliconTargetPoint.cxx
+++ b/SND/SiliconTarget/SiliconTargetPoint.cxx
@@ -12,8 +12,8 @@ using std::endl;
 SiliconTargetPoint::SiliconTargetPoint() : FairMCPoint() {}
 // -------------------------------------------------------------------------
 
-SiliconTargetPoint::SiliconTargetPoint(Int_t trackID, Int_t detID, TVector3 pos,
-                                       TVector3 mom, Double_t tof,
+SiliconTargetPoint::SiliconTargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
+                                       const TVector3& mom, Double_t tof,
                                        Double_t length, Double_t eLoss,
                                        Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),

--- a/SND/SiliconTarget/SiliconTargetPoint.cxx
+++ b/SND/SiliconTarget/SiliconTargetPoint.cxx
@@ -12,10 +12,10 @@ using std::endl;
 SiliconTargetPoint::SiliconTargetPoint() : FairMCPoint() {}
 // -------------------------------------------------------------------------
 
-SiliconTargetPoint::SiliconTargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
-                                       const TVector3& mom, Double_t tof,
-                                       Double_t length, Double_t eLoss,
-                                       Int_t pdgcode)
+SiliconTargetPoint::SiliconTargetPoint(Int_t trackID, Int_t detID,
+                                       const TVector3& pos, const TVector3& mom,
+                                       Double_t tof, Double_t length,
+                                       Double_t eLoss, Int_t pdgcode)
     : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
       fPdgCode(pdgcode) {}
 

--- a/SND/SiliconTarget/SiliconTargetPoint.h
+++ b/SND/SiliconTarget/SiliconTargetPoint.h
@@ -25,9 +25,9 @@ class SiliconTargetPoint : public FairMCPoint {
    *@param pdgcode  PDG code of MCTrack
    **/
 
-  SiliconTargetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
-                     Double_t tof, Double_t length, Double_t eLoss,
-                     Int_t pdgcode);
+  SiliconTargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
+                     const TVector3& mom, Double_t tof, Double_t length,
+                     Double_t eLoss, Int_t pdgcode);
 
   /** Destructor **/
   ~SiliconTargetPoint() override;

--- a/SND/SiliconTarget/SiliconTargetPoint.h
+++ b/SND/SiliconTarget/SiliconTargetPoint.h
@@ -25,7 +25,7 @@ class SiliconTargetPoint : public FairMCPoint {
    *@param pdgcode  PDG code of MCTrack
    **/
 
-  SiliconTargetPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
+  SiliconTargetPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
                      Double_t tof, Double_t length, Double_t eLoss,
                      Int_t pdgcode);
 

--- a/field/ShipFieldMaker.cxx
+++ b/field/ShipFieldMaker.cxx
@@ -1287,7 +1287,7 @@ void ShipFieldMaker::plotField(Int_t type, const TVector3& xAxis,
   }
 }
 
-void ShipFieldMaker::generateFieldMap(TString fileName, const float step,
+void ShipFieldMaker::generateFieldMap(const TString& fileName, const float step,
                                       const float xRange, const float yRange,
                                       const float zRange, const float zShift) {
   std::ofstream myfile;

--- a/field/ShipFieldMaker.h
+++ b/field/ShipFieldMaker.h
@@ -282,7 +282,7 @@ class ShipFieldMaker : public TG4VUserPostDetConstruction {
   void plotField(Int_t type, const TVector3& xAxis, const TVector3& yAxis,
                  const std::string& plotFile) const;
 
-  void generateFieldMap(TString fileName, const float step = 2.5,
+  void generateFieldMap(const TString& fileName, const float step = 2.5,
                         const float xRange = 179, const float yRange = 317,
                         const float zRange = 1515.5,
                         const float zShift = -4996);

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -61,7 +61,7 @@ void ShipMuonShield::SetSNDSpace(Bool_t hole, Double_t hole_dx,
   snd_hole_dy = hole_dy;
 }
 
-void ShipMuonShield::CreateArb8(TString arbName, TGeoMedium* medium,
+void ShipMuonShield::CreateArb8(const TString& arbName, TGeoMedium* medium,
                                 Double_t dZ, std::array<Double_t, 16> corners,
                                 Int_t color, TGeoUniformMagField* magField,
                                 TGeoVolume* tShield, Double_t x_translation,
@@ -132,7 +132,7 @@ void ShipMuonShield::CreateArb8(TString arbName, TGeoMedium* medium,
 }
 
 void ShipMuonShield::CreateMagnet(
-    TString magnetName, TGeoMedium* medium, TGeoVolume* tShield,
+    const TString& magnetName, TGeoMedium* medium, TGeoVolume* tShield,
     TGeoUniformMagField* fields[4], FieldDirection fieldDirection, Double_t dX,
     Double_t dY, Double_t dX2, Double_t dY2, Double_t ratio_yoke_1,
     Double_t ratio_yoke_2, Double_t dY_yoke_1, Double_t dY_yoke_2, Double_t dZ,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -39,7 +39,7 @@ class ShipMuonShield : public FairModule {
   Bool_t snd_hole{false};
   Double_t snd_hole_dx = 0., snd_hole_dy = 0.;
 
-  void CreateArb8(TString arbName, TGeoMedium* medium, Double_t dZ,
+  void CreateArb8(const TString& arbName, TGeoMedium* medium, Double_t dZ,
                   std::array<Double_t, 16> corners, Int_t color,
                   TGeoUniformMagField* magField, TGeoVolume* top,
                   Double_t x_translation, Double_t y_translation,
@@ -58,7 +58,7 @@ class ShipMuonShield : public FairModule {
                   std::vector<Double_t>& Bgoal, std::vector<Double_t>& gapIn,
                   std::vector<Double_t>& gapOut, std::vector<Double_t>& Z);
 
-  void CreateMagnet(TString magnetName, TGeoMedium* medium, TGeoVolume* tShield,
+  void CreateMagnet(const TString& magnetName, TGeoMedium* medium, TGeoVolume* tShield,
                     TGeoUniformMagField* fields[4],
                     FieldDirection fieldDirection, Double_t dX, Double_t dY,
                     Double_t dX2, Double_t dY2, Double_t ratio_yoke_1,

--- a/passive/ShipMuonShield.h
+++ b/passive/ShipMuonShield.h
@@ -58,8 +58,8 @@ class ShipMuonShield : public FairModule {
                   std::vector<Double_t>& Bgoal, std::vector<Double_t>& gapIn,
                   std::vector<Double_t>& gapOut, std::vector<Double_t>& Z);
 
-  void CreateMagnet(const TString& magnetName, TGeoMedium* medium, TGeoVolume* tShield,
-                    TGeoUniformMagField* fields[4],
+  void CreateMagnet(const TString& magnetName, TGeoMedium* medium,
+                    TGeoVolume* tShield, TGeoUniformMagField* fields[4],
                     FieldDirection fieldDirection, Double_t dX, Double_t dY,
                     Double_t dX2, Double_t dY2, Double_t ratio_yoke_1,
                     Double_t ratio_yoke_2, Double_t dY_yoke_1,

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -63,7 +63,7 @@ FixedTargetGenerator::FixedTargetGenerator() {
   wspill = 1.;  // event weight == 1 for primary events
   heartbeat = 1000;
 }
-Bool_t FixedTargetGenerator::InitForCharmOrBeauty(TString fInName, Int_t nev,
+Bool_t FixedTargetGenerator::InitForCharmOrBeauty(const TString& fInName, Int_t nev,
                                                   Double_t npot, Int_t nStart) {
   Option = "charm";
   nEntry = nStart;

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -63,8 +63,9 @@ FixedTargetGenerator::FixedTargetGenerator() {
   wspill = 1.;  // event weight == 1 for primary events
   heartbeat = 1000;
 }
-Bool_t FixedTargetGenerator::InitForCharmOrBeauty(const TString& fInName, Int_t nev,
-                                                  Double_t npot, Int_t nStart) {
+Bool_t FixedTargetGenerator::InitForCharmOrBeauty(const TString& fInName,
+                                                  Int_t nev, Double_t npot,
+                                                  Int_t nStart) {
   Option = "charm";
   nEntry = nStart;
   // open input file with charm or beauty

--- a/shipgen/FixedTargetGenerator.h
+++ b/shipgen/FixedTargetGenerator.h
@@ -41,7 +41,7 @@ class FixedTargetGenerator : public SHiP::Generator {
   using SHiP::Generator::Init;
   Bool_t Init() override;
 
-  Bool_t InitForCharmOrBeauty(TString fInName, Int_t nev, Double_t npots = 5E13,
+  Bool_t InitForCharmOrBeauty(const TString& fInName, Int_t nev, Double_t npots = 5E13,
                               Int_t nStart = 0);
 
   void SetMom(Double_t mom) { fMom = mom; };

--- a/shipgen/FixedTargetGenerator.h
+++ b/shipgen/FixedTargetGenerator.h
@@ -41,8 +41,8 @@ class FixedTargetGenerator : public SHiP::Generator {
   using SHiP::Generator::Init;
   Bool_t Init() override;
 
-  Bool_t InitForCharmOrBeauty(const TString& fInName, Int_t nev, Double_t npots = 5E13,
-                              Int_t nStart = 0);
+  Bool_t InitForCharmOrBeauty(const TString& fInName, Int_t nev,
+                              Double_t npots = 5E13, Int_t nStart = 0);
 
   void SetMom(Double_t mom) { fMom = mom; };
   void UseRandom1() {

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -131,7 +131,7 @@ GenieGenerator::~GenieGenerator() {
   }
 }
 // -------------------------------------------------------------------------
-void GenieGenerator::AddBox(TVector3 dVec, TVector3 box) {
+void GenieGenerator::AddBox(const TVector3& dVec, const TVector3& box) {
   dVecs.push_back(dVec);
   m_boxes.push_back(box);
   cout << "Debug GenieGenerator: " << dVec.X() << " " << box.Z() << endl;

--- a/shipgen/GenieGenerator.h
+++ b/shipgen/GenieGenerator.h
@@ -38,7 +38,7 @@ class GenieGenerator : public SHiP::Generator {
     startZ = zS;
     endZ = zE;
   }
-  void AddBox(TVector3 dVec, TVector3 box);
+  void AddBox(const TVector3& dVec, const TVector3& box);
 
  private:
   std::vector<double> Rotate(Double_t x, Double_t y, Double_t z, Double_t px,

--- a/shipgen/ParticleGunGenerator.cxx
+++ b/shipgen/ParticleGunGenerator.cxx
@@ -345,7 +345,7 @@ void ParticleGunGenerator::SetMomentumModel(int modelNo,
             << spec.description << ")";
 }
 
-void ParticleGunGenerator::SetVertexModel(std::string model,
+void ParticleGunGenerator::SetVertexModel(const std::string& model,
                                           std::vector<Double32_t> pars) {
   // Normalise to lowercase so "Gaussian", "GAUSSIAN" etc. all work
   std::string lower = model;

--- a/shipgen/ParticleGunGenerator.h
+++ b/shipgen/ParticleGunGenerator.h
@@ -116,7 +116,7 @@ class ParticleGunGenerator : public SHiP::Generator {
   /** Clone this object (used in MT mode only) */
   FairGenerator* CloneGenerator() const override;
 
-  void SetVertexModel(std::string model, std::vector<Double32_t> pars);
+  void SetVertexModel(const std::string& model, std::vector<Double32_t> pars);
   void SetMomentumModel(const int modelNo, std::vector<Double32_t> pars);
 
   void PrintMomentumModels();

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -11,6 +11,7 @@
 #include <array>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 #include "FairGeoBuilder.h"
 #include "FairGeoInterface.h"
@@ -45,7 +46,7 @@ strawtubes::strawtubes()
     : Detector("strawtubes", kTRUE, kStraw), fMedium("air") {}
 
 strawtubes::strawtubes(std::string medium)
-    : Detector("strawtubes", kTRUE, kStraw), fMedium(medium) {}
+    : Detector("strawtubes", kTRUE, kStraw), fMedium(std::move(medium)) {}
 
 strawtubes::strawtubes(const char* name, Bool_t active)
     : Detector(name, active, kStraw) {}
@@ -172,7 +173,7 @@ void strawtubes::SetDeltazView(Double_t delta_z_view) {
 }
 
 void strawtubes::SetFrameMaterial(TString frame_material) {
-  f_frame_material = frame_material;  //!  Structure frame material
+  f_frame_material = std::move(frame_material);  //!  Structure frame material
 }
 
 void strawtubes::SetStationEnvelope(Double_t x, Double_t y, Double_t z) {

--- a/strawtubes/strawtubesPoint.cxx
+++ b/strawtubes/strawtubesPoint.cxx
@@ -15,9 +15,9 @@ strawtubesPoint::strawtubesPoint() : DetectorPoint() {}
 
 // -----   Standard constructor   ------------------------------------------
 strawtubesPoint::strawtubesPoint(Int_t eventID, Int_t trackID, Int_t detID,
-                                 const TVector3& pos, const TVector3& mom, Double_t tof,
-                                 Double_t length, Double_t eLoss, Int_t pdgcode,
-                                 Double_t dist)
+                                 const TVector3& pos, const TVector3& mom,
+                                 Double_t tof, Double_t length, Double_t eLoss,
+                                 Int_t pdgcode, Double_t dist)
     : DetectorPoint(eventID, trackID, detID, pos, mom, tof, length, eLoss,
                     pdgcode, pos, mom),
       fdist2Wire(dist) {}

--- a/strawtubes/strawtubesPoint.cxx
+++ b/strawtubes/strawtubesPoint.cxx
@@ -15,7 +15,7 @@ strawtubesPoint::strawtubesPoint() : DetectorPoint() {}
 
 // -----   Standard constructor   ------------------------------------------
 strawtubesPoint::strawtubesPoint(Int_t eventID, Int_t trackID, Int_t detID,
-                                 TVector3 pos, TVector3 mom, Double_t tof,
+                                 const TVector3& pos, const TVector3& mom, Double_t tof,
                                  Double_t length, Double_t eLoss, Int_t pdgcode,
                                  Double_t dist)
     : DetectorPoint(eventID, trackID, detID, pos, mom, tof, length, eLoss,

--- a/strawtubes/strawtubesPoint.h
+++ b/strawtubes/strawtubesPoint.h
@@ -26,9 +26,10 @@ class strawtubesPoint : public SHiP::DetectorPoint {
    *@param length   Track length since creation [cm]
    *@param eLoss    Energy deposit [GeV]
    **/
-  strawtubesPoint(Int_t eventID, Int_t trackID, Int_t detID, const TVector3& pos,
-                  const TVector3& mom, Double_t tof, Double_t length, Double_t eLoss,
-                  Int_t pdgcode, Double_t dist);
+  strawtubesPoint(Int_t eventID, Int_t trackID, Int_t detID,
+                  const TVector3& pos, const TVector3& mom, Double_t tof,
+                  Double_t length, Double_t eLoss, Int_t pdgcode,
+                  Double_t dist);
 
   /** Destructor **/
   ~strawtubesPoint() override;

--- a/strawtubes/strawtubesPoint.h
+++ b/strawtubes/strawtubesPoint.h
@@ -26,8 +26,8 @@ class strawtubesPoint : public SHiP::DetectorPoint {
    *@param length   Track length since creation [cm]
    *@param eLoss    Energy deposit [GeV]
    **/
-  strawtubesPoint(Int_t eventID, Int_t trackID, Int_t detID, TVector3 pos,
-                  TVector3 mom, Double_t tof, Double_t length, Double_t eLoss,
+  strawtubesPoint(Int_t eventID, Int_t trackID, Int_t detID, const TVector3& pos,
+                  const TVector3& mom, Double_t tof, Double_t length, Double_t eLoss,
                   Int_t pdgcode, Double_t dist);
 
   /** Destructor **/

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -168,9 +168,9 @@ double veto::wy(double z) {  // calculate y thickness at z
   return (wy1 + (z - z1) * (wy2 - wy1) / (z2 - z1));
 }
 
-TGeoVolume* veto::GeoSideObj(const TString& xname, double dz, double a1, double b1,
-                             double a2, double b2, double dA, double dB,
-                             Int_t color, TGeoMedium* material,
+TGeoVolume* veto::GeoSideObj(const TString& xname, double dz, double a1,
+                             double b1, double a2, double b2, double dA,
+                             double dB, Int_t color, TGeoMedium* material,
                              Bool_t sens = kFALSE) {
   // a1- width in X, at the beginning
   // b1- width in Y, at the beginning
@@ -197,10 +197,11 @@ TGeoVolume* veto::GeoSideObj(const TString& xname, double dz, double a1, double 
   return T;
 }
 
-TGeoVolume* veto::GeoCornerLiSc1(const TString& xname, double dz, bool isClockwise,
-                                 double a1, double a2, double b1, double b2,
-                                 double dA, double dB, Int_t color,
-                                 TGeoMedium* material, Bool_t sens = kFALSE) {
+TGeoVolume* veto::GeoCornerLiSc1(const TString& xname, double dz,
+                                 bool isClockwise, double a1, double a2,
+                                 double b1, double b2, double dA, double dB,
+                                 Int_t color, TGeoMedium* material,
+                                 Bool_t sens = kFALSE) {
   TGeoArb8* T1 = new TGeoArb8(dz);
 
   if (isClockwise) {
@@ -234,10 +235,11 @@ TGeoVolume* veto::GeoCornerLiSc1(const TString& xname, double dz, bool isClockwi
   return T;
 }
 
-TGeoVolume* veto::GeoCornerLiSc2(const TString& xname, double dz, bool isClockwise,
-                                 double a1, double a2, double b1, double b2,
-                                 double dA, double dB, Int_t color,
-                                 TGeoMedium* material, Bool_t sens = kFALSE) {
+TGeoVolume* veto::GeoCornerLiSc2(const TString& xname, double dz,
+                                 bool isClockwise, double a1, double a2,
+                                 double b1, double b2, double dA, double dB,
+                                 Int_t color, TGeoMedium* material,
+                                 Bool_t sens = kFALSE) {
   TGeoArb8* T1 = new TGeoArb8(dz);
 
   if (isClockwise) {
@@ -334,8 +336,8 @@ int veto::makeId(double z, double x, double y) {
          static_cast<int>(phi);
 }
 
-int veto::liscId(const TString& ShapeTypeName, int blockNr, int Zlayer, int number,
-                 int position) {
+int veto::liscId(const TString& ShapeTypeName, int blockNr, int Zlayer,
+                 int number, int position) {
   int id = 999999;
   int ShapeType = -1;
 

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -68,7 +68,7 @@ veto::veto()
   fLiquidVeto = 1;
 }
 
-TGeoVolume* veto::GeoTrapezoid(TString xname, Double_t z_thick,
+TGeoVolume* veto::GeoTrapezoid(const TString& xname, Double_t z_thick,
                                Double_t x_thick_start, Double_t x_thick_end,
                                Double_t y_thick_start, Double_t y_thick_end,
                                Int_t color, TGeoMedium* material,
@@ -168,7 +168,7 @@ double veto::wy(double z) {  // calculate y thickness at z
   return (wy1 + (z - z1) * (wy2 - wy1) / (z2 - z1));
 }
 
-TGeoVolume* veto::GeoSideObj(TString xname, double dz, double a1, double b1,
+TGeoVolume* veto::GeoSideObj(const TString& xname, double dz, double a1, double b1,
                              double a2, double b2, double dA, double dB,
                              Int_t color, TGeoMedium* material,
                              Bool_t sens = kFALSE) {
@@ -197,7 +197,7 @@ TGeoVolume* veto::GeoSideObj(TString xname, double dz, double a1, double b1,
   return T;
 }
 
-TGeoVolume* veto::GeoCornerLiSc1(TString xname, double dz, bool isClockwise,
+TGeoVolume* veto::GeoCornerLiSc1(const TString& xname, double dz, bool isClockwise,
                                  double a1, double a2, double b1, double b2,
                                  double dA, double dB, Int_t color,
                                  TGeoMedium* material, Bool_t sens = kFALSE) {
@@ -234,7 +234,7 @@ TGeoVolume* veto::GeoCornerLiSc1(TString xname, double dz, bool isClockwise,
   return T;
 }
 
-TGeoVolume* veto::GeoCornerLiSc2(TString xname, double dz, bool isClockwise,
+TGeoVolume* veto::GeoCornerLiSc2(const TString& xname, double dz, bool isClockwise,
                                  double a1, double a2, double b1, double b2,
                                  double dA, double dB, Int_t color,
                                  TGeoMedium* material, Bool_t sens = kFALSE) {
@@ -271,7 +271,7 @@ TGeoVolume* veto::GeoCornerLiSc2(TString xname, double dz, bool isClockwise,
   return T;
 }
 
-TGeoVolumeAssembly* veto::GeoCornerRib(TString xname, double ribThick,
+TGeoVolumeAssembly* veto::GeoCornerRib(const TString& xname, double ribThick,
                                        double lt1, double lt2, double dz,
                                        double slopeX, double slopeY,
                                        Int_t color, TGeoMedium* material,
@@ -334,7 +334,7 @@ int veto::makeId(double z, double x, double y) {
          static_cast<int>(phi);
 }
 
-int veto::liscId(TString ShapeTypeName, int blockNr, int Zlayer, int number,
+int veto::liscId(const TString& ShapeTypeName, int blockNr, int Zlayer, int number,
                  int position) {
   int id = 999999;
   int ShapeType = -1;

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -133,7 +133,7 @@ class veto : public SHiP::Detector<vetoPoint> {
    * dimensions of wX_start * wY_start and end cross-section dimensions of
    * wX_end *wY_end
    */
-  TGeoVolume* GeoTrapezoid(TString xname, Double_t wz, Double_t wX_start,
+  TGeoVolume* GeoTrapezoid(const TString& xname, Double_t wz, Double_t wX_start,
                            Double_t wX_end, Double_t wY_start, Double_t wY_end,
                            Int_t color, TGeoMedium* material, Bool_t sens);
 
@@ -161,7 +161,7 @@ class veto : public SHiP::Detector<vetoPoint> {
                 double liscThick1, double liscThick2, double ribThick);
   /**Definition of a Corner Rib Support Structure.
    */
-  TGeoVolumeAssembly* GeoCornerRib(TString xname, double ribThick, double lt1,
+  TGeoVolumeAssembly* GeoCornerRib(const TString& xname, double ribThick, double lt1,
                                    double lt2, double dz, double slopeX,
                                    double slopeY, Int_t color,
                                    TGeoMedium* material, Bool_t sens);
@@ -171,7 +171,7 @@ class veto : public SHiP::Detector<vetoPoint> {
   int makeId(double z, double x, double y);
   /**Detector ID implementation for the SBT
    */
-  int liscId(TString ShapeTypeName, int blockNr, int Zlayer, int number,
+  int liscId(const TString& ShapeTypeName, int blockNr, int Zlayer, int number,
              int position);
   //! slope along the width (x)
   double wx(double z);
@@ -179,18 +179,18 @@ class veto : public SHiP::Detector<vetoPoint> {
   double wy(double z);
   /**Definition of a Rib Support Structure.
    */
-  TGeoVolume* GeoSideObj(TString xname, double dz, double a1, double b1,
+  TGeoVolume* GeoSideObj(const TString& xname, double dz, double a1, double b1,
                          double a2, double b2, double dA, double dB,
                          Int_t color, TGeoMedium* material, Bool_t sens);
   /**Definition of a LiSc cell (Type 1)
    */
-  TGeoVolume* GeoCornerLiSc1(TString xname, double dz, bool isClockwise,
+  TGeoVolume* GeoCornerLiSc1(const TString& xname, double dz, bool isClockwise,
                              double a1, double a2, double b1, double b2,
                              double dA, double dB, Int_t color,
                              TGeoMedium* material, Bool_t sens);
   /**Definition of a LiSc cell (Type 2)
    */
-  TGeoVolume* GeoCornerLiSc2(TString xname, double dz, bool isClockwise,
+  TGeoVolume* GeoCornerLiSc2(const TString& xname, double dz, bool isClockwise,
                              double a1, double a2, double b1, double b2,
                              double dA, double dB, Int_t color,
                              TGeoMedium* material, Bool_t sens);

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -161,9 +161,9 @@ class veto : public SHiP::Detector<vetoPoint> {
                 double liscThick1, double liscThick2, double ribThick);
   /**Definition of a Corner Rib Support Structure.
    */
-  TGeoVolumeAssembly* GeoCornerRib(const TString& xname, double ribThick, double lt1,
-                                   double lt2, double dz, double slopeX,
-                                   double slopeY, Int_t color,
+  TGeoVolumeAssembly* GeoCornerRib(const TString& xname, double ribThick,
+                                   double lt1, double lt2, double dz,
+                                   double slopeX, double slopeY, Int_t color,
                                    TGeoMedium* material, Bool_t sens);
 
   /**Definition of ID for the support structure.


### PR DESCRIPTION
## Summary

Sweeps the 41 `performance-unnecessary-value-param` findings on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759): `TVector3`, `TString` and `std::string` parameters that the function body only reads, changed from pass-by-value to pass-by-const-reference.

## Approach

`clang-tidy --fix --checks='-*,performance-unnecessary-value-param'` applied 24 sites in 13 translation units. The FIX-IT propagated into 12 headers (`Detector/DetectorPoint.h`, `SND/*/`*Point.h`, generator helpers in `shipgen/`, `passive/ShipMuonShield.h`, `strawtubes/strawtubesPoint.h`, `veto/veto.h`).

## Safety net

Every TObject-derived virtual is now marked `override` (PR #1213 + the `splitcalCluster` follow-up), so any signature mismatch between an override and its base would have failed the build. The build still passes 88/88 incremental, and the existing `ctest` suite (`DataClassIO`, `RNtupleIO`) is green.

## Test plan

- [x] `pixi run --locked build` clean
- [x] `pixi run --locked test` — 2/2 tests pass
- [x] `CPP_FILES=<all-touched> pixi run --locked ci-clang-tidy` reports 0 `performance-unnecessary-value-param` findings

## Risks / notes

- A few of the touched functions are virtual overrides; if any FairROOT base has a `T param` signature we now pass `const T&`, the build would fail to find the override match. None did.
- No behavioural change for callers — these parameters were already read-only inside the body; the diff just avoids a `TVector3`/`TString` copy per invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal method parameter passing across detector and geometry components for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->