### PR TITLE
fix: replace atof/atoi with std::stod/std::stoi

### DIFF
--- a/field/ShipFieldMaker.cxx
+++ b/field/ShipFieldMaker.cxx
@@ -188,9 +188,9 @@ void ShipFieldMaker::defineUniform(const stringVect& inputLine) {
   if (nWords == 5) {
     const TString name(inputLine[1].c_str());
 
-    Double_t Bx = std::atof(inputLine[2].c_str());
-    Double_t By = std::atof(inputLine[3].c_str());
-    Double_t Bz = std::atof(inputLine[4].c_str());
+    Double_t Bx = std::stod(inputLine[2]);
+    Double_t By = std::stod(inputLine[3]);
+    Double_t Bz = std::stod(inputLine[4]);
     const TVector3 BVector(Bx, By, Bz);
 
     this->defineUniform(name, BVector);
@@ -233,19 +233,19 @@ void ShipFieldMaker::defineConstant(const stringVect& inputLine) {
   if (nWords == 11) {
     TString name(inputLine[1].c_str());
 
-    Double_t xMin = std::atof(inputLine[2].c_str());
-    Double_t xMax = std::atof(inputLine[3].c_str());
+    Double_t xMin = std::stod(inputLine[2]);
+    Double_t xMax = std::stod(inputLine[3]);
 
-    Double_t yMin = std::atof(inputLine[4].c_str());
-    Double_t yMax = std::atof(inputLine[5].c_str());
+    Double_t yMin = std::stod(inputLine[4]);
+    Double_t yMax = std::stod(inputLine[5]);
 
-    Double_t zMin = std::atof(inputLine[6].c_str());
-    Double_t zMax = std::atof(inputLine[7].c_str());
+    Double_t zMin = std::stod(inputLine[6]);
+    Double_t zMax = std::stod(inputLine[7]);
 
     // Input field in Tesla_, interface needs kGauss units
-    Double_t Bx = std::atof(inputLine[8].c_str());
-    Double_t By = std::atof(inputLine[9].c_str());
-    Double_t Bz = std::atof(inputLine[10].c_str());
+    Double_t Bx = std::stod(inputLine[8]);
+    Double_t By = std::stod(inputLine[9]);
+    Double_t Bz = std::stod(inputLine[10]);
 
     const TVector2 xRange(xMin, xMax);
     const TVector2 yRange(yMin, yMax);
@@ -299,19 +299,19 @@ void ShipFieldMaker::defineBell(const stringVect& inputLine) {
   if (nWords == 6 || nWords == 9) {
     TString name(inputLine[1].c_str());
 
-    Double_t BPeak = std::atof(inputLine[2].c_str());
-    Double_t zMiddle = std::atof(inputLine[3].c_str());  // cm
+    Double_t BPeak = std::stod(inputLine[2]);
+    Double_t zMiddle = std::stod(inputLine[3]);  // cm
 
-    Int_t orient = std::atoi(inputLine[4].c_str());
-    Double_t tubeR = std::atof(inputLine[5].c_str());  // cm
+    Int_t orient = std::stoi(inputLine[4]);
+    Double_t tubeR = std::stod(inputLine[5]);  // cm
 
     Double_t xy(0.0), z(0.0), L(0.0);
 
     if (nWords == 9) {
       // Specify "target" dimensions (cm)
-      xy = std::atof(inputLine[6].c_str());
-      z = std::atof(inputLine[7].c_str());
-      L = std::atof(inputLine[8].c_str());
+      xy = std::stod(inputLine[6]);
+      z = std::stod(inputLine[7]);
+      L = std::stod(inputLine[8]);
     }
 
     this->defineBell(name, BPeak, zMiddle, orient, tubeR, xy, z, L);
@@ -361,15 +361,15 @@ void ShipFieldMaker::defineFieldMap(const stringVect& inputLine,
     Double_t phi(0.0), theta(0.0), psi(0.0);
 
     if (nWords > 5) {
-      x0 = std::atof(inputLine[3].c_str());
-      y0 = std::atof(inputLine[4].c_str());
-      z0 = std::atof(inputLine[5].c_str());
+      x0 = std::stod(inputLine[3]);
+      y0 = std::stod(inputLine[4]);
+      z0 = std::stod(inputLine[5]);
     }
 
     if (nWords == 9) {
-      phi = std::atof(inputLine[6].c_str());
-      theta = std::atof(inputLine[7].c_str());
-      psi = std::atof(inputLine[8].c_str());
+      phi = std::stod(inputLine[6]);
+      theta = std::stod(inputLine[7]);
+      psi = std::stod(inputLine[8]);
     }
 
     const TVector3 localCentre(x0, y0, z0);
@@ -452,16 +452,16 @@ void ShipFieldMaker::defineFieldMapCopy(const stringVect& inputLine) {
     // We want to try to copy and transpose an already existing field map
     const TString mapNameToCopy(inputLine[2].c_str());
 
-    Double_t x0 = std::atof(inputLine[3].c_str());
-    Double_t y0 = std::atof(inputLine[4].c_str());
-    Double_t z0 = std::atof(inputLine[5].c_str());
+    Double_t x0 = std::stod(inputLine[3]);
+    Double_t y0 = std::stod(inputLine[4]);
+    Double_t z0 = std::stod(inputLine[5]);
 
     Double_t phi(0.0), theta(0.0), psi(0.0);
 
     if (nWords == 9) {
-      phi = std::atof(inputLine[6].c_str());
-      theta = std::atof(inputLine[7].c_str());
-      psi = std::atof(inputLine[8].c_str());
+      phi = std::stod(inputLine[6]);
+      theta = std::stod(inputLine[7]);
+      psi = std::stod(inputLine[8]);
     }
 
     const TVector3 translation(x0, y0, z0);
@@ -686,7 +686,7 @@ void ShipFieldMaker::defineRegionField(const stringVect& inputLine) {
 
     Double_t scale(1.0);
     if (nWords == 4) {
-      scale = std::atof(inputLine[3].c_str());
+      scale = std::stod(inputLine[3]);
     }
 
     this->defineRegionField(volName, fieldName, scale);
@@ -808,7 +808,7 @@ void ShipFieldMaker::defineLocalField(const stringVect& inputLine) {
 
     Double_t scale(1.0);
     if (nWords == 4) {
-      scale = std::atof(inputLine[3].c_str());
+      scale = std::stod(inputLine[3]);
     }
 
     this->defineLocalField(volName, fieldName, scale);

--- a/splitcal/splitcalHit.cxx
+++ b/splitcal/splitcalHit.cxx
@@ -136,19 +136,19 @@ void splitcalHit::Decoder(const std::string& encodedID, int& isPrecision,
   std::string substring;
 
   substring = encodedID.substr(0, 1);
-  isPrecision = atoi(substring.c_str());
+  isPrecision = std::stoi(substring);
 
   substring = encodedID.substr(1, 3);
-  nLayer = atoi(substring.c_str());
+  nLayer = std::stoi(substring);
 
   substring = encodedID.substr(4, 1);
-  nModuleX = atoi(substring.c_str());
+  nModuleX = std::stoi(substring);
 
   substring = encodedID.substr(5, 1);
-  nModuleY = atoi(substring.c_str());
+  nModuleY = std::stoi(substring);
 
   substring = encodedID.substr(6, 3);
-  nStrip = atoi(substring.c_str());
+  nStrip = std::stoi(substring);
 }
 
 void splitcalHit::Decoder(int id, int& isPrecision, int& nLayer, int& nModuleX,


### PR DESCRIPTION
## Summary

Sweeps the 38 `atof`/`atoi` sites in `field/ShipFieldMaker.cxx` (33) and `splitcal/splitcalHit.cxx` (5) that triggered `bugprone-unchecked-string-to-number-conversion` on master run [27465304759](https://github.com/ShipSoft/FairShip/actions/runs/27465304759).

## Why this matters

`atoi`/`atof` silently return `0` on parse failure. A malformed field-map config file would have produced silent zero magnetic fields instead of a startup error — a real footgun for a HEP simulation framework. The `std::stoi`/`std::stod` replacements throw `std::invalid_argument` or `std::out_of_range` with the offending substring, surfacing the parse error at simulation start.

## Transform

```
std::atof(s.c_str()) → std::stod(s)
std::atoi(s.c_str()) → std::stoi(s)
atoi(s.c_str())      → std::stoi(s)
```

`std::stoi`/`std::stod` take `const std::string&` directly, so the `.c_str()` is also dropped.

## Out of scope

The two `fscanf` calls in `shipgen/Pythia6Generator.cxx` (the remaining two `bugprone-unchecked-string-to-number-conversion` findings) are a different parser pattern and out of scope for this PR; they need a proper rewrite around `std::istringstream` and will be tracked separately.

## Test plan

- [x] `pixi run --locked build` clean (133/133, 0 warnings)
- [x] `pixi run --locked test` — 2/2 tests pass (DataClassIO, RNtupleIO)
- [x] `CPP_FILES=… pixi run --locked ci-clang-tidy` reports 0 `bugprone-unchecked-string-to-number-conversion` findings in the touched files

## Risks

A previously-tolerated malformed config file will now throw at startup. This is the intended fail-fast behaviour, but worth noting in case any in-flight branch relied on the silent-zero quirk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved numeric parsing robustness by replacing legacy C-style conversions with modern C++ string-to-number functions across field initialization and decoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->