### PR TITLE
fix(typing): annotate shipDet_conf module containers as heterogeneous

### DIFF
--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
+from typing import Any
+
 import os
 
 import ROOT
@@ -9,7 +11,9 @@ import shipunit as u
 import yaml
 from ShipGeoConfig import AttrDict
 
-detectorList = []
+# Holds heterogeneous FairModule subclasses (Target, MTC, ShipCave, …); annotate
+# as list[Any] so pyrefly doesn't lock the element type to the first append.
+detectorList: list[Any] = []
 
 
 def configure_snd_old(yaml_file: str, emulsion_target_z_end, cave_floorHeightMuonShield) -> None:
@@ -462,7 +466,10 @@ def configure(run, ship_geo):
     # exclusionList = ["strawtubes","TargetTrackers","NuTauTarget",\
     #                 "SiliconTarget","Veto","Magnet","MuonShield","TargetStation", "TimeDet", "UpstreamTagger"]
 
-    detElements = {}
+    # Heterogeneous module dict: keys are GetName() strings, values are
+    # FairModule subclasses (Target/MTC/strawtubes/...). Annotate as Any to
+    # match the heterogeneous detectorList type.
+    detElements: dict[str, Any] = {}
     for x in detectorList:
         if x.GetName() in exclusionList:
             continue

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
-from typing import Any
-
 import os
+from typing import Any
 
 import ROOT
 import shipunit as u


### PR DESCRIPTION
## Summary

`pyrefly` inferred the type of `detectorList` (and the `detElements` dict returned by `configure()`) from the first `.append()` call, which locked the container element type to a single subclass (e.g. `Target`). All subsequent appends of other FairModule subclasses (`MTC`, `ShipCave`, `ShipMagnet`, `strawtubes`, `veto`, `splitcal`, `UpstreamTagger`, `TimeDet`, `ShipMuonShield`, `ShipTargetStation`, `SiliconTarget`, `TargetTracker`) then tripped `bad-argument-type` warnings.

The narrowing flowed through to callers that indexed `modules["strawtubes"]` (notably `macro/ShipAna.py`) and got told `Target has no attribute StrawEndPoints`.

## Change

Annotate the container element type as `Any` to match the actual heterogeneity:

```python
detectorList: list[Any] = []
# ...
detElements: dict[str, Any] = {}
```

## Test plan

- [x] `pyrefly check --output-format=full-text python macro` — total error count drops 168 → 153 (12 `bad-argument-type` at the append sites + 1 downstream `missing-attribute` at `ShipAna.StrawEndPoints` + a few transitive cleanups)
- [x] Imports nothing new besides `typing.Any`
- [x] No behavioural change — `detectorList` and `detElements` were already heterogeneous at runtime; this only widens the static type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code type annotations for detector configuration handling to enhance code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->