### PR TITLE
perf: move parameters that are copied once into a member

### DIFF
--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -5,6 +5,8 @@
 #ifndef MUONSHIELDOPTIMIZATION_EXITHADRONABSORBER_H_
 #define MUONSHIELDOPTIMIZATION_EXITHADRONABSORBER_H_
 
+#include <utility>
+
 #include "Detector.h"
 #include "TFile.h"
 #include "TNtuple.h"
@@ -33,7 +35,7 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   inline void SetOpt4DP() { withNtuple = kTRUE; }
   inline void SkipNeutrinos() { fSkipNeutrinos = kTRUE; }
   inline void SetZposition(Float_t x) { fzPos = x; }
-  inline void SetVetoPointName(TString name) { fVetoName = name; }
+  inline void SetVetoPointName(TString name) { fVetoName = std::move(name); }
   inline void SetCylindricalPlane() { fCylindricalPlane = kTRUE; }
   inline void SetUseCaveCoordinates() { fUseCaveCoordinates = kTRUE; }
 

--- a/shipgen/FixedTargetGenerator.h
+++ b/shipgen/FixedTargetGenerator.h
@@ -5,6 +5,8 @@
 #ifndef SHIPGEN_FIXEDTARGETGENERATOR_H_
 #define SHIPGEN_FIXEDTARGETGENERATOR_H_
 
+#include <utility>
+
 #include "FairLogger.h"  // for FairLogger, MESSAGE_ORIGIN
 #include "Generator.h"
 #include "GenieGenerator.h"
@@ -54,7 +56,7 @@ class FixedTargetGenerator : public SHiP::Generator {
     fUseRandom3 = kTRUE;
   };
   void SetTarget(TString s, Double_t x, Double_t y) {
-    targetName = s;
+    targetName = std::move(s);
     xOff = x;
     yOff = y;
   };

--- a/shipgen/Generator.h
+++ b/shipgen/Generator.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "FairGenerator.h"
@@ -36,7 +37,7 @@ class Generator : public FairGenerator {
   };
 
   virtual void UseExternalFile(std::string x, Int_t i) {
-    fextFile = x;
+    fextFile = std::move(x);
     firstEvent = i;
   };
 

--- a/shipgen/Pythia8Generator.h
+++ b/shipgen/Pythia8Generator.h
@@ -6,6 +6,7 @@
 #define SHIPGEN_PYTHIA8GENERATOR_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "FairLogger.h"  // for FairLogger, MESSAGE_ORIGIN
@@ -53,7 +54,7 @@ class Pythia8Generator : public SHiP::Generator {
 
   void SetfFDs(Double_t z) { fFDs = z; };
   void SetTarget(TString s, Double_t x, Double_t y) {
-    targetName = s;
+    targetName = std::move(s);
     xOff = x;
     yOff = y;
   };

--- a/shipgen/tPythia6Generator.h
+++ b/shipgen/tPythia6Generator.h
@@ -5,6 +5,8 @@
 #ifndef SHIPGEN_TPYTHIA6GENERATOR_H_
 #define SHIPGEN_TPYTHIA6GENERATOR_H_
 
+#include <utility>
+
 #include "Generator.h"
 #include "TPythia6.h"
 #include "TPythia6Calls.h"
@@ -29,8 +31,8 @@ class tPythia6Generator : public SHiP::Generator {
 
   void SetMom(Double_t mom) { fMom = mom; };
   void SetTarget(TString Type, TString Target) {
-    fType = Type;
-    fTarget = Target;
+    fType = std::move(Type);
+    fTarget = std::move(Target);
   };
   void UseDeepCopy() { fDeepCopy = kTRUE; };
   double getPyint5_XSEC(int i, int j) {

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -6,6 +6,7 @@
 #define VETO_VETO_H_
 
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "Detector.h"
@@ -61,11 +62,11 @@ class veto : public SHiP::Detector<vetoPoint> {
     f_InnerSupportThickness = a;
     f_VetoThickness = b;
     f_OuterSupportThickness = c;
-    supportMedIn_name = d;
+    supportMedIn_name = std::move(d);
     f_LidThickness = l;
-    vetoMed_name = e;
-    supportMedOut_name = f;
-    decayVolumeMed_name = v;
+    vetoMed_name = std::move(e);
+    supportMedOut_name = std::move(f);
+    decayVolumeMed_name = std::move(v);
     f_RibThickness = r;
   }
 


### PR DESCRIPTION
## Summary

Sweeps the 10 `performance-unnecessary-value-param` findings of the *"passed by value and only copied once; consider moving it"* variant that PR #1241 deliberately skipped — that PR handled only the *"only used as a const reference"* subset where a const-ref signature change was the right fix.

Each touched setter assigns a `TString` or `std::string` parameter into exactly one member. Adding `std::move` at the assignment site lets the member take the parameter's storage by move-assignment instead of deep-copying it, while the by-value parameter still binds rvalues cleanly without forcing a const-ref overload.

## Sites

| File | Setter |
|---|---|
| `muonShieldOptimization/exitHadronAbsorber.h:36` | `SetVetoPointName(TString)` |
| `shipgen/FixedTargetGenerator.h:57` | `SetTarget(TString s, ...)` |
| `shipgen/Generator.h:38` | `UseExternalFile(std::string x, ...)` |
| `shipgen/Pythia8Generator.h:56` | `SetTarget(TString s, ...)` |
| `shipgen/tPythia6Generator.h:32,33` | `SetTarget(TString Type, TString Target)` |
| `veto/veto.h:64,66,67,68` | `SetVesselStructure(...)` (4 × `TString`) |

Each header gains a `#include <utility>` for `std::move`.

## Test plan

- [x] `pixi run --locked build` — clean (33/33 incremental, 0 warnings)
- [x] `pixi run --locked test` — 2/2 pass (DataClassIO, RNtupleIO)
- [x] `CPP_FILES=<all-touched-cxx> pixi run --locked ci-clang-tidy` — 0 `performance-unnecessary-value-param` findings remain

## Notes

clang-tidy's autofix doesn't propose this fix on its own (it would need to see both the parameter binding and the body assignment as a unit, which the `performance-unnecessary-value-param` check doesn't combine). Each fix here is hand-applied but mechanical.

The parameters are by-value because the existing call sites pass mixed lvalues and rvalues; switching to const-ref would force a copy on every rvalue caller anyway. Move-from-by-value is the modern idiom for "I want to take ownership but I don't want two overloads".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory handling in multiple setter methods across the generator and veto components for improved performance.
  * Enhanced internal data transfer mechanisms for target name assignments, external file path handling, and configuration parameters.
  * Changes ensure more efficient resource usage when updating system settings without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->