### PR TITLE
fix(shipVertex): give VertexError a uniform 3-tuple return

### DIFF
--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -135,7 +135,7 @@ class Task:
                 # ignore this for background studies
                 if PosDirCharge[t2]["charge"] == c1:
                     continue
-                newPos, doca = self.VertexError(t1, t2, PosDirCharge)
+                newPos, _covX, doca = self.VertexError(t1, t2, PosDirCharge)
                 # Extrapolate both tracks toward the initial vertex
                 # estimate in steps to avoid long backward extrapolation
                 # through the magnetic field which causes RK failures.
@@ -164,7 +164,7 @@ class Task:
                 if not rc:
                     continue
                 # Recompute DOCA from the extrapolated positions
-                newPos, doca = self.VertexError(t1, t2, extrapolatedPosDir)
+                newPos, _covX, doca = self.VertexError(t1, t2, extrapolatedPosDir)
                 # as we have learned, need iterative procedure
                 dz = 99999.0
                 step = 0
@@ -185,7 +185,7 @@ class Task:
                         }
                     if not rc:
                         break
-                    newPos, doca = self.VertexError(t1, t2, self.newPosDir)
+                    newPos, _covX, doca = self.VertexError(t1, t2, self.newPosDir)
                     dz = abs(zBefore - newPos[2])
                     step += 1
                     if step > 10:
@@ -516,7 +516,8 @@ class Task:
         # self.h['N_Vtx'].Fill(hasVertex)
 
     def VertexError(self, t1, t2, PosDir, CovMat=None, scalFac=None):
-        # with improved Vx x,y resolution
+        # with improved Vx x,y resolution. Returns (X, covX, dist) where covX is
+        # None when no track covariance was supplied.
         a, u = PosDir[t1]["position"], PosDir[t1]["direction"]
         c, v = PosDir[t2]["position"], PosDir[t2]["direction"]
         Vsq = v.Dot(v)
@@ -532,7 +533,8 @@ class Task:
         l1 = a - X + u * Va  # l2 = c - X + v*Vb
         dist = 2.0 * ROOT.TMath.Sqrt(l1.Dot(l1))
         if not CovMat:
-            return X, dist
+            return X, None, dist
+        assert scalFac is not None, "VertexError requires scalFac when CovMat is set"
         T = ROOT.TMatrixD(3, 12)
         for i in range(3):
             for k in range(4):


### PR DESCRIPTION
## Summary

`VertexError` returned `(X, dist)` when `CovMat` was `None` and `(X, covX, dist)` otherwise. Pyrefly types the polymorphic return as `tuple[X, float] | tuple[X, TMatrixD, float]` and flagged both the 2-value and 3-value unpacks at the four call sites as `bad-unpacking`.

## Changes

- Always return three values, with `covX = None` on the no-covariance path.
- Update the four call sites in `TwoTrackVertex` (lines 138, 167, 188, 220) to bind a `_covX` slot for the early-return branch.
- Add `assert scalFac is not None` inside the CovMat branch — the existing `CovTracks` loop already relied on this implicitly when indexing `scalFac[tlist[k]]`, which caused two `None is not subscriptable` findings at lines 577/579.

## Test plan

- [x] `pyrefly check --output-format=full-text python macro` drops 128 → 122 (6 fewer in shipVertex.py)
- [x] No behavioural change for either branch; the early-return path's None slot is `_covX`-bound at all callers

The remaining `TMinuit.mnstat` missing-attribute finding is a stub gap covered by #1256.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertex calculation handling so results are returned consistently, even when no covariance data is available.
  * Fixed vertex recomputation after extrapolation to correctly process the full set of returned values.
  * Added a safeguard when scaling track covariance inputs, helping prevent invalid calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->