### PR TITLE
fix(Pythia6Generator): replace fscanf parsing with istringstream

### DIFF
--- a/shipgen/Pythia6Generator.cxx
+++ b/shipgen/Pythia6Generator.cxx
@@ -10,6 +10,8 @@
 
 #include <cstdio>
 #include <iostream>
+#include <sstream>
+#include <string>
 
 #include "FairLogger.h"
 #include "FairPrimaryGenerator.h"
@@ -51,36 +53,54 @@ Bool_t Pythia6Generator::ReadEvent(FairPrimaryGenerator* primGen) {
   }
 
   // Define event variable to be read from file
-  Int_t ntracks = 0, eventID = 0, ncols = 0;
+  Int_t ntracks = 0, eventID = 0;
 
   // Define track variables to be read from file
   Int_t nLev = 0, pdgID = 0, nM1 = -1, nM2 = -1, nDF = -1, nDL = -1;
   Float_t fPx = 0., fPy = 0., fPz = 0., fM = 0., fE = 0.;
   Float_t fVx = 0., fVy = 0., fVz = 0., fT = 0.;
 
-  // Read event header line from input file
-
-  ncols = fscanf(fInputFile, "%d\t%d", &eventID, &ntracks);
-
-  if (ncols && ntracks > 0) {
-    if (fVerbose > 0)
-      cout << "Event number: " << eventID << "\tNtracks: " << ntracks << endl;
-
-    for (Int_t ll = 0; ll < ntracks; ll++) {
-      (void)fscanf(fInputFile, "%d %d %d %d %d %d %f %f %f %f %f %f %f %f %f",
-                   &nLev, &pdgID, &nM1, &nM2, &nDF, &nDL, &fPx, &fPy, &fPz, &fE,
-                   &fM, &fVx, &fVy, &fVz, &fT);
-      if (fVerbose > 0)
-        cout << nLev << "\t" << pdgID << "\t" << nM1 << "\t" << nM2 << "\t"
-             << nDF << "\t" << nDL << "\t" << fPx << "\t" << fPy << "\t" << fPz
-             << "\t" << fE << "\t" << fM << "\t" << fVx << "\t" << fVy << "\t"
-             << fVz << "\t" << fT << endl;
-      if (nLev == 1) primGen->AddTrack(pdgID, fPx, fPy, fPz, fVx, fVy, fVz);
-    }
-  } else {
+  // Read event header line from input file. fgets+istringstream gives us
+  // per-field error checking that the old fscanf("%d\t%d", …) lacked.
+  char headerBuf[256];
+  if (fgets(headerBuf, sizeof(headerBuf), fInputFile) == nullptr) {
     cout << "-I Pythia6Generator: End of input file reached " << endl;
     CloseInput();
     return kFALSE;
+  }
+  std::istringstream headerStream(headerBuf);
+  if (!(headerStream >> eventID >> ntracks) || ntracks <= 0) {
+    cout << "-I Pythia6Generator: End of input file reached " << endl;
+    CloseInput();
+    return kFALSE;
+  }
+
+  if (fVerbose > 0)
+    cout << "Event number: " << eventID << "\tNtracks: " << ntracks << endl;
+
+  for (Int_t ll = 0; ll < ntracks; ll++) {
+    char trackBuf[512];
+    if (fgets(trackBuf, sizeof(trackBuf), fInputFile) == nullptr) {
+      LOG(error) << "Pythia6Generator: unexpected end of file while reading "
+                    "tracks for event "
+                 << eventID;
+      CloseInput();
+      return kFALSE;
+    }
+    std::istringstream trackStream(trackBuf);
+    if (!(trackStream >> nLev >> pdgID >> nM1 >> nM2 >> nDF >> nDL >> fPx >>
+          fPy >> fPz >> fE >> fM >> fVx >> fVy >> fVz >> fT)) {
+      LOG(error) << "Pythia6Generator: malformed track line for event "
+                 << eventID << " track " << ll << ": " << trackBuf;
+      CloseInput();
+      return kFALSE;
+    }
+    if (fVerbose > 0)
+      cout << nLev << "\t" << pdgID << "\t" << nM1 << "\t" << nM2 << "\t" << nDF
+           << "\t" << nDL << "\t" << fPx << "\t" << fPy << "\t" << fPz << "\t"
+           << fE << "\t" << fM << "\t" << fVx << "\t" << fVy << "\t" << fVz
+           << "\t" << fT << endl;
+    if (nLev == 1) primGen->AddTrack(pdgID, fPx, fPy, fPz, fVx, fVy, fVz);
   }
 
   // If end of input file is reached : close it and abort run


### PR DESCRIPTION
## Summary

clang-tidy's `bugprone-unchecked-string-to-number-conversion` flagged both `fscanf` calls in `Pythia6Generator::ReadEvent` (the remaining 2 sites from that category after PR #1244 swept atoi/atof). `fscanf` silently produces zeros when an input field doesn't match the format — the value just stays at its prior contents — instead of surfacing the parse error to the caller.

## Change

Rewrite with `fgets` + `std::istringstream`. Each line is read into a buffer, then `>>` extracts the typed fields one at a time. If any extraction fails, log the offending line and abort the event, matching the `std::stoi`/`std::stod` error model PR #1244 adopted.

Both the header line (`eventID`, `ntracks`) and the per-track line (15 fields) get explicit fail checks. End-of-file detection now naturally drops out of `fgets` returning `nullptr`.

## Test plan

- [x] `pixi run --locked build` — clean (133/133, 0 warnings)
- [x] `pixi run --locked test` — 2/2 pass
- [x] `CPP_FILES=shipgen/Pythia6Generator.cxx pixi run --locked ci-clang-tidy` — 0 `bugprone-unchecked-string-to-number-conversion` findings
- [ ] CI's `ci-fixed-target` job still passes (its Pythia6 input is well-formed, so behaviour is unchanged)

## Risks

Malformed Pythia6 input lines that previously fell through with zero fields will now log an error and skip the event. If any existing input file relies on the zero-fallback, this will surface as a runtime failure with a clear message — preferred to silent corruption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event and track input parsing with improved error detection and validation for malformed or incomplete data entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->