### PR TITLE
fix: validate -A for --DarkPhoton runs (#1166)

### DIFF
--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -427,6 +427,8 @@ if options.RPVSUSY:
     HNL = False
 if options.DarkPhoton:
     HNL = False
+    if inclusive not in {"meson", "pbrem", "qcd"}:
+        parser.error("For --DarkPhoton, -A must be one of: meson, pbrem, qcd")
 if not options.theMass:
     if options.DarkPhoton:
         options.theMass = theDPmass


### PR DESCRIPTION
## Summary
- Fixes #1166. When `--DarkPhoton` was used without `-A`, the `inclusive` variable kept its HNL default of `"c"`. `pythia8darkphoton_conf.configure()` only handles `"meson"`, `"qcd"`, and `"pbrem"`, so the run was silently misconfigured.
- Adds a `parser.error()` in the `--DarkPhoton` branch of `macro/run_simScript.py` that rejects any `-A` value not in `{meson, pbrem, qcd}`.

## Test plan
- [x] `run_simScript.py --DarkPhoton` → exits 2 with `error: For --DarkPhoton, -A must be one of: meson, pbrem, qcd`
- [x] `run_simScript.py --DarkPhoton -A c` → same error
- [x] `run_simScript.py --DarkPhoton -A foo` → same error
- [x] `run_simScript.py --DarkPhoton -A meson` / `pbrem` / `qcd` → passes the new check (heavy sim setup runs as before)
- [x] `run_simScript.py` without `--DarkPhoton` → unaffected (HNL `-A c` default still works)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for production-mode configuration options. The script now enforces stricter parameter checking and provides clear error messages when invalid values are supplied, preventing execution with incorrect settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->