### PR TITLE
makeDecay: add target composition option, default to Tungsten

### DIFF
--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -3,9 +3,8 @@
 
 # Use Pythia8 to decay the signals (Charm/Beauty) as produced by makeCascade.
 # Output is an ntuple with muon/neutrinos
-import getopt
+import argparse
 import os
-import sys
 
 import ROOT
 import rootUtils as ut
@@ -13,32 +12,58 @@ import rootUtils as ut
 ROOT.gROOT.LoadMacro("$VMCWORKDIR/gconfig/basiclibs.C")
 ROOT.basiclibs()
 
-# latest production May 2016,76 M pot which produce a charm event equivalent,roughly 150 M charm hadrons
-fname = "/eos/experiment/ship/data/Charm/Cascade-parp16-MSTP82-1-MSEL4-76Mpot_1"
+# Reference values for Molybdenum (historical defaults). Cross-section ratios
+# scale ~ A^(1/3) since heavy-flavour ~ A and mbias ~ A^(2/3).
+A_REF = 98.0
+CHICC_REF = 1.7e-3  # prob to produce primary ccbar pair/pot on Mo
+CHIBB_REF = 1.6e-7  # prob to produce primary bbbar pair/pot on Mo
+TARGET_A = {"W": 184.0, "Mo": 98.0}
 
-nrpotspill = 5.0e13  # number of pot/spill
-chicc = 1.7e-3  # prob to produce primary ccbar pair/pot
-chibb = 1.6e-7  # prob to produce primary bbbar pair/pot
-setByHand = False
+ap = argparse.ArgumentParser(description="Decay charm/beauty signals from makeCascade output with Pythia8")
+ap.add_argument(
+    "-f",
+    "--input",
+    default="/eos/experiment/ship/data/Charm/Cascade-parp16-MSTP82-1-MSEL4-76Mpot_1",
+    help="input file with charm/beauty hadrons (.root suffix optional)",
+)
+ap.add_argument("-p", "--pot", type=float, default=5.0e13, help="number of protons on target per spill to normalise on")
+ap.add_argument(
+    "-c", "--chicc", type=float, default=None, help="ccbar over mbias cross section (overrides target-derived value)"
+)
+ap.add_argument(
+    "--chibb", type=float, default=None, help="bbbar over mbias cross section (overrides target-derived value)"
+)
+ap.add_argument(
+    "--target_composition",
+    default="W",
+    choices=["W", "Mo"],
+    help="Target composition. Default is Tungsten (W); Molybdenum (Mo) is the other preset.",
+)
+ap.add_argument(
+    "-A",
+    type=float,
+    default=None,
+    help="Target mass number; overrides --target_composition preset. Used to scale chicc/chibb as (A/A_Mo)^(1/3).",
+)
+args = ap.parse_args()
 
-print("usage: python $FAIRSHIP/macro/makeDecay.py -f ")
+fname = args.input.replace(".root", "")
+nrpotspill = args.pot
 
-try:
-    opts, args = getopt.getopt(sys.argv[1:], "f:p:c:", ["pot=", "chicc="])
-except getopt.GetoptError:
-    # print help information and exit:
-    print(" enter -f: input file with charm hadrons")
-    print(" for experts: p pot= number of protons on target per spill to normalize on")
-    print("            : c chicc= ccbar over mbias cross section")
-    sys.exit()
-for o, a in opts:
-    if o in ("-f",):
-        fname = a.replace(".root", "")
-    if o in ("-p", "--pot"):
-        nrpotspill = float(a)
-    if o in ("-c", "--chicc"):
-        chicc = float(a)
-        setByHand = True
+A = args.A if args.A is not None else TARGET_A[args.target_composition]
+scale = (A / A_REF) ** (1.0 / 3.0)
+
+if args.chicc is not None:
+    chicc = args.chicc
+    setByHand = True
+else:
+    chicc = CHICC_REF * scale
+    setByHand = False
+
+chibb = args.chibb if args.chibb is not None else CHIBB_REF * scale
+
+print(f"Target composition: {args.target_composition}, A={A}, scale=(A/{A_REF})^(1/3)={scale:.4f}")
+print(f"Derived cross-section ratios: chicc={chicc:.3e}, chibb={chibb:.3e}")
 
 FIN = fname + ".root"
 tmp = os.path.abspath(FIN).split("/")


### PR DESCRIPTION
## Summary
- Adds `--target_composition {W,Mo}` (default `W`) to `macro/makeDecay.py`, mirroring the flag introduced for `makeCascade.py` in #777.
- Scales `chicc`/`chibb` from their Molybdenum reference values by `(A/A_Mo)^(1/3)` (heavy-flavour ~ A, mbias ~ A^(2/3)). For Tungsten this gives `chicc ≈ 2.10e-3` and `chibb ≈ 1.97e-7`; `--target_composition Mo` reproduces the historical defaults.
- Also adds a numeric `-A` override for non-preset targets and a `--chibb` override (previously only `--chicc` could be set explicitly).
- Migrates the script from `getopt` to `argparse` along the way.

The auto-detect-beauty branch (`sTree.M > 5` → swap `chicc → chibb`) is preserved and still gated by whether the user passed `--chicc` explicitly.

Closes #1263.

## Test plan
- [ ] Run on a Tungsten cascade ntuple and confirm the new printout shows `chicc ≈ 2.10e-3`, `chibb ≈ 1.97e-7`.
- [ ] Run with `--target_composition Mo` and confirm the historical values `chicc = 1.7e-3`, `chibb = 1.6e-7`.
- [ ] Run with `-A 200` and confirm the scaling.
- [ ] Run with `--chicc 1.0e-3` and confirm the explicit override wins.
- [ ] Run on a beauty cascade (file with `sTree.M > 5`) and confirm the auto-switch picks up the target-scaled `chibb`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded command-line interface with improved argument parsing and validation.
  * Added configurable options for input file, potential, and cross-section parameters.
  * Implemented automatic scaling of cross-section parameters based on target mass number.
  * New target composition selection and preset configuration capabilities.
  * Better control over parameter overrides through explicit command-line flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->