### PR TITLE
feat: change A scaling in makeDecay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ it in future.
 
 ### Changed
 
+* Change A scaling in makeDecay
+
 ### Fixed
 
 ### Removed

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -13,7 +13,10 @@ ROOT.gROOT.LoadMacro("$VMCWORKDIR/gconfig/basiclibs.C")
 ROOT.basiclibs()
 
 # Reference values for Molybdenum (historical defaults). Cross-section ratios
-# scale ~ A^(1/3) since heavy-flavour ~ A and mbias ~ A^(2/3).
+# scale heavy-flavour ~ A and mbias ~ A^(0.71).
+heavyflavour_Ascale = 1
+mbias_Ascale = 0.71
+
 A_REF = 98.0
 CHICC_REF = 1.7e-3  # prob to produce primary ccbar pair/pot on Mo
 CHIBB_REF = 1.6e-7  # prob to produce primary bbbar pair/pot on Mo
@@ -51,7 +54,7 @@ fname = args.input.replace(".root", "")
 nrpotspill = args.pot
 
 A = args.A if args.A is not None else TARGET_A[args.target_composition]
-scale = (A / A_REF) ** (1.0 / 3.0)
+scale = (A / A_REF) ** (heavyflavour_Ascale - mbias_Ascale)
 
 if args.chicc is not None:
     chicc = args.chicc
@@ -62,7 +65,7 @@ else:
 
 chibb = args.chibb if args.chibb is not None else CHIBB_REF * scale
 
-print(f"Target composition: {args.target_composition}, A={A}, scale=(A/{A_REF})^(1/3)={scale:.4f}")
+print(f"Target composition: {args.target_composition}, A={A}, scale=(A/{A_REF})^({heavyflavour_Ascale}-{mbias_Ascale})={scale:.4f}")
 print(f"Derived cross-section ratios: chicc={chicc:.3e}, chibb={chibb:.3e}")
 
 FIN = fname + ".root"

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -46,7 +46,11 @@ ap.add_argument(
     "-A",
     type=float,
     default=None,
-    help="Target mass number; overrides --target_composition preset. Used to scale chicc/chibb as (A/A_Mo)^(1/3).",
+    help=(
+        "Target mass number; overrides --target_composition preset. "
+        "Used to scale chicc/chibb as (A/A_Mo)^(heavyflavour_Ascale-mbias_Ascale) "
+        "(default exponent: 0.29)."
+    ),
 )
 args = ap.parse_args()
 

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -65,7 +65,9 @@ else:
 
 chibb = args.chibb if args.chibb is not None else CHIBB_REF * scale
 
-print(f"Target composition: {args.target_composition}, A={A}, scale=(A/{A_REF})^({heavyflavour_Ascale}-{mbias_Ascale})={scale:.4f}")
+print(
+    f"Target composition: {args.target_composition}, A={A}, scale=(A/{A_REF})^({heavyflavour_Ascale}-{mbias_Ascale})={scale:.4f}"
+)
 print(f"Derived cross-section ratios: chicc={chicc:.3e}, chibb={chibb:.3e}")
 
 FIN = fname + ".root"


### PR DESCRIPTION
Dear all,

small follow-up to #1264 : using the same scaling described in the SHiP technical proposal, 
SPSC-P-350, chapter 5.3.
A ** (1-0.71) instead of A**(1/3).
Of course, these are also approximate value, nothing set in stone, so for clarity I have reported both scalings as separated variables.
The values they now gives for tungsten are:
`chicc=2.041e-03, chibb=1.921e-07`

All the best,
Antonio

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [x] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Updated the charm and beauty particle scaling calculations to derive the exponent from new reference values rather than a fixed power. As a result, the target composition/scaling message and downstream computed scaling factors now follow the new exponent model when values aren’t provided manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->