### PR TITLE
docs: prepare changelog for 26.06 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,61 @@ it in future.
 
 ### Added
 
-* Add experimental script to import Muons and Matter pkl files
-* Add TTreeGenerator to read M&M ntuples
-
 ### Changed
-
-* Change A scaling in makeDecay
 
 ### Fixed
 
 ### Removed
+
+## 26.06 - 2026-06-18
+
+### Added
+
+* Add experimental script to import Muons and Matter pkl files
+* Add `TTreeGenerator` to read events from ROOT TTrees (including the converted M&M ntuples)
+* Add `--ttree` option to `run_simScript.py` for ROOT TTree input
+* Add `--target_composition` option to `makeDecay`, defaulting to Tungsten and mirroring the `makeCascade.py` flag
+* Add `--validation` flag to `run_simScript.py` and `ShipReco.py` that prints generator, output, pattern-recognition, and fit counters
+* Add `--remote-input` flag to `run_simScript.py` for direct `root://…` input without local download
+* Add `--reproducible` mode and explicit, reusable run IDs in `run_simScript.py` / `run_fixedTarget.py`, with consistent metadata written into output headers
+* Add pixi environment (`pixi.toml`) and pixi-based CI build workflow as the new primary build path
+* Add CI sim-chain tasks driven by pixi
+* Add CI workflow to build and publish pixi-based container images on release
+* Add REUSE compliance badge to README
+* Add pixi installation instructions to README
+
+### Changed
+
+* Change A scaling in makeDecay
+* Rewrite README to be pixi-first
+* Derive project version from git tags via `git describe` instead of hardcoded `0.0.0`
+* Migrate CI to shared `ShipSoft/.github` reusable workflows
+
+### Fixed
+
+* Validate `-A` choice for `--DarkPhoton` runs; previously silently misconfigured (#1166)
+* Always allocate `validation_stats` dict and fix `GetHitID` typo in `shipDigiReco`
+* Harden generator input handling: fail-fast on missing files, trees, branches, and out-of-range start events, and switch to `TFile::Open` for remote-input compatibility
+* Prevent MuonBack post-processing double-free of output `TFile` at interpreter shutdown (#1226)
+* Null-init `MuonBackGenerator` pointers and drop dead `CloseFile` path
+* Keep `BranchList` `TObjStrings` alive under ROOT 6.40 PyROOT ownership changes
+* Load `libEGPythia6` in `shipRoot_conf`
+* Remove unnecessary `libG4clhep` loads
+* Chain `Initialize` through immediate parent in `exitHadronAbsorber`
+* Address real bugs surfaced by `pyrefly` static type-checking
+* Remove throwing static initializers
+* Initialise variables before conditional branches
+* Replace `atof`/`atoi` with `std::stod`/`std::stoi` for proper error handling
+* Replace floating-point loop counters with integers
+* Use `size_t` for `ShipMuonShield` corner-index loop
+* Use `git rev-parse` in `retrieveGitTags` for Python 3 compatibility
+* Correct DOI badge link in README
+* Fix help-message text in `makeDecay`
+
+### Removed
+
+* Drop unused HepMC dependency
+* Retire aliBuild-driven `build-run.yml`; replaced by `pixi-build.yml`
 
 ## 26.05 - 2026-05-25
 


### PR DESCRIPTION
## Summary

- Move the existing `Unreleased` block to a new `## 26.06 - 2026-06-18` section and restore an empty `Unreleased` skeleton on top.
- Back-fill entries for the ~80 user-facing commits since `26.05` that were not already tracked under `Unreleased`. The big themes are:
  - Pixi-first build & CI (replaces the aliBuild `build-run.yml` pipeline; new pixi-based container publish workflow).
  - Generator hardening and remote-input support (`--remote-input`, `TFile::Open`, fail-fast validation), plus the MuonBack double-free fix (#1226).
  - Simulation reproducibility (`--reproducible`, explicit run IDs, consistent output metadata) and `--validation` counters in `run_simScript.py` / `ShipReco.py`.
  - `makeDecay` gains `--target_composition` (default Tungsten) and the new A-scaling.
  - DarkPhoton `-A` validation (#1166), shipDigiReco `validation_stats` allocation fix, ROOT 6.40 `BranchList` ownership fix, and a batch of pyrefly-driven correctness fixes.
  - Drop unused HepMC dependency.

Pure style / dependabot / pre-commit / pixi-lock-churn commits are intentionally omitted, matching the convention of the `26.04` and `26.05` sections.

No other files change: the project version is now derived from `git describe`, and the per-release CI matrix bump retired with `build-run.yml`.

## Test plan

- [x] Diff reviewed: only `CHANGELOG.md` modified, ordering is `Unreleased → 26.06 → 26.05 → …`.
- [x] Skim entries against `git log v26.05..HEAD` to make sure no user-visible change was missed.
- [ ] After merge: tag `v26.06`, which triggers the pixi-based container publish workflow.