### PR TITLE
ci: trigger container build on unprefixed CalVer tags

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,7 +1,7 @@
 name: Container Build
 on:
   push:
-    tags: ['v*']
+    tags: ['[0-9]*']
   workflow_dispatch:
     inputs:
       ref:
@@ -33,18 +33,19 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/shipsoft/fairship
-          # FairShip uses CalVer (e.g. v26.05, v26.05.1) — semver rules would
-          # silently drop these (strict semver rejects leading-zero ".05").
-          # The two type=match patterns are intentionally overlapping so a
-          # tag like v26.05.1 also updates :26.05, mirroring the moving
-          # minor-line pointer that type=semver/{{major}}.{{minor}} produces.
+          # FairShip uses unprefixed CalVer tags (e.g. 26.06, 26.06.1) —
+          # semver rules would silently drop these (strict semver rejects
+          # leading-zero ".05/.06"). The (\d+\.\d+)\.\d+ pattern only matches
+          # three-component tags, so a patch tag like 26.06.1 also updates
+          # the :26.06 minor-line pointer, while a plain 26.06 tag emits a
+          # single 26.06 image tag without a redundant duplicate.
           tags: |
             type=ref,event=tag
-            type=match,pattern=v(\d+\.\d+\.\d+),group=1
-            type=match,pattern=v(\d+\.\d+),group=1
+            type=match,pattern=(\d+\.\d+\.\d+),group=1
+            type=match,pattern=(\d+\.\d+)\.\d+,group=1
             type=ref,event=branch
             type=sha,format=short
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
       - uses: docker/build-push-action@v7
         with:
           context: .


### PR DESCRIPTION
## Summary

The `Container Build` workflow did not start when `26.06` was pushed because every gate in the workflow assumed a `v`-prefixed tag, but every actual release tag in this repo is unprefixed CalVer (`25.12`, `26.03`, `26.04`, `26.05`, `26.06`). The workflow has in fact never fired on a CalVer tag — only on manual `workflow_dispatch` — this is just the first release where it was noticed.

This PR realigns the workflow with the existing tag convention:

- `on.push.tags`: `['v*']` → `['[0-9]*']`. All non-CalVer tags in the repo (`condDB`, `ECN3_2022`, `online-*`, `pre-ECN3version`, `SHiP-BDF-2020`, `v1-00`, `v2-10`, …) start with a non-digit, so the digit-prefix glob selects CalVer tags only without listing them by hand.
- Drop the `v` from both `docker/metadata-action` `type=match` patterns so they actually fire.
- Tighten the patch-line pattern to `(\d+\.\d+)\.\d+` so a three-component tag like `26.06.1` still moves the `:26.06` minor-line pointer, while a plain `26.06` tag emits a single `26.06` image tag without a redundant duplicate.
- Gate `:latest` on any tag ref (`refs/tags/`) now that the trigger filter already restricts pushes to release tags only.
- Update the misleading header comment (which claimed tags look like `v26.05` / `v26.05.1`).

No source code parses release tags — `CMakeLists.txt` already uses `git describe` with a regex that expects unprefixed tags.

To actually publish the `26.06` container image, the existing tag will need to be re-pushed after this merges (separate, manual step):

```sh
git push origin :26.06        # delete tag on origin
git push origin 26.06         # re-push same commit, fires the workflow
```

## Test plan

- [ ] After merge, sanity-check the rendered workflow YAML.
- [ ] Re-push the `26.06` tag and confirm `gh run list --workflow=container-build.yml` picks up a tag-triggered run.
- [ ] After the run completes, `docker pull ghcr.io/shipsoft/fairship:26.06` and `:latest` resolve to the same digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image tagging to support unprefixed CalVer version formats (e.g., `26.06`, `26.06.1`).
  * Refined tag detection logic to recognize digit-and-dot patterns instead of v-prefixed versions.
  * Ensured `latest` tag is applied only to tagged releases while maintaining branch and commit-hash tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->