### PR TITLE
ci: minimal legacy CVMFS smoke test for 26.02 and 26.06

### DIFF
--- a/.github/workflows/legacy-cvmfs.yml
+++ b/.github/workflows/legacy-cvmfs.yml
@@ -1,0 +1,44 @@
+name: Legacy CVMFS CI
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+    tags: ['v*']
+  workflow_dispatch:
+  merge_group:
+concurrency:
+  group: legacy-cvmfs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build-and-test:
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["26.02", "26.06"]
+    container:
+      image: registry.cern.ch/ship/gha-runner:latest
+      volumes:
+        - /cvmfs/ship.cern.ch:/cvmfs/ship.cern.ch
+    env:
+      version: ${{ matrix.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: FairShip
+          lfs: true
+          fetch-depth: 0
+      - name: Build
+        run: |
+          set -o pipefail
+          source /cvmfs/ship.cern.ch/$version/setUp.sh
+          aliBuild build FairShip --always-prefer-system --config-dir $SHIPDIST --defaults release --jobs $(nproc) --debug 2>&1 | tee build.log | python3 FairShip/.github/scripts/annotate_build.py
+      - name: Run sim
+        run: |
+          source /cvmfs/ship.cern.ch/$version/setUp.sh
+          eval $(alienv load FairShip/latest)
+          python $FAIRSHIP/macro/run_simScript.py --test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     - [Documentation](#documentation)
     - [License](#license)
     - [Contributing code](#contributing-code)
-    - [Legacy releases (CVMFS + aliBuild, ≤26.04)](#legacy-releases-cvmfs--alibuild-2604)
+    - [Legacy releases (CVMFS + aliBuild)](#legacy-releases-cvmfs--alibuild)
 
 <!-- markdown-toc end -->
 
@@ -39,11 +39,11 @@ documentation.
   <dt><code>SHiP-2018</code></dt>
   <dd>Frozen branch for the CDS, kept for backward compatibility.
       Python 2 only. Builds via the
-      <a href="#legacy-releases-cvmfs--alibuild-2604">legacy aliBuild path</a> only.</dd>
+      <a href="#legacy-releases-cvmfs--alibuild">legacy aliBuild path</a> only.</dd>
   <dt><code>muflux</code></dt>
   <dd>Branch for the muon flux analysis.
       Python 2 only. Builds via the
-      <a href="#legacy-releases-cvmfs--alibuild-2604">legacy aliBuild path</a> only.</dd>
+      <a href="#legacy-releases-cvmfs--alibuild">legacy aliBuild path</a> only.</dd>
 </dl>
 
 All packages are managed in Git and GitHub. Please read [the Git tutorial for
@@ -195,13 +195,16 @@ Copyright is held by CERN for the benefit of the SHiP Collaboration. Some compon
 * Please split your work into small commits with self-contained changes to make them easy to review and check.
 * To help us consistently improve the quality of our code, please try to follow the [C++](https://github.com/ShipSoft/FairShip/wiki/CPP-guidelines) and [Python](https://github.com/ShipSoft/FairShip/wiki/Python-guidelines) guidelines.
 
-## Legacy releases (CVMFS + aliBuild, ≤26.04)
+## Legacy releases (CVMFS + aliBuild)
 
-These instructions are kept for users running existing CVMFS releases up to
-**26.04** and for legacy branches (`SHiP-2018`, `muflux`). New work should use
-[Using pixi](#using-pixi) instead; the
+aliBuild on top of a CVMFS-provided toolchain was the supported default up to
+and including release **26.05**. From **26.06** onwards [pixi](#using-pixi) is
+the recommended build path; CVMFS images of newer releases (e.g. 26.06) may
+still be published for convenience, but are no longer the primary
+distribution channel. These instructions are kept for users running existing
+CVMFS releases and for legacy branches (`SHiP-2018`, `muflux`). The
 [shipdist](https://github.com/ShipSoft/shipdist) repository (aliBuild recipes)
-is no longer maintained.
+is now in maintenance mode.
 
 ### With CVMFS (lxplus and similar)
 
@@ -215,7 +218,7 @@ is no longer maintained.
     ```bash
     ls /cvmfs/ship.cern.ch
     ```
-3. Source the chosen release (≤ 26.04; see the
+3. Source the chosen release (see the
    [cvmfs_release](https://github.com/ShipSoft/cvmfs_release) repo for the
    list):
     ```bash


### PR DESCRIPTION
## Summary

- Add `.github/workflows/legacy-cvmfs.yml`: a thin smoke test that builds FairShip with aliBuild on the `/cvmfs/ship.cern.ch/{26.02,26.06}` stacks and runs `python $FAIRSHIP/macro/run_simScript.py --test`. Self-hosted runners with the `registry.cern.ch/ship/gha-runner:latest` container, mirroring the pattern of the retired `build-run.yml` (commit 2d7f914a4) but trimmed to a single matrix axis and no post-sim steps. Triggers, concurrency, and matrix `fail-fast: false` match `pixi-build.yml` so both run side-by-side on every PR/push.
- Rephrase the `Legacy releases` section in `README.md`: drop the `≤26.04` qualifier from heading/anchors, state that aliBuild+CVMFS was the supported default through 26.05 with pixi preferred from 26.06 onward, and acknowledge that 26.06 is also published on CVMFS. Soften the shipdist note to "maintenance mode" (it is clearly still producing 26.06 builds).

## Test plan

- [ ] Workflow appears under Actions and both matrix cells (26.02, 26.06) reach the "Run sim" step and exit zero
- [ ] `pixi-build.yml` is unaffected and runs in parallel
- [ ] README renders correctly on GitHub; the in-page TOC and `<dd>` anchor links to the renamed `#legacy-releases-cvmfs--alibuild` heading resolve