### PR TITLE
fix(shipgen): make tPythia6Generator concrete again (#1272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ it in future.
 
 ### Fixed
 
+* Restore `tPythia6Generator` instantiation from Python — broken since 26.02 by the `SHiP::Generator` base-class refactor leaving the file-based `Init` overloads pure virtual without a stub override (#1272)
+
 ### Removed
 
 ## 26.06 - 2026-06-18

--- a/shipgen/tPythia6Generator.h
+++ b/shipgen/tPythia6Generator.h
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "FairLogger.h"
 #include "Generator.h"
 #include "TPythia6.h"
 #include "TPythia6Calls.h"
@@ -28,6 +29,12 @@ class tPythia6Generator : public SHiP::Generator {
 
   using SHiP::Generator::Init;
   Bool_t Init() override;
+  Bool_t Init(const char* inFile) override { return Init(inFile, 0); };
+  Bool_t Init(const char* inFile, int startEvent) override {
+    LOG(warning) << "Init with files not implemented for tPythia6Generator. "
+                    "Using default Init() instead";
+    return Init();
+  };
 
   void SetMom(Double_t mom) { fMom = mom; };
   void SetTarget(TString Type, TString Target) {


### PR DESCRIPTION
## Summary
- `tPythia6Generator` became abstract in 26.02 when it was reparented onto `SHiP::Generator` (which has pure-virtual file-based `Init` overloads) without stub overrides; cppyy correctly refuses to instantiate it, breaking `makeCascade.py` and the Pythia6 branch of `run_simScript.py`. Add the stub `Init(const char*)` / `Init(const char*, int)` pair that the other generators use.
- Closes #1272.

## Test plan
- [x] `pixi run build` succeeds
- [x] `python -c "import ROOT; ROOT.gSystem.Load('libShipGen'); ROOT.tPythia6Generator()"` constructs cleanly (was `TypeError: cannot instantiate abstract class`)
- [x] `makeCascade.py`-style sequence (`TDatabasePDG`, `TPythia6`, `tPythia6Generator`, `SetMom`, `SetTarget`) runs past the reported failure site
- [ ] Reporter confirmation on a real `makeCascade.py` run

## Follow-up
The sibling class `Pythia6Generator` (no `t`) had the same latent abstract-class bug but is unused (zero callsites anywhere in the tree, no substantive commit since 2008). A separate PR will remove it rather than fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Restored Pythia6Generator instantiation from Python, which was broken following a previous refactor.
* Added file-based initialization method overloads accepting input filenames and optional event indices; methods currently unsupported but prevent crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->