### PR TITLE
fix: fix check of existing particle pdg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ it in future.
 
 ### Fixed
 
+* Fix check of existing particle pdg in makeCascade
+
 * Restore `tPythia6Generator` instantiation from Python — broken since 26.02 by the `SHiP::Generator` base-class refactor leaving the file-based `Init` overloads pure virtual without a stub override (#1272)
 
 ### Removed

--- a/macro/makeCascade.py
+++ b/macro/makeCascade.py
@@ -241,7 +241,7 @@ for idp in range(0, len(idbeam)):
     for idpm in [-1, 1]:  # particle or anti-particle
         idw = idbeam[idp] * idpm
         _p = PDG.GetParticle(idw)
-        if _p is not None:  # if particle exists, book hists etc.
+        if _p:  # if particle exists, book hists etc.
             name = _p.GetName()
             id = id + 1
             for idnp in range(2):


### PR DESCRIPTION
Dear all,
As follow-up of #1272, this solves the following crash:

```
K-, p+, for  chi, seconds: 104.71095895767212
K-, n0, for  chi, seconds: 114.03099989891052
K+, p+, for  chi, seconds: 123.62032270431519
K+, n0, for  chi, seconds: 134.18917179107666
Traceback (most recent call last):
  File "/afs/cern.ch/work/a/aiuliano/public/ECN3_SHIPBuild/FairShip/macro/makeCascade.py", line 245, in <module>
    name = _p.GetName()
           ^^^^^^^^^^^^
ReferenceError: attempt to access a null-pointer
```
Due to looking for not existing particle -130. The pointer _p is 0x (nil), and it does not satisfy the "is None" condition, therefore the crash. Fixed with an usual C++-style  if(_p) check for void pointers.


## Checklist

- [X ] Changelog updated (if applicable)
- [X ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed particle existence validation check in cascade operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->