### PR TITLE
Fix call to next Pythia event generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ it in future.
 ### Fixed
 
 * Restore `tPythia6Generator` instantiation from Python — broken since 26.02 by the `SHiP::Generator` base-class refactor leaving the file-based `Init` overloads pure virtual without a stub override (#1272)
-
+* Fix call to next Pythia event generation
 ### Removed
 
 * Remove unused legacy `Pythia6Generator` (custom text-format event-record reader from 2008, zero callsites anywhere in the tree). `tPythia6Generator` is unaffected.

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -169,7 +169,7 @@ for n in range(nEvents):
             nDsprim += 1
     P8.event.reset()
     P8.event.append(int(sTree.id), 1, 0, 0, sTree.px, sTree.py, sTree.pz, sTree.E, sTree.M, 0.0, 9.0)
-    next(P8)
+    P8.next()
     # P8.event.list()
     for n in range(len(P8.event)):
         # ask for stable particles


### PR DESCRIPTION
Dear all,

After fixing makeCascade, testing makeDecay leads to this following error:
```
Traceback (most recent call last):
  File "/afs/cern.ch/work/a/aiuliano/public/ECN3_SHIPBuild/FairShip/macro/makeDecay.py", line 172, in <module>
    next(P8)
TypeError: 'Pythia' object is not an iterator
```
This is due to telling Pythia to generate the next event as an interator, instead of using the usual next() function call (see for example macro/runPythia8.py). I have replaced the function call.

Antonio

## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pythia8 event generation advancement to ensure proper event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->