### PR TITLE
Fix pot branch in Decay tree from makeDecay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ it in future.
 
 ### Fixed
 
+* Fix pot branch in Decay tree from makeDecay
+
 * Fix check of existing particle pdg in makeCascade
 
 * Restore `tPythia6Generator` instantiation from Python — broken since 26.02 by the `SHiP::Generator` base-class refactor leaving the file-based `Init` overloads pure virtual without a stub override (#1272)

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -192,7 +192,7 @@ for n in range(nEvents):
                     sTree.py,
                     sTree.pz,
                     sTree.E,
-                    sTree.M,
+                    nrpotspill,
                     ptGM,
                     sTree.mpz,
                 )


### PR DESCRIPTION
Dear all,

This follows issue #1282 .
Even if the fix itself is trivial, it is crucial to stress some main points:

- In all Decay*.root files produced so far, the "pot" branch actually contains the mother particle mass. I have verified that this was the case from the creation of the code in 2015;
- At least in FairShip, I do not see this branch used in any code, so there is no effect on the rest of the software;
- When merging multiple files (i.e. batch productions), naturally the number of pot needs to be added, or weights to be readjusted accordingly.

All the best,
Antonio
## Checklist

- [X] Changelog updated (if applicable)
- [X] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the value written to the decay output’s `weight` field so it now uses the proper per-spill normalization.
  * Fixed the “pot” branch behavior in the decay tree generated by the decay-making workflow.

* **Documentation**
  * Updated the changelog with the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->