### PR TITLE
Simplify TFile open checks and fix graceful-degradation crash

### DIFF
--- a/.github/scripts/extract_physics_metrics.py
+++ b/.github/scripts/extract_physics_metrics.py
@@ -196,10 +196,12 @@ def extract_metrics_from_file(file_path: Path, config: dict[str, Any]) -> dict[s
         2. Add a new key to the metrics dict (e.g., "graphs": {})
         3. Add an isinstance check in the loop below
     """
-    with ROOT.TFile.Open(str(file_path)) as root_file:
-        if not root_file or root_file.IsZombie():
-            return None
+    try:
+        root_file = ROOT.TFile.Open(str(file_path))
+    except OSError:
+        return None
 
+    with root_file:
         metrics = {
             "file_size": file_path.stat().st_size,
             "trees": {},

--- a/.github/scripts/render_plots.py
+++ b/.github/scripts/render_plots.py
@@ -110,8 +110,9 @@ def main() -> int:
     all_rendered: list[dict[str, str]] = []
 
     for input_path in args.inputs:
-        root_file = ROOT.TFile.Open(input_path)
-        if not root_file or root_file.IsZombie():
+        try:
+            root_file = ROOT.TFile.Open(input_path)
+        except OSError:
             print(f"WARNING: Cannot open {input_path}", file=sys.stderr)
             continue
 

--- a/examples/analysis_example.py
+++ b/examples/analysis_example.py
@@ -21,14 +21,6 @@ def main() -> None:
 
     # Open MC simulation file
     f = ROOT.TFile.Open(options.simfile, "read")
-    if not f or f.IsZombie():
-        import os
-
-        print(f"ERROR: Cannot open MC simulation file: {options.simfile}")
-        print(f"Current working directory: {os.getcwd()}")
-        print("Files in current directory:")
-        os.system("ls -lh *.root")
-        raise RuntimeError(f"Cannot open MC simulation file: {options.simfile}")
 
     # Check what trees are in the file
     keys = [k.GetName() for k in f.GetListOfKeys()]
@@ -43,8 +35,6 @@ def main() -> None:
 
     # Add reconstruction data as friend tree
     reco_f = ROOT.TFile.Open(options.recofile, "read")
-    if not reco_f or reco_f.IsZombie():
-        raise RuntimeError(f"Cannot open reconstruction file: {options.recofile}")
 
     reco_keys = [k.GetName() for k in reco_f.GetListOfKeys()]
     print(f"Keys in {options.recofile}: {reco_keys}")
@@ -52,8 +42,6 @@ def main() -> None:
     tree.AddFriend("ship_reco_sim", options.recofile)
 
     geo_file = ROOT.TFile.Open(options.geofile, "read")
-    if not geo_file or geo_file.IsZombie():
-        raise RuntimeError(f"Cannot open geometry file: {options.geofile}")
 
     selection = analysis_toolkit.selection_check(geo_file)
     inspector = analysis_toolkit.event_inspector()

--- a/macro/makeGenieEvents.py
+++ b/macro/makeGenieEvents.py
@@ -71,9 +71,7 @@ NUPDGLIST = [16, -16, 14, -14, 12, -12]
 
 def extract_nu_over_nubar(neutrino_flux: Path, particles: Sequence[int]) -> dict[int, float]:
     """Compute ν/ν̄ = sum(nu)/sum(nubar) from 1D flux histograms."""
-    f = ROOT.TFile(str(neutrino_flux), "READ")
-    if not f or f.IsZombie():
-        raise FileNotFoundError(f"Cannot open flux file: {neutrino_flux}")
+    f = ROOT.TFile.Open(str(neutrino_flux), "READ")
     try:
         ratios: dict[int, float] = {}
         for pdg in particles:

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -1009,8 +1009,6 @@ if options.muonback:
             break
     if fin is None:
         fin = ROOT.TFile.Open(outFile)
-    if not fin or fin.IsZombie():
-        raise OSError(f"Failed to open output file: {outFile}")
     t = fin["cbmsim"]
     fout = ROOT.TFile(tmpFile, "recreate")
     fSink = ROOT.FairRootFileSink(fout)
@@ -1102,8 +1100,6 @@ if options.command == "Genie":
     # Copy Genie (gst TTree) information to the output file
     input_path = inputFile[0] if isinstance(inputFile, (list, tuple)) else inputFile
     f_input = ROOT.TFile.Open(input_path, "READ")
-    if not f_input or f_input.IsZombie():
-        raise OSError(f"Failed to open GENIE input file: {input_path}")
     gst = f_input["gst"]
     if not gst:
         raise KeyError("TTree 'gst' not found in GENIE input file")

--- a/python/genie_interface.py
+++ b/python/genie_interface.py
@@ -343,19 +343,14 @@ def add_hists(inputflux: PathLike, simfile: PathLike, nupdg: int) -> None:
     ------
     FileNotFoundError
         If the requested histogram is not found in ``inputflux``.
-    RuntimeError
+    OSError
         If ROOT fails to open either file.
 
     """
-    infile = ROOT.TFile(str(inputflux), "READ")
-    if not infile or infile.IsZombie():
-        raise RuntimeError(f"Failed to open input flux file: {inputflux}")
-    sfile = ROOT.TFile(str(simfile), "UPDATE")
-    if not sfile or sfile.IsZombie():
-        infile.Close()
-        raise RuntimeError(f"Failed to open simulation file for update: {simfile}")
-
-    try:
+    with (
+        ROOT.TFile.Open(str(inputflux), "READ") as infile,
+        ROOT.TFile.Open(str(simfile), "UPDATE") as sfile,
+    ):
         hname = get_2D_flux_name(nupdg)
         obj = infile.Get(hname)
         if not obj:
@@ -363,9 +358,6 @@ def add_hists(inputflux: PathLike, simfile: PathLike, nupdg: int) -> None:
         # Write into the current directory of sfile
         sfile.cd()
         obj.Write()
-    finally:
-        infile.Close()
-        sfile.Close()
 
 
 # --------------------------- CLI ---------------------------------------------

--- a/python/validationTools.py
+++ b/python/validationTools.py
@@ -261,11 +261,13 @@ def print_simulation_output_summary(ROOT, output_filename, requested_events, fla
         for label, value in generator_stats:
             print_kv(label, value)
 
-    with ROOT.TFile.Open(output_filename, "READ") as summary_file:
-        if not summary_file or summary_file.IsZombie():
-            print("Could not reopen output file for summary:", output_filename)
-            return
+    try:
+        summary_file = ROOT.TFile.Open(output_filename, "READ")
+    except OSError:
+        print("Could not reopen output file for summary:", output_filename)
+        return
 
+    with summary_file:
         keys = list(summary_file.GetListOfKeys())
         print_section("Tree Validation")
         print_kv("Requested events", requested_events)

--- a/shipgen/EvtCalcGenerator.cxx
+++ b/shipgen/EvtCalcGenerator.cxx
@@ -29,7 +29,7 @@ Bool_t EvtCalcGenerator::Init(const char* fileName, const int startEvent) {
   }
   fInputFile = std::unique_ptr<TFile>(TFile::Open(fileName, "read"));
   LOGF(info, "Info EvtCalcGenerator: Opening input file %s", fileName);
-  if (!fInputFile || fInputFile->IsZombie()) {
+  if (!fInputFile) {
     LOG(error) << "EvtCalcGenerator: error opening input file " << fileName;
     fInputFile.reset();
     return kFALSE;

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -75,7 +75,7 @@ Bool_t FixedTargetGenerator::InitForCharmOrBeauty(const TString& fInName,
     return kFALSE;
   }
   fin = TFile::Open(fInName, "READ");
-  if (!fin || fin->IsZombie()) {
+  if (!fin) {
     LOG(error) << "FixedTargetGenerator: could not open input file "
                << fInName.Data();
     delete fin;

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -41,7 +41,7 @@ Bool_t GenieGenerator::Init(const char* fileName, const int startEvent) {
     return kFALSE;
   }
   fInputFile = TFile::Open(fileName, "READ");
-  if (!fInputFile || fInputFile->IsZombie()) {
+  if (!fInputFile) {
     LOG(error) << "GenieGenerator: error opening input file " << fileName;
     delete fInputFile;
     fInputFile = nullptr;

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -54,7 +54,7 @@ Bool_t HNLPythia8Generator::Init() {
     fInputFile = TFile::Open(fextFile->c_str(), "READ");
     LOG(info) << "Open external file with charm or beauty hadrons: "
               << *fextFile;
-    if (!fInputFile || fInputFile->IsZombie()) {
+    if (!fInputFile) {
       LOG(error) << "HNLPythia8Generator: error opening input file "
                  << *fextFile;
       delete fInputFile;

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -43,7 +43,7 @@ Bool_t MuDISGenerator::Init(const char* fileName, const int startEvent) {
   dPart = nullptr;
   dPartSoft = nullptr;
   fInputFile = TFile::Open(fileName, "READ");
-  if (!fInputFile || fInputFile->IsZombie()) {
+  if (!fInputFile) {
     LOG(error) << "MuDISGenerator: error opening input file " << fileName;
     delete fInputFile;
     fInputFile = nullptr;

--- a/shipgen/NtupleGenerator.cxx
+++ b/shipgen/NtupleGenerator.cxx
@@ -34,7 +34,7 @@ Bool_t NtupleGenerator::Init(const char* fileName, const int startEvent) {
 
   LOG(info) << "NtupleGenerator: Opening input file " << fileName;
   fInputFile = TFile::Open(fileName, "READ");
-  if (!fInputFile || fInputFile->IsZombie()) {
+  if (!fInputFile) {
     LOG(error) << "NtupleGenerator: Error opening input file " << fileName;
     delete fInputFile;
     fInputFile = nullptr;

--- a/shipgen/ParticleGunGenerator.cxx
+++ b/shipgen/ParticleGunGenerator.cxx
@@ -88,7 +88,7 @@ void ParticleGunGenerator::LoadHistoFromFile(
     const std::string& inFile, const std::string& inHisto,
     std::vector<std::string> varNames) {
   TFile* loadFile = TFile::Open(inFile.c_str(), "READ");
-  if (!loadFile || loadFile->IsZombie()) {
+  if (!loadFile) {
     delete loadFile;
     LOG(fatal) << "ParticleGunGenerator: Cannot open file " << inFile;
     throw std::runtime_error("ParticleGunGenerator: Cannot open file " +

--- a/shipgen/Pythia8Generator.cxx
+++ b/shipgen/Pythia8Generator.cxx
@@ -52,7 +52,7 @@ Bool_t Pythia8Generator::Init() {
     fInputFile = TFile::Open(fextFile->c_str(), "READ");
     LOG(info) << "Open external file with charm or beauty hadrons: "
               << *fextFile;
-    if (!fInputFile || fInputFile->IsZombie()) {
+    if (!fInputFile) {
       LOG(error) << "Pythia8Generator: error opening input file " << *fextFile;
       delete fInputFile;
       fInputFile = nullptr;

--- a/shipgen/TTreeGenerator.cxx
+++ b/shipgen/TTreeGenerator.cxx
@@ -49,7 +49,7 @@ Bool_t TTreeGenerator::Init(const char* fileName, int startEvent) {
   fCurrentEvent = 0;
 
   fInputFile = TFile::Open(fileName, "READ");
-  if (!fInputFile || fInputFile->IsZombie()) {
+  if (!fInputFile) {
     LOG(error) << "TTreeGenerator: Cannot open file " << fileName;
     delete fInputFile;
     fInputFile = nullptr;

--- a/tests/data/skim_muonback_smoke.py
+++ b/tests/data/skim_muonback_smoke.py
@@ -40,15 +40,11 @@ def main() -> int:
     args = parser.parse_args()
 
     src = ROOT.TFile.Open(args.source, "READ")
-    if not src or src.IsZombie():
-        raise SystemExit(f"Failed to open source: {args.source}")
     tree = src.Get("pythia8-Geant4") or src.Get("cbmsim")
     if not tree:
         raise SystemExit("Neither pythia8-Geant4 nor cbmsim tree found in source")
 
     out = ROOT.TFile.Open(str(args.output), "RECREATE")
-    if not out or out.IsZombie():
-        raise SystemExit(f"Failed to open output: {args.output}")
     skim = tree.CopyTree("", "", args.entries, 0)
     skim.Write()
     out.Close()


### PR DESCRIPTION
## Summary

Cleans up `TFile` open/zombie checks across the C++ generators and Python code, and fixes a latent crash where unreadable ROOT files were meant to be skipped.

The driving observation is that `TFile::Open` already handles zombies for you, but it does so differently in the two languages:

- **C++ `TFile::Open`** returns `nullptr` on failure (it deletes the zombie object internally). A non-null result is therefore always non-zombie, so `if (!f || f->IsZombie())` is redundant — the `IsZombie()` half can never fire.
- **PyROOT `TFile.Open` *and* the `TFile(...)` constructor** are pythonized to **raise `OSError`** on failure (see `ROOT/_pythonization/_tfile.py`). They never return `None` or a zombie, so the usual `if not f: ...` guards after them are unreachable dead code.

## Changes

**`refactor(shipgen)`** — drop the redundant `|| ->IsZombie()` from all 9 generators, keeping the live `if (!f)` null check.

**`fix`** — three Python sites intended to *degrade gracefully* on a bad file (skip + warn, return `None`, print + return) never did: because `TFile.Open` raises `OSError`, a bad file crashed the caller instead. Wrap those opens in `try/except OSError` so they behave as intended:
- `.github/scripts/render_plots.py` — skip the file and warn
- `.github/scripts/extract_physics_metrics.py` — return `None`
- `python/validationTools.py` — print a warning and return

**`refactor`** — remove the now-dead `if not f:` guards at the re-raise sites (the open already raises `OSError`), convert the remaining `ROOT.TFile(...)` constructors to `TFile.Open` for consistency, and manage `genie_interface.add_hists`' files with a combined `with` statement (which also closes the input file if opening the output file fails).

## Testing

- `prek` (ruff, ruff-format, mypy, clang-format, cpplint, codespell, …) passes on all changed files.
- All 9 changed C++ files pass `-fsyntax-only` with their real compile flags from `compile_commands.json`.
- Runtime checks: `extract_metrics_from_file(<missing>)` now returns `None` instead of crashing; `add_hists` closes the input file when the output open fails, still raises `FileNotFoundError` on a missing histogram, and copies the histogram on the happy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several analysis, validation, and generator workflows to handle file-open failures more consistently.
  * Some file checks now rely on standard open errors, which may change when invalid inputs are reported during processing.

* **Refactor**
  * Simplified ROOT file opening and cleanup logic across scripts and generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->