### PR TITLE
ci: drop obsolete gcc-include workaround from clang-tidy

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -127,7 +127,7 @@ cmd = "python .github/scripts/render_plots.py *_run_fixedTarget_1/*.root --outpu
 # expansion.
 
 [tasks.ci-clang-tidy]
-cmd = "bash -c 'set -o pipefail; GCC_INC=$(x86_64-conda-linux-gnu-gcc -print-file-name=include); echo $CPP_FILES | xargs -P $(nproc) clang-tidy -p build/ --extra-arg-before=-isystem$GCC_INC 2>&1 | python .github/scripts/annotate_build.py'"
+cmd = "bash -c 'set -o pipefail; echo $CPP_FILES | xargs -P $(nproc) clang-tidy -p build/ 2>&1 | python .github/scripts/annotate_build.py'"
 
 [tasks.ci-pyrefly]
 cmd = "pyrefly check --output-format=github $PY_FILES"


### PR DESCRIPTION
## Problem

The gating **Static analysis (PR diff)** check fails on every C++-touching PR. The `ci-clang-tidy` task injects the conda GCC internal include dir:

```
--extra-arg-before=-isystem$(x86_64-conda-linux-gnu-gcc -print-file-name=include)
```

added in cf7d7e9e0 to fix `'stdarg.h'/'stddef.h' file not found`. That pulls conda **GCC 14.3** intrinsic headers (`adxintrin.h`, `cetintrin.h`, `ia32intrin.h`, …) ahead of clang's own. **LLVM 22 clang** can't resolve GCC's `__builtin_ia32_*` builtins, so it emits `clang-diagnostic-error`s and exits non-zero; `set -o pipefail` turns that into a job failure. (`annotate_build.py` filters those `.pixi/` diagnostics out of the annotations but always exits 0, so the check goes red with no inline comments.)

## Fix

The premise behind the workaround no longer holds: clang's resource dir (`lib/clang/22/include`) now ships `stddef.h`, `stdarg.h` **and** clang-compatible x86 intrinsics, and clang finds it by default. So the GCC-include injection is both obsolete and the direct cause of the failure. Remove it; keep `set -o pipefail` (genuine clang-tidy errors still gate) and the `annotate_build.py` pipe. The `HeaderFilterRegex` narrowing from cf7d7e9e0 (in `.clang-tidy`) is unrelated and stays.

## Verification

Running the unchanged pipeline (minus the workaround) over the `shipgen/*.cxx` sources locally:

```
PIPELINE_EXIT=0
Annotation Summary — Errors: 0  Warnings: 0  Notices: 0
clang-diagnostic-errors: 0
```

Before this change the same files produced 76 `clang-diagnostic-error`s from `.pixi/.../include/*intrin.h` and exit 1.