### PR TITLE
build(deps): add explicit eigen dependency

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -47,6 +47,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py313h5d5ffb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/evtgen-2.2.3-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.8.1-hecca717_1.conda
@@ -454,6 +455,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py313h5d5ffb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/evtgen-2.2.3-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.8.1-hecca717_1.conda
@@ -1511,6 +1513,19 @@ packages:
     - double-conversion >=3.4.0,<3.5.0a0
   size: 71809
   timestamp: 1765193127016
+- conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h54a6638_2.conda
+  sha256: a627704a4dc57459dbcdec8296c3f7f1801e53d441b7cadb56a2caa57920a5b3
+  md5: 00f77958419a22c6a41568c6decd4719
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  run_exports: {}
+  size: 1173190
+  timestamp: 1771922274213
 - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
   sha256: a5b51e491fec22bcc1765f5b2c8fff8a97428e9a5a7ee6730095fb9d091b0747
   md5: 057083b06ccf1c2778344b6dabace38b

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,6 +17,10 @@ faircmakemodules = { version = ">=1.0", channel = "conda-forge" }
 # fairlogger is on conda-forge but is not in fairroot's runtime deps —
 # keep it explicit so CMake's find_package(FairLogger) resolves.
 fairlogger = ">=2.3"
+# Eigen is header-only, so its conda package has no run_export and is not pulled
+# in transitively by acts-ship/genfit. acts-ship's CMake config requires
+# Eigen3 3.4.0 EXACT, so pin to 3.4.x (conda-forge is the only source).
+eigen = "3.4.*"
 
 # Python (conda-forge)
 # acts-ship requires python 3.13, so the whole env is pinned to 3.13.


### PR DESCRIPTION
## Summary

Eigen3 is required by both **acts-ship** and **genfit** but was not present in the pixi environment. As a header-only library, Eigen's conda package carries no `run_export` — the mechanism conda uses to propagate a dependency's headers downstream — so neither package pulls it in transitively. `pixi.lock` had zero eigen entries and the env had no `include/eigen3` directory.

This declares Eigen explicitly and regenerates the lock.

## Version pin

acts-ship's installed CMake config does `find_dependency(Eigen3 3.4.0 CONFIG EXACT)` and exposes Eigen in its public headers, so it must be the exact 3.4.0 it was built against — not conda-forge's current default (5.0.x). Pinned to `3.4.*`; eigen is only on conda-forge (not on prefix.dev/ship), so no channel pin is needed.

## Verification

- `pixi lock` resolves cleanly; eigen 3.4.0 added to the `default` and `lint` solve-groups (no other packages moved).
- After install, `include/eigen3/Eigen` headers and `share/eigen3/cmake/Eigen3Config.cmake` are present at exactly 3.4.0 — satisfying acts-ship's EXACT requirement.
- Full `pixi run build` from scratch: 132/132 targets, 0 errors.