### PR TITLE
Freeze Eigen in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>ShipSoft/.github"]
+  "extends": ["local>ShipSoft/.github"],
+  "packageRules": [
+    {
+      "description": "Eigen is pinned to 3.4.x because acts-ship requires Eigen 3.4.0 EXACT",
+      "matchManagers": ["pixi"],
+      "matchPackageNames": ["eigen"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Disables Renovate updates for `eigen`, which is pinned to `3.4.*` because acts-ship requires Eigen 3.4.0 EXACT; without this Renovate would open a build-breaking 5.x bump.