### PR TITLE
ci(lint): let prek post its output as a PR comment

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   prek:
     name: Pre-commit (prek)
+    permissions:
+      contents: read
+      pull-requests: write # let prek post its output as a PR comment on failure
     uses: ShipSoft/.github/.github/workflows/prek.yml@main
     with:
       # mypy was skipped on pre-commit.ci; keep it local-only for now.


### PR DESCRIPTION
## Summary

Grants the `prek` job `pull-requests: write` so the reusable prek workflow can post its hook output as a sticky PR comment when a hook fails (updated in place on subsequent pushes; flipped to a "passed" note once hooks pass).

The reusable workflow inherits the caller's token, so this permission has to be granted here — see ShipSoft/.github#12, which makes commenting opt-in per caller.

## Notes

- Requires ShipSoft/.github#12 to be merged first (it removes the elevated `permissions:` block from the reusable workflow that was causing `startup_failure` on this repo).
- `actionlint` passes.