### PR TITLE
fix: correct float return types in branching-ratio helpers

### DIFF
--- a/python/pythia8_conf_utils.py
+++ b/python/pythia8_conf_utils.py
@@ -249,7 +249,7 @@ def add_dummy_channel(P8gen, particle, remainder) -> None:
         P8gen.SetParameters(f"{particle}:addChannel      1   {remainder:.16}    0       22      22")
 
 
-def compute_max_total_br(decay_chains) -> int:
+def compute_max_total_br(decay_chains) -> float:
     """
     This function computes the maximum total branching ratio for all decay chains.
 
@@ -271,11 +271,11 @@ def compute_max_total_br(decay_chains) -> int:
     return max(total_branching_ratios)
 
 
-def compute_total_br(particle, decay_chains) -> int:
+def compute_total_br(particle, decay_chains) -> float:
     """
     Returns the total branching ratio to HNLs for a given particle.
     """
-    return sum(np.prod(branching_ratios) for (top, branching_ratios) in decay_chains if top == particle)
+    return sum(float(np.prod(branching_ratios)) for (top, branching_ratios) in decay_chains if top == particle)
 
 
 def get_top_level_particles(decay_chains):


### PR DESCRIPTION
`compute_total_br` and `compute_max_total_br` in `python/pythia8_conf_utils.py` were annotated `-> int`, but branching ratios are floats (`branching_ratios = np.zeros(...)`, values in [0, 1]), so their total/maximum are floats too.

This tripped the mypy pre-commit hook:

```
python/pythia8_conf_utils.py:278:16: error: Generator has incompatible item type "signedinteger[Any]"; expected "bool"  [misc]
```

With no `start` argument, `sum()` matched typeshed's `Iterable[bool | int] -> int` overload, which `np.prod(...)` (a numpy scalar) does not satisfy.

Changes:
- Annotate both helpers `-> float`.
- Cast the per-chain product to a plain Python `float` so `sum()` resolves to the `float` overload.

No caller depends on an integer return — the result is only used in a `<= 0` comparison and passed to float-compatible helpers.

Verified with mypy (same flags as the hook): `Success: no issues found in 1 source file`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Branching-ratio calculations now return floating-point values consistently.
  * Improved total branching-ratio aggregation to avoid unintended integer-style results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->