### PR TITLE
Fix correctness and memory-safety bugs in C++ detector modules

### DIFF
--- a/SND/MTC/MTCDetHit.cxx
+++ b/SND/MTC/MTCDetHit.cxx
@@ -75,6 +75,12 @@ MTCDetHit::MTCDetHit(int SiPMChan, const std::vector<MTCDetPoint*>& points,
 
   // Separate handling for scintillating mat (plane_type == 2)
   if (plane_type == 2) {
+    if (points.empty()) {
+      // No deposits: avoid dividing by n == 0 (NaN coordinates) and seeding
+      // the time from FLT_MAX.
+      flag = false;
+      return;
+    }
     Float_t x_temp = 0.0, y_temp = 0.0, z_temp = 0.0;
     for (auto* pt : points) {
       signal_sum += pt->GetEnergyLoss();

--- a/SND/MTC/MTCDetHit.h
+++ b/SND/MTC/MTCDetHit.h
@@ -66,7 +66,7 @@ class MTCDetHit : public SHiP::DetectorHit {
   */
  private:
   Float_t signals = 0;
-  Float_t time;
+  Float_t time = 0;
   Float_t Xch = 0.0, Ych = 0.0, Zch = 0.0;
   Bool_t flag{true};  ///< flag
 

--- a/TimeDet/TimeDetHit.h
+++ b/TimeDet/TimeDetHit.h
@@ -56,8 +56,8 @@ class TimeDetHit : public SHiP::DetectorHit {
   static constexpr Double_t v_drift = 15.;  // cm/ns
   static constexpr Double_t par[4] = {0.0272814, 109.303, 0, 0.0539487};
 
-  Bool_t flag{true};  ///< flag
-  Float_t t_1, t_2;   ///< TDC on both sides
+  Bool_t flag{true};       ///< flag
+  Float_t t_1{0}, t_2{0};  ///< TDC on both sides
 
   ClassDefOverride(TimeDetHit, 4);
 };

--- a/passive/ShipMuonShield.cxx
+++ b/passive/ShipMuonShield.cxx
@@ -314,7 +314,9 @@ void ShipMuonShield::Initialize(
   for (auto i : {&dXIn, &dXOut, &dYIn, &dYOut, &dZ, &Z_rel, &midGapIn,
                  &midGapOut, &ratio_yokesIn, &ratio_yokesOut, &dY_yokeIn,
                  &dY_yokeOut, &Bgoal, &gapIn, &gapOut, &Z}) {
-    i->reserve(nMagnets);
+    // These are written below via operator[], which requires size(), not
+    // merely reserved capacity; resize() to avoid out-of-bounds UB.
+    i->resize(nMagnets);
   }
   magnetName.push_back("MagnAbsorb");
   for (size_t i = 1; i < nMagnets; ++i) {
@@ -327,6 +329,11 @@ void ShipMuonShield::Initialize(
                     FieldDirection::up,   FieldDirection::up,
                     FieldDirection::up,   FieldDirection::down,
                     FieldDirection::down, FieldDirection::down};
+  if (nMagnets > fieldDirection.size()) {
+    LOG(fatal) << "ShipMuonShield::Initialize: " << nMagnets
+               << " magnets configured but only " << fieldDirection.size()
+               << " field directions are defined; extend fieldDirection.";
+  }
 
   std::vector<Double_t> params;
   params = shield_params;

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -281,6 +281,7 @@ void ShipStack::UpdateTrackIndex(TRefArray* detList) {
 
   if (fDetList == nullptr) {
     // Now iterate through all active detectors
+    fDetList = detList;
     fDetIter = detList->MakeIterator();
     fDetIter->Reset();
   } else {

--- a/splitcal/splitcal.cxx
+++ b/splitcal/splitcal.cxx
@@ -169,11 +169,11 @@ void splitcal::ConstructGeometry() {
   TGeoVolume* stripGivingX;
   TGeoVolume* stripGivingY;
 
-  TGeoVolume* newHCALfilter[100];
-  TGeoVolume* newHCALdet[100];
-  const char* char_labelHCALfilter[100];
+  TGeoVolume* newHCALfilter[100] = {};
+  TGeoVolume* newHCALdet[100] = {};
+  const char* char_labelHCALfilter[100] = {};
   TString labelHCALfilter;
-  const char* char_labelHCALdet[100];
+  const char* char_labelHCALdet[100] = {};
   TString labelHCALdet;
 
   Double_t z_splitcal = 0;
@@ -301,7 +301,7 @@ void splitcal::ConstructGeometry() {
 
   }  // end loop in ecal layers
 
-  for (Int_t i_nlayHCAL = 0; i_nlayHCAL < 1; i_nlayHCAL++) {
+  for (Int_t i_nlayHCAL = 0; i_nlayHCAL < fnHCALSamplings; i_nlayHCAL++) {
     labelHCALfilter = "HCALfilter_";
     labelHCALfilter += i_nlayHCAL;
     char_labelHCALfilter[i_nlayHCAL] = labelHCALfilter;

--- a/splitcal/splitcal.cxx
+++ b/splitcal/splitcal.cxx
@@ -5,6 +5,7 @@
 #include "splitcal.h"
 
 #include <iostream>
+#include <vector>
 
 #include "FairGeoBuilder.h"
 #include "FairGeoInterface.h"
@@ -169,12 +170,10 @@ void splitcal::ConstructGeometry() {
   TGeoVolume* stripGivingX;
   TGeoVolume* stripGivingY;
 
-  TGeoVolume* newHCALfilter[100] = {};
-  TGeoVolume* newHCALdet[100] = {};
-  const char* char_labelHCALfilter[100] = {};
   TString labelHCALfilter;
-  const char* char_labelHCALdet[100] = {};
   TString labelHCALdet;
+  std::vector<TGeoVolume*> newHCALfilter(fnHCALSamplings, nullptr);
+  std::vector<TGeoVolume*> newHCALdet(fnHCALSamplings, nullptr);
 
   Double_t z_splitcal = 0;
 
@@ -304,17 +303,13 @@ void splitcal::ConstructGeometry() {
   for (Int_t i_nlayHCAL = 0; i_nlayHCAL < fnHCALSamplings; i_nlayHCAL++) {
     labelHCALfilter = "HCALfilter_";
     labelHCALfilter += i_nlayHCAL;
-    char_labelHCALfilter[i_nlayHCAL] = labelHCALfilter;
     labelHCALdet = "HCAL_det";
     labelHCALdet += i_nlayHCAL;
-    char_labelHCALdet[i_nlayHCAL] = labelHCALdet;
-    newHCALfilter[i_nlayHCAL] =
-        gGeoManager->MakeBox(char_labelHCALfilter[i_nlayHCAL], A2, fXMax, fYMax,
-                             fFilterHCALThickness / 2);
+    newHCALfilter[i_nlayHCAL] = gGeoManager->MakeBox(
+        labelHCALfilter, A2, fXMax, fYMax, fFilterHCALThickness / 2);
     if (fActiveHCAL) {
-      newHCALdet[i_nlayHCAL] =
-          gGeoManager->MakeBox(char_labelHCALdet[i_nlayHCAL], A4, fXMax, fYMax,
-                               fActiveHCALThickness / 2);
+      newHCALdet[i_nlayHCAL] = gGeoManager->MakeBox(
+          labelHCALdet, A4, fXMax, fYMax, fActiveHCALThickness / 2);
 
       AddSensitiveVolume(newHCALdet[i_nlayHCAL]);
 

--- a/splitcal/splitcalCluster.cxx
+++ b/splitcal/splitcalCluster.cxx
@@ -54,13 +54,21 @@ void splitcalCluster::ComputeEtaPhiE(const std::vector<splitcalHit>& hits) {
     }
   }  // end loop on hit
 
+  // A cluster needs both an X and a Y projection to yield a 3D start/end
+  // point; dereferencing an empty map below would be undefined behaviour.
+  if (mapLayerWeigthedX.empty() || mapLayerWeigthedY.empty()) {
+    double zeroEta = 0., zeroPhi = 0.;
+    SetEtaPhiE(zeroEta, zeroPhi, energy);
+    return;
+  }
+
   auto const& [minLayerX, weightedMinX] = *mapLayerWeigthedX.begin();
   double minX = weightedMinX / mapLayerSumWeigthsX[minLayerX];
   double minZ1 = mapLayerZ1[minLayerX];
 
   auto const& [minLayerY, weightedMinY] = *mapLayerWeigthedY.begin();
   double minY = weightedMinY / mapLayerSumWeigthsY[minLayerY];
-  double minZ2 = mapLayerZ1[minLayerY];
+  double minZ2 = mapLayerZ2[minLayerY];
 
   double minZ = (minZ1 + minZ2) / 2.;
 
@@ -72,7 +80,7 @@ void splitcalCluster::ComputeEtaPhiE(const std::vector<splitcalHit>& hits) {
 
   auto const& [maxLayerY, weightedMaxY] = *mapLayerWeigthedY.rbegin();
   double maxY = weightedMaxY / mapLayerSumWeigthsY[maxLayerY];
-  double maxZ2 = mapLayerZ1[maxLayerY];
+  double maxZ2 = mapLayerZ2[maxLayerY];
 
   double maxZ = (maxZ1 + maxZ2) / 2.;
 

--- a/strawtubes/Tracklet.cxx
+++ b/strawtubes/Tracklet.cxx
@@ -39,7 +39,7 @@ Tracklet::~Tracklet() = default;
 Int_t Tracklet::link2MCTrack(std::vector<strawtubesPoint>* strawPoints,
                              Float_t min) {
   Int_t nTot = aTracklet.size();
-  std::unordered_map<int, int> MC;
+  std::unordered_map<int, double> MC;
   Int_t trackID = -1;
   for (std::vector<int>::size_type i = 0; i != aTracklet.size(); i++) {
     trackID = (*strawPoints)[aTracklet[i]].GetTrackID();

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -60,6 +60,11 @@ Bool_t strawtubes::ProcessHits(FairVolume* vol) {
     fLength = gMC->TrackLength();
     gMC->TrackPosition(fPos);
     gMC->TrackMomentum(fMom);
+    // Clear the "already recorded" marker on every fresh entry so that a later
+    // traversal of the same straw (curling track, delta ray, next track or
+    // event) is not silently dropped. The marker only exists to deduplicate
+    // repeated exit signals at the same boundary crossing.
+    fVolumeID = -1;
   }
   // Sum energy loss for all steps in the active volume
   fELoss += gMC->Edep();

--- a/strawtubes/strawtubes.h
+++ b/strawtubes/strawtubes.h
@@ -45,7 +45,7 @@ class strawtubes : public SHiP::Detector<strawtubesPoint> {
   void SetDeltazView(Double_t delta_z_view);
   void SetStationEnvelope(Double_t x, Double_t y, Double_t z);
   static std::array<Int_t, 4> StrawDecode(Int_t detID);
-  static void StrawEndPoints(Int_t detID, TVector3& top, TVector3& bot);
+  static void StrawEndPoints(Int_t detID, TVector3& bot, TVector3& top);
   // for the digitizing step
   void SetStrawResolution(Double_t a, Double_t b) {
     v_drift = a;


### PR DESCRIPTION
Fixes a batch of bug-category findings from a full-tree code review, scoped to the C++ detector modules. Each commit is a self-contained fix grouped by risk/kind.

## High severity (memory safety / logic)
- **ShipMuonShield**: `Initialize` wrote 16 magnet-parameter vectors through `operator[]` after only `reserve()`-ing them — out-of-bounds UB. Switched to `resize()`, and added a guard against configuring more magnets than the hard-coded `fieldDirection` list provides.
- **splitcal**: `ConstructGeometry` created only `newHCALfilter[0]`/`newHCALdet[0]` (loop bound `< 1`) but placed `fnHCALSamplings` of them — dereferencing uninitialized pointers when `fnHCALSamplings > 1` (latent; current config uses 0). Zero-initialized the arrays and let the creation loop cover `fnHCALSamplings`.
- **Tracklet**: `link2MCTrack` accumulated the fractional weight `1./nTot` into an `int`-valued map, truncating every increment to 0 so the threshold never fired. Now uses a `double`-valued map.

## Medium severity
- **splitcalCluster**: `ComputeEtaPhiE` indexed the X-layer z-map with Y-layer keys (`mapLayerZ1` instead of `mapLayerZ2`), roughly halving the cluster Z. Also guards empty clusters against `begin()`/`rbegin()` UB.
- **strawtubes** (behaviour-changing, reviewed with maintainer): the `fVolumeID` dedup marker was never cleared, so all straw hits after the first in a given straw — from curling tracks, delta rays, later tracks or events — were silently dropped along with their energy loss. Now cleared on each track entry.

## Low severity (hardening)
- **ShipStack**: `fDetList` was never assigned, leaking a fresh detector iterator every event.
- **TimeDetHit / MTCDetHit**: added in-class initializers for indeterminate time members; guarded the MTC scint branch against an empty points vector (NaN / FLT_MAX).
- **strawtubes.h**: `StrawEndPoints` declaration named its out-params `(top, bot)` while the definition fills `(bot, top)`; renamed the declaration to match.

## Not included (deferred to domain expert)
- `MTCDetector::ProcessHits` has an always-false condition (`fVolumeID/100000 == 3`) that prevents scint-tile hits from using the entry/exit midpoint. Filed as #1307 for MTC-expert confirmation of intent rather than changing hit reconstruction here.

## Verification
Built cleanly with pixi; `ci-sim` and `ci-reco` both complete successfully on the default HNL signal chain (real outputs, no errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid detector hit/time calculations when no deposit data is available and when calorimeter projection inputs are missing; corrected Y-layer Z-coordinate averaging.
  * Added default initialization for hit time and TDC members to avoid unintended uninitialized values.
  * Improved robustness and correctness of detector iteration updates, muon-shield magnetic field setup (including a fatal config mismatch check), straw hit deduplication on re-entry, and MC track-linking precision; updated straw endpoint argument order (API change).
* **Chores**
  * Updated HCAL geometry construction to use configuration-driven dynamic containers for safer layer assembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->