### PR TITLE
Fix correctness bugs in shipgen event generators

### DIFF
--- a/shipgen/CosmicsGenerator.cxx
+++ b/shipgen/CosmicsGenerator.cxx
@@ -186,7 +186,7 @@ Bool_t CosmicsGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   cpg->AddTrack(
       PID, px, py, pz, x, y, z, -1, true, TMath::Sqrt(P * P + mass * mass), 0,
       weight);  // -1 = Mother ID, true = tracking, SQRT(x) = Energy, 0 = t
-  if (!nInside % 10000) {
+  if (nInside % 10000 == 0) {
     cout << nInside / 10000 << "10k events have been simulated" << endl;
   }
   return kTRUE;

--- a/shipgen/CosmicsGenerator.h
+++ b/shipgen/CosmicsGenerator.h
@@ -78,7 +78,7 @@ class CosmicsGenerator : public SHiP::Generator {
   int n_EVENTS;
 
  private:
-  Co3Rng* fRandomEngine;  //!
+  Co3Rng* fRandomEngine = nullptr;  //!
 
  protected:
   double P, px, py, pz, x, y, z, weighttest, weight, mass, FluxIntegral, theta;

--- a/shipgen/DPPythia8Generator.h
+++ b/shipgen/DPPythia8Generator.h
@@ -94,11 +94,11 @@ class DPPythia8Generator : public SHiP::Generator {
 
  protected:
   // Bool_t fHadDecay;    //select hadronic decay
-  Double_t fMom;       // proton energy
-  Int_t fDP;           // DP ID
-  Int_t fId;           // target type
-  Bool_t fUseRandom1;  // flag to use TRandom1
-  Bool_t fUseRandom3;  // flag to use TRandom3 (default)
+  Double_t fMom;               // proton energy
+  Int_t fDP;                   // DP ID
+  Int_t fId;                   // target type
+  Bool_t fUseRandom1{kFALSE};  // flag to use TRandom1
+  Bool_t fUseRandom3{kTRUE};   // flag to use TRandom3 (default)
   Bool_t
       fpbrem;  // flag to do proton bremstrahlung production (default is false)
   TH2F* fpbremPDF;   // pointer to TH2 containing PDF(p,theta) to have a dark

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -171,6 +171,7 @@ Bool_t FixedTargetGenerator::Init() {
     fPythiaN = new Pythia8::Pythia();
   } else if (Option != "charm" && Option != "beauty" && !G4only) {
     LOG(error) << "Option not known " << Option.Data() << ", abort";
+    return kFALSE;
   }
   if (fUseRandom1) fRandomEngine = std::make_shared<PyTr1Rng>();
   if (fUseRandom3) fRandomEngine = std::make_shared<PyTr3Rng>();
@@ -465,7 +466,7 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     Double_t pt = TMath::Sqrt((n_mpx * n_mpx) + (n_mpy * n_mpy));
     // every event appears twice, i.e.
     if (pt < 1.e-5 && n_mid == 2212) {
-      pot += +0.5;
+      pot += 0.5;
       ntotprim += 1;
     }
     Int_t idabs = static_cast<int>(TMath::Abs(n_id));

--- a/shipgen/FixedTargetGenerator.h
+++ b/shipgen/FixedTargetGenerator.h
@@ -115,7 +115,8 @@ class FixedTargetGenerator : public SHiP::Generator {
   Bool_t fUseRandom1;  // flag to use TRandom1
   Bool_t fUseRandom3;  // flag to use TRandom3 (default)
   Double_t fSeed, EMax, fBoost, chicc, chibb, wspill, nrpotspill;
-  Int_t nEvents, nEntry, pot, nDsprim, ntotprim;
+  Double_t pot;  // proton-on-target counter, incremented by 0.5 per signal
+  Int_t nEvents, nEntry, nDsprim, ntotprim;
   Bool_t tauOnly, JpsiMainly, DrellYan, PhotonCollision, G4only, setByHand,
       Debug, withEvtGen, OnlyMuons;
   FairLogger* fLogger;        //!   don't make it persistent, magic ROOT command

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -94,16 +94,16 @@ class HNLPythia8Generator : public SHiP::Generator {
   std::shared_ptr<Pythia8::RndmEngine> fRandomEngine;
 
  protected:
-  Double_t fMom;       // proton momentum
-  Int_t fHNL;          // HNL ID
-  Int_t fId;           // target type
-  Bool_t fUseRandom1;  // flag to use TRandom1
-  Bool_t fUseRandom3;  // flag to use TRandom3 (default)
-  Double_t fLmin;      // m minimum  decay position z
-  Double_t fLmax;      // m maximum decay position z
-  Int_t fnRetries;     // retries: no HNL produced
-  Double_t fctau;      // hnl lifetime
-  Double_t fFDs;       // correction for Pythia6 to match measured Ds production
+  Double_t fMom;               // proton momentum
+  Int_t fHNL;                  // HNL ID
+  Int_t fId;                   // target type
+  Bool_t fUseRandom1{kFALSE};  // flag to use TRandom1
+  Bool_t fUseRandom3{kTRUE};   // flag to use TRandom3 (default)
+  Double_t fLmin;              // m minimum  decay position z
+  Double_t fLmax;              // m maximum decay position z
+  Int_t fnRetries;             // retries: no HNL produced
+  Double_t fctau;              // hnl lifetime
+  Double_t fFDs;  // correction for Pythia6 to match measured Ds production
   Double_t fsmearBeam;  // finite beam size
   Double_t fPaintBeam;  // beam painting radius
   TFile* fInputFile;    //! pointer to a file

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -167,18 +167,22 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     // get local material at this point
     TGeoNode* node = gGeoManager->FindNode(xmu, ymu, zmu);
     TGeoMaterial* mat = nullptr;
-    if (node && !gGeoManager->IsOutside())
+    if (node && !gGeoManager->IsOutside()) {
       mat = node->GetVolume()->GetMaterial();
-    LOG(debug) << "Info MuDISGenerator: mat " << count << ", " << mat->GetName()
-               << ", " << mat->GetDensity();
-    // density relative to Prob largest density along this trajectory, i.e. use
-    // rho(Pt)
-    prob2int = mat->GetDensity() / mparam[7];
-    if (prob2int > 1.) {
-      LOG(warning) << "MuDISGenerator: prob2int > Maximum density????";
-      LOG(warning) << "prob2int: " << prob2int;
-      LOG(warning) << "maxrho: " << mparam[7];
-      LOG(warning) << "material: " << mat->GetName();
+      LOG(debug) << "Info MuDISGenerator: mat " << count << ", "
+                 << mat->GetName() << ", " << mat->GetDensity();
+      // density relative to Prob largest density along this trajectory, i.e.
+      // use rho(Pt)
+      prob2int = mat->GetDensity() / mparam[7];
+      if (prob2int > 1.) {
+        LOG(warning) << "MuDISGenerator: prob2int > Maximum density????";
+        LOG(warning) << "prob2int: " << prob2int;
+        LOG(warning) << "maxrho: " << mparam[7];
+        LOG(warning) << "material: " << mat->GetName();
+      }
+    } else {
+      // sampled point is outside the geometry: reject and resample
+      prob2int = 0.;
     }
     count += 1;
   }

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -293,7 +293,7 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
           for (unsigned i = 0; i < list.size(); i++) {
             auto* v = getVetoPoint(list.at(i));
             Int_t muIndex = v->GetTrackID();
-            muList.insert({muIndex, i});
+            muList.insert({muIndex, list.at(i)});
           }
         }
       }

--- a/shipgen/ParticleGunGenerator.cxx
+++ b/shipgen/ParticleGunGenerator.cxx
@@ -47,7 +47,7 @@ static const std::map<std::string, ModelSpec>& kVertexModels() {
         [](ParticleGunParticle& p, const std::vector<Double32_t>& pars) {
           p.X = (pars[1] > 0) ? gRandom->Uniform(pars[0] - pars[1] / 2.,
                                                  pars[0] + pars[1] / 2.)
-                              : pars[1];
+                              : pars[0];
           p.Y = (pars[3] > 0) ? gRandom->Uniform(pars[2] - pars[3] / 2.,
                                                  pars[2] + pars[3] / 2.)
                               : pars[2];

--- a/shipgen/Pythia8Generator.cxx
+++ b/shipgen/Pythia8Generator.cxx
@@ -190,6 +190,16 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
   Double_t x, y, z, px, py, pz, dl, e, tof;
   Int_t im, id, key;
   fnRetries = 0;
+  // ReadEvent only supports the external-file mode (charm/beauty hadrons read
+  // from fTree). The standalone (no external file) branch in Init() has no
+  // corresponding event path here, so guard against dereferencing a null fTree
+  // instead of crashing on an uninitialized pointer.
+  if (!fTree) {
+    LOG(fatal) << "Pythia8Generator::ReadEvent: no external input tree is set; "
+                  "standalone generation is not implemented. Call "
+                  "UseExternalFile() before generating.";
+    return kFALSE;
+  }
   // take charm hadrons from external file
   // correct eventually for too much primary Ds produced by pythia6
   key = 0;
@@ -222,7 +232,7 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
     }
   }
   Double_t zinter = 0;
-  if (targetName != "") {
+  if (targetFromGeometry || targetName != "") {
     // calculate primary proton interaction point:
     // loop over trajectory between start and end to pick an interaction point,
     // copied from GenieGenerator and adapted to hadrons

--- a/shipgen/TTreeGenerator.cxx
+++ b/shipgen/TTreeGenerator.cxx
@@ -104,8 +104,10 @@ Bool_t TTreeGenerator::ReadEvent(FairPrimaryGenerator* primGen) {
     return kFALSE;
   }
 
-  // Position in cm, momentum in GeV/c
-  primGen->AddTrack(fPdgId, fPx, fPy, fPz, fX, fY, fZ, -1, true, 0., 0.,
+  // Position in cm, momentum in GeV/c. Pass e < 0 (-9e9) so
+  // FairPrimaryGenerator computes the energy from the momentum and PDG mass
+  // instead of storing E = 0.
+  primGen->AddTrack(fPdgId, fPx, fPy, fPz, fX, fY, fZ, -1, true, -9e9, 0.,
                     fWeight);
 
   fCurrentEvent++;

--- a/shipgen/tPythia6Generator.cxx
+++ b/shipgen/tPythia6Generator.cxx
@@ -76,7 +76,7 @@ Bool_t tPythia6Generator::ReadEvent(FairPrimaryGenerator* cpg) {
     Double_t pz = fPythia->GetP(ii, 3);
     Double_t px = fPythia->GetP(ii, 1);
     Double_t py = fPythia->GetP(ii, 2);
-    Int_t im = fPythia->GetV(ii, 4);
+    Int_t im = fPythia->GetK(ii, 3);  // parent line number (K(I,3))
     // cout << "debug p6 "<<id<<" "<< pz << endl;
     // copy blind complete pythia event
     if (fDeepCopy || wanttracking) {


### PR DESCRIPTION
Fixes bug-category findings from a full-tree code review, scoped to `shipgen/`. Commits are grouped by risk/kind.

## Crash / high severity
- **MuDISGenerator**: dereferenced the material pointer even when the sampled point was outside the geometry (`FindNode` failed / `IsOutside`) → segfault. Now guards on the node/material and resamples, matching `GenieGenerator`.
- **ParticleGunGenerator**: the `uniform` vertex model set X to the width (`pars[1]`) instead of the central value (`pars[0]`) in the non-positive-width fallback, unlike the Y branch and gaussian model.

## Physics behaviour (reviewed with maintainer)
- **Pythia8Generator**: the primary interaction-point sampling was gated on `targetName != ""`, but the modern `SetTargetCoordinates()` path (used by run_simScript charmonly) leaves `targetName` empty. `zinter` stayed 0, so all charm-hadron vertices were placed at z≈0 instead of distributed through the target with interaction-length weighting. Now gated on `targetFromGeometry || targetName != ""`. Also guards `ReadEvent` against a null input tree (the standalone Init branch has no event path).

## Medium
- **MuonBackGenerator**: the downscaled-dimuon recovery loop keyed the muon map with the loop counter instead of the actual vetoPoint index (`list.at(i)`).
- **TTreeGenerator**: primaries were stored with `E = 0` (passed `e=0.`; FairPrimaryGenerator only recomputes when `e<0`). Now passes `-9e9`.
- **tPythia6Generator**: mother index read PYJETS `V(I,4)` (production time) instead of `K(I,3)` (parent line).
- **HNL/DPPythia8Generator**: `fUseRandom1/3` were uninitialized; a null RNG engine could be handed to `setRndmEnginePtr`. Defaulted to TRandom3 in-class.
- **CosmicsGenerator.h**: `fRandomEngine` raw pointer was indeterminate yet deleted in the destructor; defaulted to `nullptr`.

## Low
- **FixedTargetGenerator**: `pot` counter was `Int_t` incremented by 0.5 (truncated to 0); made `Double_t`. Unknown `Option` now aborts `Init()` instead of continuing half-configured.
- **CosmicsGenerator**: `!nInside % 10000` parsed as `(!nInside) % 10000`; fixed the progress modulo.

## Verification
Built cleanly with pixi; `ci-sim`, `ci-reco`, and `ci-fixed-target` all complete successfully (the last exercises FixedTargetGenerator; ci-sim exercises HNLPythia8Generator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event generation reliability by fixing several edge cases in particle, cosmic, muon, and fixed-target workflows.
  * Corrected progress reporting so milestone messages appear at the expected intervals.
  * Added safer handling for invalid settings and missing inputs to prevent crashes or silent bad results.
  * Fixed track and vertex bookkeeping so generated events use the correct source values and energy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->