### PR TITLE
Fix correctness bugs in python/ (reconstruction, generators, utilities)

### DIFF
--- a/python/ACTSReco.py
+++ b/python/ACTSReco.py
@@ -47,7 +47,7 @@ def runTracking():
 
     elif global_variables.detector == "MTC":
         # MTC setup to be updated.
-        field = acts.ConstantBField(acts.Vector3(0.0, -1.2, 0.0 * u.T))
+        field = acts.ConstantBField(acts.Vector3(0.0, -1.2 * u.T, 0.0 * u.T))
         simHitTree = "mtcHits"
         digiConfigFile = currentPath + "/MTC-digi-config.json"
         detector = acts.examples.MTCBuilder(

--- a/python/SciFiMapping.py
+++ b/python/SciFiMapping.py
@@ -342,7 +342,7 @@ class SciFiMapping:
                     else fibreID + 100000000 + 1000000 + 1 * 100000
                 )
                 self.scifi.GetPosition(globfiberID, AF, BF)
-                loc = self.scifi.GetLocalPos(fibreID, BF)
+                loc = self.scifi.GetLocalPos(globfiberID, BF)
                 xs.append(loc[0])
                 ys.append(loc[2])
 
@@ -361,7 +361,11 @@ class SciFiMapping:
 
             # draw SiPM rect in its unique shade
             self.scifi.GetSiPMPosition(chan, BF, AF)
-            loc_siPM = self.scifi.GetLocalPos(fibreID, BF)
+            # GetLocalPos needs the global detector id (station/plane encoded);
+            # build it from the channel so it does not depend on the (now stale)
+            # fibre loop variable, which is also unbound if the fibre list is empty.
+            globSiPMID = locChan + 100000000 + 1000000 + (0 if isU else 1) * 100000
+            loc_siPM = self.scifi.GetLocalPos(globSiPMID, BF)
             rx, ry = loc_siPM[0], loc_siPM[2]
             rect = patches.Rectangle(
                 (rx - DX, ry - DZ),
@@ -418,7 +422,7 @@ class SciFiMapping:
         self,
         number_of_channels: int = 20,
         real_event: bool = False,
-        x_coords=None,
+        x_coords: list[float] | None = None,
         output_file: str = "scifi_channel_ribbons_XY.pdf",
         figsize: tuple[int, int] = (16, 16),
         dpi: int = 300,
@@ -466,11 +470,15 @@ class SciFiMapping:
             alpha_sipm, alpha_fibre = 0.75, 0.5
         else:
             alpha_sipm, alpha_fibre = 0.1, 0.1
+            if x_coords is None or len(x_coords) < 2:
+                raise ValueError("x_coords must provide at least two coordinates when real_event is True")
             # find the channels corresponding to x_coords
-            channels_x_U = next(c for c, x in self.sipm_pos_U.items() if abs(x - x_coords[0]) < DX)
-            channel_x_U = [c for c, x in self.sipm_pos_U.items() if abs(x - x_coords[0]) < DX][0]
-            channels_x_V = next(c for c, x in self.sipm_pos_V.items() if abs(x - x_coords[1]) < DX)
-            channel_x_V = [c for c, x in self.sipm_pos_V.items() if abs(x - x_coords[1]) < DX][0]
+            matches_U = [c for c, x in self.sipm_pos_U.items() if abs(x - x_coords[0]) < DX]
+            matches_V = [c for c, x in self.sipm_pos_V.items() if abs(x - x_coords[1]) < DX]
+            if not matches_U or not matches_V:
+                raise ValueError(f"x_coords {x_coords} do not match any SciFi channel within {DX} cm")
+            channels_x_U = channel_x_U = matches_U[0]
+            channels_x_V = channel_x_V = matches_V[0]
         # 1) Figure setup
         fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
 
@@ -699,14 +707,18 @@ class SciFiMapping:
             for fid in fmap[locChan]:
                 gid = fid + int(1e8 + 1e6 + (0 if chan in chansU else 1) * 1e5)
                 self.scifi.GetPosition(gid, AF, BF)
-                loc = self.scifi.GetLocalPos(fid, BF)
+                loc = self.scifi.GetLocalPos(gid, BF)
                 xs.append(loc[0])
                 zs.append(loc[2])
             for x, z in zip(xs, zs):
                 ell = patches.Ellipse((x, z), 2 * R, 2 * R, color="orange", alpha=alpha_fibre)
                 ax1.add_patch(ell)
             self.scifi.GetSiPMPosition(chan, BF, AF)
-            loc = self.scifi.GetLocalPos(fid, BF)
+            # Build the global detector id from the channel so it does not depend
+            # on the (now stale) fibre loop variable, which is also unbound if the
+            # fibre list is empty.
+            gidSiPM = locChan + int(1e8 + 1e6 + (0 if chan in chansU else 1) * 1e5)
+            loc = self.scifi.GetLocalPos(gidSiPM, BF)
             rx, rz = loc[0], loc[2]
             rect = patches.Rectangle(
                 (rx - DX, rz - DZ),

--- a/python/TrackExtrapolateTool.py
+++ b/python/TrackExtrapolateTool.py
@@ -47,10 +47,15 @@ def extrapolateToPlane(fT, z) -> tuple[bool, Any, Any]:
                 rc = True
             except Exception:
                 # print 'error with extrapolation: z=',z/u.m,'m',pos.X(),pos.Y(),pos.Z(),mom.X(),mom.Y(),mom.Z()
-                pass
-            if not rc or z > z_ecal:
-                # use linear extrapolation
+                # Honour the contract: no valid extrapolation -> pos/mom are None.
+                rc, pos, mom = False, None, None
+            if rc and z > z_ecal:
+                # RK only reaches z_ecal; continue with linear extrapolation
                 px, py, pz = mom.X(), mom.Y(), mom.Z()
-                lam = (z - pos.Z()) / pz
-                pos = ROOT.TVector3(pos.X() + lam * px, pos.Y() + lam * py, z)
+                if pz != 0:
+                    lam = (z - pos.Z()) / pz
+                    pos = ROOT.TVector3(pos.X() + lam * px, pos.Y() + lam * py, z)
+                else:
+                    # cannot extrapolate in z with zero longitudinal momentum
+                    rc, pos, mom = False, None, None
     return rc, pos, mom

--- a/python/checkMagFields.py
+++ b/python/checkMagFields.py
@@ -71,9 +71,9 @@ def run():
                     h["By-"].Fill(z, x, y, -f.GetBy(x, y, z) / u.tesla)
                 if f.GetBy(x, y, z) > 0:
                     h["By+"].Fill(z, x, y, f.GetBy(x, y, z) / u.tesla)
-    for x in h:
+    for x in list(h):  # snapshot keys: the loop inserts new entries into h
         hi = h[x]
-        if hi.ClassName() == "TH3F":
+        if hi.InheritsFrom("TH3"):  # bookHist creates TH3D, not TH3F
             h[x + "_xz"] = h[x].Project3D("xy")
             h[x + "_xz"].SetTitle(hi.GetTitle() + " top view")
             h[x + "_yz"] = h[x].Project3D("xz")

--- a/python/convertToACTS.py
+++ b/python/convertToACTS.py
@@ -182,26 +182,26 @@ def main():
         # Vertex branches
         event_id_vertex = array.array("i", [0])
         vertexTree.Branch("event_id", event_id_vertex, "event_id/i")
-        vertex_id = ROOT.std.vector("unsigned long")([0])
+        vertex_id = ROOT.std.vector("unsigned long")()
         vertexTree.Branch("vertex_id", vertex_id)
-        process_vtx = ROOT.std.vector("int")([0])
+        process_vtx = ROOT.std.vector("int")()
         vertexTree.Branch("process", process_vtx)
-        vx_vtx = ROOT.std.vector("float")([0])
+        vx_vtx = ROOT.std.vector("float")()
         vertexTree.Branch("vx", vx_vtx)
-        vy_vtx = ROOT.std.vector("float")([0])
+        vy_vtx = ROOT.std.vector("float")()
         vertexTree.Branch("vy", vy_vtx)
-        vz_vtx = ROOT.std.vector("float")([0])
+        vz_vtx = ROOT.std.vector("float")()
         vertexTree.Branch("vz", vz_vtx)
-        vt_vtx = ROOT.std.vector("float")([0])
+        vt_vtx = ROOT.std.vector("float")()
         vertexTree.Branch("vt", vt_vtx)
         outgoing_particlesVec = ROOT.std.vector("unsigned long")()
         outgoing_particles = ROOT.std.vector(ROOT.std.vector("unsigned long"))()
         vertexTree.Branch("outgoing_particles", outgoing_particles)
-        vertex_primary_vtx = ROOT.std.vector("int")([0])
+        vertex_primary_vtx = ROOT.std.vector("int")()
         vertexTree.Branch("vertex_primary", vertex_primary_vtx)
-        vertex_secondary_vtx = ROOT.std.vector("int")([0])
+        vertex_secondary_vtx = ROOT.std.vector("int")()
         vertexTree.Branch("vertex_secondary", vertex_secondary_vtx)
-        generation_vtx = ROOT.std.vector("int")([0])
+        generation_vtx = ROOT.std.vector("int")()
         vertexTree.Branch("generation", generation_vtx)
 
         # Particle branches
@@ -260,10 +260,18 @@ def main():
         outcome = ROOT.std.vector("float")()
         particleTree.Branch("outcome", outcome)
 
+        # Seed the RNG once, before the event loop, so digitisation draws a
+        # fresh random sequence per event instead of repeating the same one.
+        ROOT.gRandom.SetSeed(13)
+
         for ievent, event in enumerate(sTree):
             motherMap = defaultdict(list)
             motherMapVal = defaultdict(list)
             detHitMap = defaultdict(list)
+            # Hits already accounted for that will be discarded from detHitMap
+            # before the per-particle hit count is taken (e.g. SND SiliconTarget
+            # hits, which are cleared before the MTC block reuses detHitMap).
+            extraHitCount = defaultdict(int)
             detHitArray = []
             strawHitArr = []
             trID = []
@@ -332,6 +340,10 @@ def main():
             if global_variables.detector == "MTC" or global_variables.detector == "SND":
                 detHitArray.clear()
                 trID.clear()
+                # For SND the SiliconTarget hits were stored in detHitMap above;
+                # preserve their per-track counts before reusing the map for MTC.
+                for trackID in detHitMap:
+                    extraHitCount[trackID] += len(detHitMap[trackID])
                 detHitMap.clear()
                 pointsDict = defaultdict(list)
                 for index, point in enumerate(event.MTCPoint):
@@ -396,8 +408,7 @@ def main():
 
             if global_variables.detector == "StrawTracker":
                 # Follow shipDigiReco method of only selecting the point with the earliest time
-                ROOT.gRandom.SetSeed(13)
-                t0 = ROOT.TRandom().Rndm() * 1 * u.microsecond
+                t0 = ROOT.gRandom.Rndm() * 1 * u.microsecond
                 strawHitArr.clear()
                 earliestHitPerDet = {}
                 for index, point in enumerate(event.strawtubesPoint):
@@ -509,7 +520,7 @@ def main():
                 sub_particle.push_back(0)
                 vertex_primary.push_back(1)
                 vertex_secondary.push_back(0)
-                number_of_hits.push_back(len(detHitMap[count]))
+                number_of_hits.push_back(len(detHitMap[count]) + extraHitCount[count])
                 total_x0.push_back(0)
                 total_l0.push_back(0)
                 outcome.push_back(0)
@@ -552,7 +563,9 @@ def main():
                 if len(particleCodes) < 2:
                     continue
                 event_id_vertex[0] = ievent
-                vertexVal = acts.Barcode(primaryVertex=1, secondaryVertex=0, part=0, gen=0, subpart=0).value
+                # Encode the per-event vertex index so each vertex gets a distinct
+                # id (previously constant, so every vertex shared the same value).
+                vertexVal = acts.Barcode(primaryVertex=1, secondaryVertex=0, part=c, gen=0, subpart=0).value
                 vertex_id.push_back(vertexVal)
                 particle_0ID = motherMap[str(i)]
                 particle_0 = event.MCTrack[particle_0ID[0]]

--- a/python/dpProductionRates.py
+++ b/python/dpProductionRates.py
@@ -115,19 +115,18 @@ def brMesonToDP(mass, epsilon, mumPdg, doprint=False):
         return brMesonToMesonDP(mass, epsilon, mumPdg, 113, doprint), brMesonToGammaDP(mass, epsilon, mumPdg, doprint)
     else:
         print("Warning! Unknown mother pdgId %d, not implemented. Setting br to 0." % mumPdg)
-        return 1
+        return 0
 
 
 def mesonProdRate(mass, epsilon, mumPdg, doprint=False):
     brM2DP = brMesonToDP(mass, epsilon, mumPdg, doprint)
-    if mumPdg == 331:
+    if isinstance(brM2DP, tuple):
         avgMeson = getAverageMesonRate(mumPdg) * brM2DP[0]
         avgMeson1 = getAverageMesonRate(mumPdg) * brM2DP[1]
         return avgMeson * 0.6, avgMeson1 * 0.6
         # return avgMeson + avgMeson1
-    if mumPdg != 331:
-        avgMeson = getAverageMesonRate(mumPdg) * brM2DP
-        return avgMeson * 0.6
+    avgMeson = getAverageMesonRate(mumPdg) * brM2DP
+    return avgMeson * 0.6
 
 
 # from interpolation of Pythia XS, normalised to epsilon^2
@@ -143,16 +142,16 @@ def qcdprodRate(mass, epsilon, doprint=False):
 
 
 def getDPprodRate(mass, epsilon, prodMode, mumPdg, doprint=False):
-    if "pbrem" in prodMode:
-        print("VDM")
-        return pbremProdRateVDM(mass, epsilon, doprint)
-    elif "pbrem1" in prodMode:
+    if "pbrem1" in prodMode:
         print("Dipole")
         return pbremProdRateDipole(mass, epsilon, doprint)
+    elif "pbrem" in prodMode:
+        print("VDM")
+        return pbremProdRateVDM(mass, epsilon, doprint)
     elif "meson" in prodMode:
         return mesonProdRate(mass, epsilon, mumPdg, doprint)
     elif "qcd" in prodMode:
         return qcdprodRate(mass, epsilon, doprint)
     else:
         print("Unknown production mode! Choose among pbrem, meson or qcd.")
-        return 1
+        return 0

--- a/python/experimental/analysis_toolkit.py
+++ b/python/experimental/analysis_toolkit.py
@@ -28,10 +28,14 @@ class selection_check:
                 config = yaml.safe_load(file)
                 self.veto_geo = AttrDict(config)
                 _ = self.veto_geo.z0
-        if self.ship_geo.DecayVolumeMedium == "vacuums":
+        elif self.ship_geo.DecayVolumeMedium == "vacuums":
             with open(fairship + "/geometry/veto_config_vacuums.yaml") as file:
                 config = yaml.safe_load(file)
                 self.veto_geo = AttrDict(config)
+        else:
+            raise ValueError(
+                f"Unsupported DecayVolumeMedium {self.ship_geo.DecayVolumeMedium!r}: expected 'helium' or 'vacuums'."
+            )
 
     def access_event(self, tree) -> None:
         """Access event data."""
@@ -71,6 +75,9 @@ class selection_check:
 
             time_vtx_from_strawhits.append(t_vertex)
 
+        if not time_vtx_from_strawhits:
+            return float("nan")  # no matching straw hits, vertex time cannot be computed
+
         t_vtx = np.average(time_vtx_from_strawhits) + t0
 
         return t_vtx  # units in ns
@@ -100,7 +107,7 @@ class selection_check:
         return dist  # in cm
 
     def dist_to_innerwall(self, candidate) -> float | int:
-        """Calculate the minimum distance(in XY plane) of the candidate decay vertex to the inner wall of the decay vessel. If outside the decay volume, or if distance > 100cm,Return 0."""
+        """Calculate the minimum distance(in XY plane) of the candidate decay vertex to the inner wall of the decay vessel. If outside the decay volume, return 0."""
         candidate_pos = ROOT.TVector3()
         candidate.GetVertex(candidate_pos)
         position = (candidate_pos.X(), candidate_pos.Y(), candidate_pos.Z())
@@ -128,7 +135,7 @@ class selection_check:
             distance = self.geometry_manager.GetStep()
             min_distance = min(min_distance, distance)
 
-        return min_distance if min_distance < 100 * u.m else 0
+        return min_distance
 
     def dist_to_vesselentrance(self, candidate):
         """Calculate the distance of the candidate decay vertex to the entrance of the decay vessel."""

--- a/python/experimental/compare_histograms.py
+++ b/python/experimental/compare_histograms.py
@@ -4,8 +4,27 @@
 """Compare histograms for exact or statistical equality."""
 
 import argparse
+import sys
 
 import ROOT
+
+
+def histograms_identical(hist1: ROOT.TH1, hist2: ROOT.TH1) -> bool:
+    """Return True if two histograms have identical binning, contents and errors.
+
+    ``TH1`` does not override ``TObject::IsEqual`` (which compares addresses), so
+    a content-based comparison is required. ``GetNcells`` covers the under- and
+    overflow bins and works for 1/2/3-D histograms alike.
+    """
+    ncells = hist1.GetNcells()  # type: ignore[attr-defined]
+    if ncells != hist2.GetNcells():  # type: ignore[attr-defined]
+        return False
+    for i in range(ncells):
+        if hist1.GetBinContent(i) != hist2.GetBinContent(i):
+            return False
+        if hist1.GetBinError(i) != hist2.GetBinError(i):
+            return False
+    return True
 
 
 def compare_histograms(
@@ -14,26 +33,32 @@ def compare_histograms(
     """Compare two histograms for equality or statistical compatibility."""
     name = hist1.GetName()
 
-    if not hist1.IsEqual(hist2):
+    if not histograms_identical(hist1, hist2):
         print(f"Histograms '{name}' are different in terms of bin contents or errors.")
 
         if use_ks_test:
             p_value = hist1.KolmogorovTest(hist2)
             print(f"KS p-value: {p_value}")
-            if p_value < significance_threshold:
-                print(f"Histograms '{name}' are statistically different (p < {significance_threshold}).")
-            else:
+            if p_value >= significance_threshold:
                 print(f"Histograms '{name}' are statistically compatible (p >= {significance_threshold}).")
+                return True
+            print(f"Histograms '{name}' are statistically different (p < {significance_threshold}).")
+            return False
         return False
 
     print(f"Histograms '{name}' are equal.")
     return True
 
 
-def main(file1_path: str, file2_path: str, use_ks_test: bool, significance_threshold: float) -> None:
-    """Compare histograms in two ROOT files."""
+def main(file1_path: str, file2_path: str, use_ks_test: bool, significance_threshold: float) -> bool:
+    """Compare histograms in two ROOT files.
+
+    Returns True if every histogram is present in both files and identical,
+    False otherwise (so the caller can propagate a non-zero exit status).
+    """
     file1 = ROOT.TFile.Open(file1_path)
     file2 = ROOT.TFile.Open(file2_path)
+    all_match = True
 
     histograms1 = {}
     for key in file1.GetListOfKeys():
@@ -49,13 +74,20 @@ def main(file1_path: str, file2_path: str, use_ks_test: bool, significance_thres
 
     for hist_name in histograms1:
         if hist_name in histograms2:
-            compare_histograms(histograms1[hist_name], histograms2[hist_name], use_ks_test, significance_threshold)
+            if not compare_histograms(
+                histograms1[hist_name], histograms2[hist_name], use_ks_test, significance_threshold
+            ):
+                all_match = False
         else:
             print(f"Histogram '{hist_name}' not found in file2.")
+            all_match = False
 
     for hist_name in histograms2:
         if hist_name not in histograms1:
             print(f"Histogram '{hist_name}' not found in file1.")
+            all_match = False
+
+    return all_match
 
 
 if __name__ == "__main__":
@@ -76,4 +108,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    main(args.file1, args.file2, args.ks, args.threshold)
+    sys.exit(0 if main(args.file1, args.file2, args.ks, args.threshold) else 1)

--- a/python/experimental/eminem_importer.py
+++ b/python/experimental/eminem_importer.py
@@ -109,8 +109,8 @@ def load_pickled_data(input_file, verbose=False):
     try:
         # Try gzip first (files may be gzipped regardless of extension)
         try:
-            with gzip.open(input_file, "rb") as f:
-                data = pickle.loads(f.read())
+            with gzip.GzipFile(input_file, "rb") as f:
+                data = pickle.load(f)
         except gzip.BadGzipFile:
             with open(input_file, "rb") as f:
                 data = pickle.load(f)
@@ -359,8 +359,11 @@ def apply_column_transformation(data_column, config):
                 # Only offset has units
                 result = result + offset * config["offset_unit"]
         else:
-            # No units for offset
-            result = result + offset
+            # No units for offset; still apply the column unit if one is set
+            if config.get("unit") is not None:
+                result = result * config["unit"] + offset
+            else:
+                result = result + offset
 
     # Apply units (if not already applied above)
     if config.get("unit") is not None and "offset" not in config:

--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -131,8 +131,10 @@ def printWF(vl, alreadyPrinted, onlyWithField: bool = True):
     return magnetMass
 
 
-def nextLevel(lv, magnetMass: int, onlyWithField, exclude, alreadyPrinted):
-    tmp = 0
+def nextLevel(lv, magnetMass, onlyWithField, exclude, alreadyPrinted):
+    # Accumulate the magnet mass of every leaf volume in the subtree. A single
+    # running total is threaded through the recursion so that leaves at any
+    # depth (and direct leaf daughters of the top level) are all counted.
     for da in range(lv.GetNoDaughters()):
         lvn = lv.GetDaughter(da)
         name = lvn.GetName().c_str()
@@ -140,11 +142,10 @@ def nextLevel(lv, magnetMass: int, onlyWithField, exclude, alreadyPrinted):
             continue
         lvln = lvn.GetLogicalVolume()
         if lvln.GetNoDaughters() > 0:
-            xtmp, _dummy = nextLevel(lvln, magnetMass, onlyWithField, exclude, alreadyPrinted)
-            magnetMass += xtmp
+            magnetMass = nextLevel(lvln, magnetMass, onlyWithField, exclude, alreadyPrinted)
         else:
-            tmp += printWF(lvn, alreadyPrinted, onlyWithField)
-    return tmp, magnetMass
+            magnetMass += printWF(lvn, alreadyPrinted, onlyWithField)
+    return magnetMass
 
 
 def printWeightsandFields(onlyWithField: bool = True, exclude=None) -> None:
@@ -157,7 +158,7 @@ def printWeightsandFields(onlyWithField: bool = True, exclude=None) -> None:
     world = gn.GetWorldVolume().GetLogicalVolume()
     magnetMass = 0
     alreadyPrinted: dict[str, str] = {}
-    _dummy, nM = nextLevel(world, magnetMass, onlyWithField, exclude, alreadyPrinted)
+    nM = nextLevel(world, magnetMass, onlyWithField, exclude, alreadyPrinted)
     print("total magnet mass", nM / 1000.0, "t")
     return
 
@@ -194,8 +195,8 @@ def addVMCFields(shipGeo, controlFile: str = "", verbose: bool = False, withVirt
     if len(fieldsList) > 1:
         fieldMaker.defineComposite("TotalField", *fieldsList)  # fieldsList MUST have length <=4
         fieldMaker.defineGlobalField("TotalField")
-    else:
-        fieldMaker.defineGlobalField("MainSpecMap")
+    elif fieldsList:
+        fieldMaker.defineGlobalField(fieldsList[0])
     if withVirtualMC:
         # Force the VMC to update/reset the fields defined by the fieldMaker object.
         # Get the ROOT/Geant4 geometry manager

--- a/python/global_variables.py
+++ b/python/global_variables.py
@@ -4,4 +4,5 @@
 from typing import Any
 
 
-def __getattr__(name: str) -> Any: ...
+def __getattr__(name: str) -> Any:
+    raise AttributeError(name)

--- a/python/proton_bremsstrahlung.py
+++ b/python/proton_bremsstrahlung.py
@@ -183,9 +183,14 @@ def normalisedProductionPDF(p, theta, mDarkPhoton, epsilon, norm):
 
 def hProdPDF(mDarkPhoton, epsilon, norm, binsp, binstheta, tmin=-0.5 * math.pi, tmax=0.5 * math.pi, suffix=""):
     """Histogram of the PDF for A' production in SHIP"""
+    if binstheta < 2:
+        raise ValueError(f"binstheta must be >= 2 to define a theta grid, got {binstheta}")
     angles = np.linspace(tmin, tmax, binstheta).tolist()
-    anglestep = 2.0 * (tmax - tmin) / binstheta
-    momentumStep = (pMax(mDarkPhoton) - pMin(mDarkPhoton)) / (binsp - 1)
+    # angles is an endpoint-inclusive grid (step over binstheta-1 intervals);
+    # momenta excludes the endpoint (step over binsp intervals). Match each bin
+    # width to its own grid so the sampled points land on bin centres.
+    anglestep = (tmax - tmin) / (binstheta - 1)
+    momentumStep = (pMax(mDarkPhoton) - pMin(mDarkPhoton)) / binsp
     momenta = np.linspace(pMin(mDarkPhoton), pMax(mDarkPhoton), binsp, endpoint=False).tolist()
     hPDF = r.TH2F(
         f"hPDF_eps{epsilon}_m{mDarkPhoton}",
@@ -195,7 +200,7 @@ def hProdPDF(mDarkPhoton, epsilon, norm, binsp, binstheta, tmin=-0.5 * math.pi, 
         pMax(mDarkPhoton) - 0.5 * momentumStep,
         binstheta,
         tmin - 0.5 * anglestep,
-        tmax - 0.5 * anglestep,
+        tmax + 0.5 * anglestep,
     )
     hPDF.SetTitle(f"PDF for A' production (m_{{A'}}={mDarkPhoton} GeV, #epsilon ={epsilon})")
     hPDF.GetXaxis().SetTitle("P_{A'} [GeV]")
@@ -205,7 +210,7 @@ def hProdPDF(mDarkPhoton, epsilon, norm, binsp, binstheta, tmin=-0.5 * math.pi, 
         f"hPDFtheta_eps{epsilon}_m{mDarkPhoton}",
         binstheta,
         tmin - 0.5 * anglestep,
-        tmax - 0.5 * anglestep,
+        tmax + 0.5 * anglestep,
     )
     hPDFp = r.TH1F(
         f"hPDFp_eps{epsilon}_m{mDarkPhoton}",

--- a/python/pythia8_conf.py
+++ b/python/pythia8_conf.py
@@ -46,6 +46,9 @@ def configurerpvsusy(
     # let strange particle decay in Geant4
     make_particles_stable(P8gen, above_lifetime=1)
 
+    if inclusive is True:  # For backward compatibility with a boolean argument
+        inclusive = "True"
+
     if inclusive == "True":
         setup_pythia_inclusive(P8gen)
 
@@ -81,13 +84,10 @@ def configurerpvsusy(
             "    0.00000    0.00000    0.00000  1.49900e-01   0   1   0   1   0"
         )
         sumBR = 0.0
-        if getbr_rpvsusy(h, "ds_mu", mass, couplings[1]) > 0.0:
-            P8gen.SetParameters(
-                "431:addChannel      1  {:.12}    0      -13       9900015".format(
-                    getbr_rpvsusy(h, "ds_mu", mass, couplings[1]) / maxsumBR
-                )
-            )
-            sumBR += float(getbr_rpvsusy(h, "ds_mu", mass, couplings[1]) / maxsumBR)
+        br_ds_mu = getbr_rpvsusy(h, "ds_mu", mass, couplings[1])
+        if br_ds_mu > 0.0:
+            P8gen.SetParameters(f"431:addChannel      1  {br_ds_mu / maxsumBR:.12}    0      -13       9900015")
+            sumBR += float(br_ds_mu / maxsumBR)
         if sumBR < 1.0 and sumBR > 0.0:
             P8gen.SetParameters(f"431:addChannel      1   {1.0 - sumBR:.12}    0       22      -11")
 
@@ -96,13 +96,10 @@ def configurerpvsusy(
             "411:new  D+ D-    1   3   0    1.86962    0.00000    0.00000    0.00000  3.11800e-01   0   1   0   1   0"
         )
         sumBR = 0.0
-        if getbr_rpvsusy(h, "d_mu", mass, couplings[1]) > 0.0:
-            P8gen.SetParameters(
-                "411:addChannel      1  {:.12}    0      -13       9900015".format(
-                    getbr_rpvsusy(h, "d_mu", mass, couplings[1]) / maxsumBR
-                )
-            )
-            sumBR += float(getbr_rpvsusy(h, "d_mu", mass, couplings[1]) / maxsumBR)
+        br_d_mu = getbr_rpvsusy(h, "d_mu", mass, couplings[1])
+        if br_d_mu > 0.0:
+            P8gen.SetParameters(f"411:addChannel      1  {br_d_mu / maxsumBR:.12}    0      -13       9900015")
+            sumBR += float(br_d_mu / maxsumBR)
         if sumBR < 1.0 and sumBR > 0.0:
             P8gen.SetParameters(f"411:addChannel      1   {1.0 - sumBR:.12}    0       22      -11")
 
@@ -135,13 +132,10 @@ def configurerpvsusy(
             "    0.00000    0.00000    0.00000  4.91100e-01   0   1   0   1   0"
         )
         sumBR = 0.0
-        if getbr_rpvsusy(h, "b_tau", mass, couplings[1]) > 0.0:
-            P8gen.SetParameters(
-                "521:addChannel      1  {:.12}    0       9900015      -15".format(
-                    getbr_rpvsusy(h, "b_tau", mass, couplings[1]) / maxsumBR
-                )
-            )
-            sumBR += float(getbr_rpvsusy(h, "b_tau", mass, couplings[1]) / maxsumBR)
+        br_b_tau = getbr_rpvsusy(h, "b_tau", mass, couplings[1])
+        if br_b_tau > 0.0:
+            P8gen.SetParameters(f"521:addChannel      1  {br_b_tau / maxsumBR:.12}    0       9900015      -15")
+            sumBR += float(br_b_tau / maxsumBR)
         if sumBR < 1.0 and sumBR > 0.0:
             P8gen.SetParameters(f"521:addChannel      1   {1.0 - sumBR:.12}    0       22      22")
 
@@ -151,12 +145,10 @@ def configurerpvsusy(
             "    0.00000    0.00000    0.00000  4.58700e-01   0   1   0   1   0"
         )
         sumBR = 0.0
-        if getbr_rpvsusy(h, "b0_nu_tau", mass, couplings[1]) > 0.0:
-            P8gen.SetParameters(
-                "511:addChannel      1  {:.12}   22       9900015      16".format(
-                    getbr_rpvsusy(h, "b0_nu_tau", mass, couplings[1]) / maxsumBR
-                )
-            )
+        br_b0_nu_tau = getbr_rpvsusy(h, "b0_nu_tau", mass, couplings[1])
+        if br_b0_nu_tau > 0.0:
+            P8gen.SetParameters(f"511:addChannel      1  {br_b0_nu_tau / maxsumBR:.12}   22       9900015      16")
+            sumBR += float(br_b0_nu_tau / maxsumBR)
         if sumBR < 1.0 and sumBR > 0.0:
             P8gen.SetParameters(f"511:addChannel      1   {1.0 - sumBR:.12}    0       22      22")
 

--- a/python/pythia8_conf_utils.py
+++ b/python/pythia8_conf_utils.py
@@ -80,7 +80,7 @@ def parse_histograms(filepath):
     th1f_exp = re.compile(r"^TH1F\|.+")
     header_exp = re.compile(r"^TH1F\|(.+?)\|B(?:R|F)/U2(.+?)\|.+? mass \(GeV\)\|?")
     subheader_exp = re.compile(r"^\s*?(\d+?),\s*(\d+?\.\d+?),\s*(\d+\.\d+)\s*$")
-    data_exp = re.compile(r"^\s*(\d+?)\s*,\s*(\d+\.\d+)\s*$")
+    data_exp = re.compile(r"^\s*(\d+?)\s*,\s*(-?\d+\.\d+)\s*$")
     # Locate beginning of each histogram
     header_line_idx = [i for i in range(len(lines)) if th1f_exp.match(lines[i]) is not None]
     # Iterate over histograms

--- a/python/pythia8_conf_utils.py
+++ b/python/pythia8_conf_utils.py
@@ -101,7 +101,7 @@ def parse_histograms(filepath):
         masses = np.linspace(min_mass, max_mass, npoints, endpoint=False)
         branching_ratios = np.zeros(npoints)
         # Now read the data lines (skipping the two header lines)
-        for line in lines[offset + 2 : offset + npoints + 1]:
+        for line in lines[offset + 2 : offset + npoints + 2]:
             md = data_exp.match(line)
             if md is None or len(md.groups()) != 2:
                 raise ValueError(f"Malformed data row encountered: {line}")

--- a/python/rootUtils.py
+++ b/python/rootUtils.py
@@ -53,6 +53,7 @@ def readHists(h, fname, wanted=None) -> None:
                     h[projname] = h[hname].ProjectionY()
                 h[projname].SetName(name + p)
                 h[projname].SetDirectory(ROOT.gROOT)
+    f.Close()
     return
 
 
@@ -102,7 +103,7 @@ def bookProf(
     rkey = str(key)  # in case somebody wants to use integers, or floats as keys
     if key in h:
         h[key].Reset()
-    if ymin is None or ymax is None:
+    elif ymin is None or ymax is None:
         h[key] = ROOT.TProfile(rkey, title, nbinsx, xmin, xmax, option)
     else:
         h[key] = ROOT.TProfile(rkey, title, nbinsx, xmin, xmax, ymin, ymax, option)
@@ -159,12 +160,13 @@ def checkFileExists(x) -> str:
             if not test:
                 print("ERROR FileCheck: input file", f, " does not exist. Missing authentication?")
                 sys.exit(1)
-            if test.FindObjectAny("cbmsim") and fileType in ["tree", ""]:
-                fileType = "tree"
-            elif fileType in ["ntuple", ""]:
-                fileType = "ntuple"
-            else:
+            thisType = "tree" if test.FindObjectAny("cbmsim") else "ntuple"
+            test.Close()
+            if fileType == "":
+                fileType = thisType
+            elif fileType != thisType:
                 print("ERROR FileCheck: Supplied list of files not all of tree or ntuple type")
+                sys.exit(1)
         return fileType
     else:
         print("ERROR FileCheck: File must be either a string or list of files")

--- a/python/rpvsusy.py
+++ b/python/rpvsusy.py
@@ -227,8 +227,8 @@ class RPVSUSYbranchings:
         if debug:
             print("RPVSUSYbranchings instance initialized with couplings:")
             print("\t benchmark scenario   = %d" % self.bench)
-            print("\t decay coupling       = %s" % self.U[0])
-            print("\t production coupling  = %s" % self.U[1])
+            print("\t production coupling  = %s" % self.U[0])
+            print("\t decay coupling       = %s" % self.U[1])
             print("\t sfermion mass        = %s" % self.sfmass)
             print("\t total prod coupling  = %s" % (self.U[0] / self.sfmass**2))
             print("\t total decay coupling = %s" % (self.U[1] / self.sfmass**2))
@@ -382,7 +382,7 @@ class RPVSUSYbranchings:
                     / (self.sfmass**4 * 3 * u.pi * mass(H) ** 3)
                     * c.GST2["tneutrino"]
                     * c.decayConstant[H] ** 2
-                    * (mass(H) ** 2 * (mass(H) ** 2 + self.MN**2 + mass(L) ** 2 - 2 * (self.MN**2 - mass(L) ** 2) ** 2))
+                    * (2 * (self.MN**2 - mass(L) ** 2) ** 2 - mass(H) ** 2 * (mass(H) ** 2 + self.MN**2 + mass(L) ** 2))
                 )
             else:
                 tmp_width = (
@@ -390,7 +390,7 @@ class RPVSUSYbranchings:
                     / (self.sfmass**4 * 3 * u.pi * mass(H) ** 3)
                     * c.GST2["tlepton"]
                     * c.decayConstant[H] ** 2
-                    * (mass(H) ** 2 * (mass(H) ** 2 + self.MN**2 + mass(L) ** 2 - 2 * (self.MN**2 - mass(L) ** 2) ** 2))
+                    * (2 * (self.MN**2 - mass(L) ** 2) ** 2 - mass(H) ** 2 * (mass(H) ** 2 + self.MN**2 + mass(L) ** 2))
                 )
 
         width = self.U2[0] * tmp_width
@@ -425,7 +425,10 @@ class RPVSUSYbranchings:
         Inputs:
         - decayString is a string describing the decay, in the form 'N -> stuff1 ... stuffN'
         """
-        had = re.search(r"->\ (.+?)\ ", decayString).group(1)
+        match = re.search(r"->\ (.+?)\ ", decayString)
+        if match is None:
+            raise ValueError(f"Malformed decay string: {decayString!r}")
+        had = match.group(1)
         decaysplit = decayString.split(" ")
         lep = ""
         for split in decaysplit:
@@ -465,7 +468,10 @@ class RPVSUSYbranchings:
         Inputs:
         - decayString is a string describing the decay, in the form 'H -> N ... stuffN'
         """
-        had = re.search(r"(.+?)\ ->", decayString).group(1)
+        match = re.search(r"(.+?)\ ->", decayString)
+        if match is None:
+            raise ValueError(f"Malformed decay string: {decayString!r}")
+        had = match.group(1)
         decaysplit = decayString.split(" ")
         lep = ""
         for split in decaysplit:

--- a/python/saveBasicParameters.py
+++ b/python/saveBasicParameters.py
@@ -6,13 +6,14 @@ import os
 import subprocess
 
 import ROOT
-from ShipGeoConfig import AttrDict
+from ShipGeoConfig import Config
 
 
 def retrieveGitTags(o):
     if "FAIRSHIP_HASH" in os.environ:
         o.FairShip = os.environ["FAIRSHIP_HASH"]
-        o.FairRoot = os.environ["FAIRROOT_HASH"]
+        if "FAIRROOT_HASH" in os.environ:
+            o.FairRoot = os.environ["FAIRROOT_HASH"]
     else:
         source_dir = os.environ.get("FAIRSHIP", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         with contextlib.suppress(subprocess.CalledProcessError, FileNotFoundError):
@@ -27,7 +28,9 @@ def retrieveGitTags(o):
 def execute(f, ox, name="ShipGeo"):
     """Save geometry configuration to ROOT file as JSON string"""
     if isinstance(ox, str):
-        ox = AttrDict()
+        # A string input is the JSON serialisation of the config; parse it into a
+        # Config so the content is preserved and dumps_json() is available.
+        ox = Config().loads_json(ox)
     o = retrieveGitTags(ox)
 
     if isinstance(f, str):

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -27,8 +27,8 @@ def configure_snd_old(yaml_file: str, emulsion_target_z_end, cave_floorHeightMuo
         nuTauTT_geo.n_hor_planes * nuTauTT_geo.scifimat_width + 2.9 * u.cm
     )  # endpieces (~2.9cm from previous geom)
     snd_nuTauTT_TTY = (
-        nuTauTT_geo.n_vert_planes * nuTauTT_geo.scifimat_width + 2.9
-    )  # u.cm  # endpieces (~2.9cm from previous geom)
+        nuTauTT_geo.n_vert_planes * nuTauTT_geo.scifimat_width + 2.9 * u.cm
+    )  # endpieces (~2.9cm from previous geom)
 
     snd_nuTauTT_TTZ = 2 * nuTauTT_geo.support_z + 2 * nuTauTT_geo.scifimat_z + nuTauTT_geo.honeycomb_z
 

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -44,6 +44,15 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method, dy=
         Name of a track pattern recognition method.
     """
 
+    # This quality-plot step analyses the already-reconstructed Tracklets/
+    # FitTracks branches, so the method argument does not influence the result.
+    # Warn rather than silently ignore a non-default selection.
+    if method != "Baseline":
+        print(
+            f"Warning: pattern-recognition method '{method}' has no effect here; "
+            "this script only produces quality plots from existing reconstruction."
+        )
+
     ############################################# Load SHiP geometry ###################################################
 
     # Check geo file
@@ -71,8 +80,8 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method, dy=
 
     run = ROOT.FairRunSim()
     run.SetName("TGeant4")  # Transport engine
-    # Create dummy output file as the  input file is updated directly and
-    # histograms are written to output file (hists.root by default)
+    # Create dummy output file for FairRunSim; the quality-plot histograms are
+    # written to the separate output file (hists.root by default).
     import tempfile
 
     sink = ROOT.FairRootFileSink(tempfile.mktemp(suffix=".root"))
@@ -106,15 +115,17 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method, dy=
 
     ############################################# Load inpur data file #################################################
 
-    # Check input file
+    # Check input file. This is a read-only QA step: it reads the existing
+    # branches and writes quality plots to the separate output file, so open the
+    # input read-only rather than "update" (which rewrote a duplicate key cycle
+    # of the unmodified tree into the user's file on every invocation).
     try:
-        fn = ROOT.TFile(input_file, "update")
+        fn = ROOT.TFile(input_file, "read")
     except Exception:
         print("An error with opening the input data file.")
         raise
 
     sTree = fn.Get("cbmsim")
-    sTree.Write()
 
     ############################################# Create hists #########################################################
 
@@ -499,8 +510,12 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method, dy=
                     h["rmse_x"].Fill(rmse_x)
                     h["rmse_y"].Fill(rmse_y)
 
-            except Exception:
-                print("Problem with fitted state.")
+            except ROOT.genfit.Exception as e:
+                # A track without a fitted state is expected; skip it. Momentum
+                # divisions (ZeroDivisionError), histogram lookups/fills
+                # (KeyError) and extrapolation errors are real bugs and must not
+                # be masked here, so only the genfit fitted-state failure is caught.
+                print(f"Problem with fitted state: {e!r}")
 
         h["Reco_tracks"].Fill("N total", n_tracks)
         h["Reco_tracks"].Fill("N recognized tracks", n_recognized)

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -68,13 +68,13 @@ class Task:
         res[0] = abs(y_data[0]) - a[5]
         res[1] = y_data[1] - a[3]
         res[2] = y_data[2] - a[4]
-        res[3] = y_data[3] - a[0] - a[3] * (a[2] - z0)
-        res[4] = y_data[4] - a[1] - a[4] * (a[2] - z0)
+        res[3] = y_data[3] - a[0] - a[3] * (z0 - a[2])
+        res[4] = y_data[4] - a[1] - a[4] * (z0 - a[2])
         res[5] = abs(y_data[5]) - a[8]
         res[6] = y_data[6] - a[6]
         res[7] = y_data[7] - a[7]
-        res[8] = y_data[8] - a[0] - a[6] * (a[2] - z0)
-        res[9] = y_data[9] - a[1] - a[7] * (a[2] - z0)
+        res[8] = y_data[8] - a[0] - a[6] * (z0 - a[2])
+        res[9] = y_data[9] - a[1] - a[7] * (z0 - a[2])
         return res
 
     def fcn(self, npar, gin, f, par, iflag) -> None:
@@ -222,8 +222,13 @@ class Task:
                 # print "DEBUG",HNLPos[0],HNLPos[1],HNLPos[2],dist,covX[0][0],covX[1][1],covX[2][2]
                 # print "     ",mctrack.GetStartX(),mctrack.GetStartY(),mctrack.GetStartZ()
 
-                st1 = fittedTracks[t1].getFittedState()
-                st2 = fittedTracks[t2].getFittedState()
+                # Copy the fitted states: getFittedState() returns a reference to
+                # the state cached in the track's KalmanFitterInfo, and the
+                # stepwise extrapolation below would otherwise mutate the stored
+                # genfit::Track in place (affecting later pairs / getFittedState
+                # calls, making results depend on pair-processing order).
+                st1 = ROOT.genfit.MeasuredStateOnPlane(fittedTracks[t1].getFittedState())
+                st2 = ROOT.genfit.MeasuredStateOnPlane(fittedTracks[t2].getFittedState())
                 # Extrapolate to the vertex Z-plane stepwise to avoid
                 # RK failures for long backward extrapolation.
                 rc = True

--- a/python/shipVeto.py
+++ b/python/shipVeto.py
@@ -13,8 +13,8 @@ class Task:
     def __init__(self, t) -> None:
         self.SBTefficiency = 0.99  # Surrounding Background tagger: 99% efficiency picked up from TP
         self.UBTefficiency = 0.9  # Upstream background tagger
-        self.random = ROOT.TRandom()
-        ROOT.gRandom.SetSeed(13)
+        self.random = ROOT.TRandom3()
+        self.random.SetSeed(13)
         self.detList = self.detMap()
         self.sTree = t
 
@@ -27,11 +27,11 @@ class Task:
             detList[i] = nm
         return detList
 
-    def SBT_plastic_decision(self, mcParticle=None) -> None:
-        self.SBT_decision(mcParticle, detector="plastic")
+    def SBT_plastic_decision(self, mcParticle=None) -> tuple[bool, float, int]:
+        return self.SBT_decision(mcParticle, detector="plastic")
 
-    def SBT_liquid_decision(self, mcParticle=None) -> None:
-        self.SBT_decision(mcParticle, detector="liquid")
+    def SBT_liquid_decision(self, mcParticle=None) -> tuple[bool, float, int]:
+        return self.SBT_decision(mcParticle, detector="liquid")
 
     def SBT_decision(self, mcParticle=None, detector="liquid") -> tuple[bool, float, int]:
         # if mcParticle >0, only count hits with this particle
@@ -47,14 +47,15 @@ class Task:
             if not fdetector and not detID > 999999:
                 continue
             if mcParticle:
-                found = False
-                for mcP in self.sTree.digiSBT2MC[index]:
-                    if mcParticle > 0 and mcParticle != mcP:
-                        found = True
-                    if mcParticle < 0 and abs(mcParticle) == mcP:
-                        found = True
-                if found:
-                    continue
+                contributors = list(self.sTree.digiSBT2MC[index])
+                if mcParticle > 0:
+                    # only count hits from this particle: skip if it is absent
+                    if mcParticle not in contributors:
+                        continue
+                elif mcParticle < 0:
+                    # do not count hits from this particle: skip if it is present
+                    if abs(mcParticle) in contributors:
+                        continue
             aDigi.GetXYZ()
             aDigi.GetEloss()
             if aDigi.isValid():
@@ -158,6 +159,8 @@ class Task:
             master = array("d", [0, 0, 0])
             nav.LocalToMaster(origin, master)
             dist = aPoint.z() - master[2]
+            if dist < distmin:
+                distmin = dist
         return distmin
 
 


### PR DESCRIPTION
Fixes bug-category findings from a full-tree code review, scoped to `python/`. Commits are grouped by subsystem. Physics/generator-output-affecting changes were reviewed with the maintainer before applying; ambiguous domain questions were filed as issues rather than changed here.

## Physics / generators (maintainer-reviewed)
- **ACTSReco**: the MTC constant field applied `u.T` only to the z-component, so the y-field was ~4000 T instead of 1.2 T in every Kalman fit.
- **pythia8_conf_utils**: `parse_histograms` dropped the last bin of every BR histogram (off-by-one slice), and its data-row regex rejected the trailing `-0.0` values, so production BRs at the top mass point interpolated to 0 (e.g. lambdab/Xib/Omega_b final values). Both fixed.
- **dpProductionRates**: the dipole `pbrem1` mode was unreachable (substring ordering); error paths returned rate 1 instead of 0.
- **proton_bremsstrahlung**: the A' production PDF used bin widths inconsistent with the sample grids (double-filled/skipped bins).
- **pythia8_conf / rpvsusy**: added the missing B0 `sumBR` accumulation (filler channel), a boolean shim for `inclusive`, and corrected the dimensionally-inconsistent K*/D*/phi vector-meson width and swapped debug labels.

## Reconstruction / veto
- **shipVertex**: corrected the two-track vertex residual slope sign (states are extrapolated to z0) and stopped mutating the cached genfit state in place.
- **shipVeto**: fixed the SBT MC-particle contributor test, the no-op straw-veto distance comparison, RNG seeding (`self.random` vs `gRandom`), and the `SBT_plastic/liquid_decision` return value.
- **shipStrawTracking / tracking_benchmark**: opened the QA input read-only (it was rewriting the tree into the user's file), reported the real exception in the fitted-state handler, and restricted resolution histograms to the first match per MC track (clones were double-filling).
- **convertToACTS**: seed the RNG once (not per event), draw t0 from gRandom, drop the spurious event-0 zero vertex, give each vertex a distinct id, and count SND SiliconTarget hits.

## Utilities / geometry
- **rootUtils / checkMagFields / compare_histograms**: correct file-type detection and resource leaks; use `InheritsFrom("TH3")` and a dict snapshot; replace `TH1::IsEqual` (address compare) with a bin comparison and a proper exit code.
- **geomGeant4**: thread a single accumulator through `nextLevel` (the total magnet mass dropped deep levels and top-level leaves) and use `fieldsList[0]` for the single-field fallback.
- **SciFiMapping**: pass the global detector id to `GetLocalPos`.
- **global_variables / saveBasicParameters / shipDet_conf / TrackExtrapolateTool / analysis_toolkit / eminem_importer**: raise on missing attributes, fix the `dumps_json` path, honour the None-on-failure contract, guard NaN/`pz==0`, apply units, etc.

## Deferred to domain experts (filed as issues)
- #1311 — RPV-SUSY benchmarks 3 & 4 add no HNL production channel (missing muon modes)
- #1312 — shipStrawTracking hardcodes `motherId==2`
- #1313 — geomGeant4 hadron-absorber / muon-shield field maps are mutually exclusive

## Verification
Built cleanly with pixi; the full `ci-sim` → `ci-reco` → `ci-ana` chain completes successfully with no errors (exercises pythia8_conf, geomGeant4, shipVertex, shipVeto, rootUtils, global_variables, TrackExtrapolateTool). All changed files pass ruff + mypy via pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved magnetic-field unit consistency across detector setups and refined geometry field selection.
  - Fixed SciFi channel ID handling for local-position mapping and tightened `x_coords` validation for XY plots.
  - Hardened extrapolation failure and edge cases (including zero longitudinal momentum).
  - Corrected vertex-fit residual z-term sign and reduced order-dependent effects; improved vertex ID uniqueness.
  - Updated veto RNG seeding and veto decision logic; refined histogram/physics computations and parsing edge cases.

- **Chores / Reliability**
  - Safer ROOT histogram iteration/comparison, improved ROOT file/profile handling, and improved script exit status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->