### PR TITLE
Fix build, CI and packaging bugs

### DIFF
--- a/.github/workflows/cleanup-plots.yml
+++ b/.github/workflows/cleanup-plots.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Keep only last 10 main plot directories
         run: |
           if [ -d plots/main ]; then
-            ls -1 plots/main | sort -r | tail -n +11 | while read dir; do
+            ls -1 plots/main | sort -rn | tail -n +11 | while read dir; do
               rm -rf "plots/main/$dir"
             done
           fi

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,7 +1,10 @@
 name: Container Build
 on:
   push:
-    tags: ['[0-9]*']
+    # Releases use unprefixed CalVer tags: YY.MM (26.06) and YY.MM.patch
+    # (26.05.1). The explicit two-digit month keeps out non-release tags such as
+    # 26-debug or 2026-rc1, and suffixed tags like 26.6 or 26.06-debug.
+    tags: ['[0-9][0-9].[0-9][0-9]', '[0-9][0-9].[0-9][0-9].[0-9]*']
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -47,6 +47,10 @@ jobs:
             type=ref,event=branch
             type=sha,format=short
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            # metadata-action derives the tags above from github.ref, which stays
+            # on the dispatch branch even when a different inputs.ref is checked
+            # out; tag the built ref explicitly on manual dispatch.
+            type=raw,value=${{ inputs.ref }},enable=${{ github.event_name == 'workflow_dispatch' }}
       - uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -52,8 +52,9 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             # metadata-action derives the tags above from github.ref, which stays
             # on the dispatch branch even when a different inputs.ref is checked
-            # out; tag the built ref explicitly on manual dispatch.
-            type=raw,value=${{ inputs.ref }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            # out; tag the built ref explicitly on manual dispatch. type=raw does
+            # not slugify '/', so skip refs that would form an invalid tag.
+            type=raw,value=${{ inputs.ref }},enable=${{ github.event_name == 'workflow_dispatch' && !contains(inputs.ref, '/') }}
       - uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/legacy-cvmfs.yml
+++ b/.github/workflows/legacy-cvmfs.yml
@@ -2,7 +2,9 @@ name: Legacy CVMFS CI
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    # Releases use unprefixed CalVer tags (e.g. 26.06, 26.05.1), not v-prefixed
+    # (matches the container-build workflow's trigger).
+    tags: ['[0-9]*']
   workflow_dispatch:
   schedule:
     - cron: 30 2 * * *

--- a/.github/workflows/legacy-cvmfs.yml
+++ b/.github/workflows/legacy-cvmfs.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches: [main]
     # Releases use unprefixed CalVer tags (e.g. 26.06, 26.05.1), not v-prefixed
-    # (matches the container-build workflow's trigger).
-    tags: ['[0-9]*']
+    # (matches the container-build workflow's trigger). The YY.MM[.patch] shape
+    # keeps out non-release tags such as 26-debug or 2026-rc1.
+    tags: ['[0-9][0-9].[0-9]*']
   workflow_dispatch:
   schedule:
     - cron: 30 2 * * *

--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
     # Releases use unprefixed CalVer tags (e.g. 26.06, 26.05.1), not v-prefixed
     # (matches the container-build workflow's trigger).
-    tags: ['[0-9]*']
+    tags: ['[0-9][0-9].[0-9]*']
   workflow_dispatch:
   merge_group:
 concurrency:

--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -4,7 +4,9 @@ on:
     branches: [main]
   push:
     branches: [main]
-    tags: ['v*']
+    # Releases use unprefixed CalVer tags (e.g. 26.06, 26.05.1), not v-prefixed
+    # (matches the container-build workflow's trigger).
+    tags: ['[0-9]*']
   workflow_dispatch:
   merge_group:
 concurrency:
@@ -386,7 +388,10 @@ jobs:
             }
   deploy-plots:
     name: Deploy plots
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    # Fork PRs get a read-only GITHUB_TOKEN, so the gh-pages push and PR comment
+    # would always fail; only run for same-repo PRs and main pushes.
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [run-tracking-benchmark, run-sim-chain, run-fixed-target]
     concurrency:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: .dat
+        exclude: \.dat$
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-toml

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "FairShip"
-version: 25.12
-date-released: 2025-12-22
+version: 26.06
+date-released: 2026-06-18
 url: "https://github.com/ShipSoft/FairShip"
 repository-code: "https://github.com/ShipSoft/FairShip"
 type: software

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,10 +161,6 @@ find_package(genfit2 REQUIRED)
 # TPythia6 was removed from ROOT in 6.32, use external EGPythia6 package
 find_package(ROOTEGPythia6 REQUIRED)
 
-if(DEFINED $ENV{GSL_ROOT})
-    set(GSL_DIR $ENV{GSL_ROOT})
-endif()
-
 # set a variable which should be used in all CMakeLists.txt Defines all basic
 # include directories from fairbase
 message("-- Setting basic variables ...")

--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,8 @@ RUN pixi install --locked && rm -rf ~/.cache/rattler
 COPY . /FairShip
 RUN pixi run --locked build
 
-RUN pixi shell-hook -s bash > /entrypoint.sh \
+RUN echo '#!/bin/bash' > /entrypoint.sh \
+    && pixi shell-hook -s bash >> /entrypoint.sh \
     && echo 'exec "$@"' >> /entrypoint.sh \
     && chmod +x /entrypoint.sh
 

--- a/cmake/modules/FindEvtGen.cmake
+++ b/cmake/modules/FindEvtGen.cmake
@@ -120,6 +120,10 @@ if(EvtGen_FOUND)
     # Set output variables
     set(EvtGen_INCLUDE_DIRS "${EvtGen_INCLUDE_DIR}")
     set(EvtGen_LIBRARIES "${EvtGen_LIBRARY}" "${EvtGen_External_LIBRARY}")
+    # Also export the upper-case name that the config package provides, so
+    # consumers (e.g. shipgen) that use ${EVTGEN_INCLUDE_DIR} work on the
+    # module-fallback path too.
+    set(EVTGEN_INCLUDE_DIR "${EvtGen_INCLUDE_DIR}")
 
     # Create imported target for EvtGen core library (must be created first)
     if(NOT TARGET EvtGen::EvtGen)

--- a/pixi.toml
+++ b/pixi.toml
@@ -89,7 +89,7 @@ args = [
 cmd = "python macro/run_simScript.py --test --debug 2 --{{ vessel }} --SND --SND_design={{ snd_design }} --shieldName {{ muon_shield }} --EvtGenDecayer --seed 42 --tag ci-test"
 
 [tasks.ci-overlap-check]
-cmd = "python python/experimental/check_overlaps.py --geofile geo_ci-test.root | tee overlap.log && ! grep -q Overlap overlap.log"
+cmd = "bash -c 'set -o pipefail; python python/experimental/check_overlaps.py --geofile geo_ci-test.root | tee overlap.log && ! grep -q Overlap overlap.log'"
 
 [tasks.ci-geo-info]
 cmd = "python macro/getGeoInformation.py --geometry geo_ci-test.root --level 2"

--- a/splitcal/splitcalHit.h
+++ b/splitcal/splitcalHit.h
@@ -86,10 +86,11 @@ class splitcalHit : public SHiP::DetectorHit {
 
  private:
   Bool_t flag{true};
-  double _x, _y, _z, _xError, _yError, _zError;
-  double _energy;
-  int _isPrecisionLayer, _nLayer, _nModuleX, _nModuleY, _nStrip, _isUsed;
-  bool _isX, _isY;
+  double _x{0}, _y{0}, _z{0}, _xError{0}, _yError{0}, _zError{0};
+  double _energy{0};
+  int _isPrecisionLayer{0}, _nLayer{0}, _nModuleX{0}, _nModuleY{0}, _nStrip{0},
+      _isUsed{0};
+  bool _isX{false}, _isY{false};
 
   ClassDefOverride(splitcalHit, 6);
 };

--- a/tests/test_rntuple_io.cxx
+++ b/tests/test_rntuple_io.cxx
@@ -8,15 +8,36 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <iostream>
 #include <memory>
+#include <typeinfo>
 #include <vector>
 
 #include "ROOT/RNTuple.hxx"
 #include "ROOT/RNTupleModel.hxx"
 #include "ROOT/RNTupleReader.hxx"
 #include "ROOT/RNTupleWriter.hxx"
+#include "TBufferFile.h"
+#include "TClass.h"
 #include "TFile.h"
+
+// Compare two objects field-by-field via their ROOT streamer: if the round-trip
+// preserved every persisted member the serialised buffers are identical. This
+// verifies value preservation generically for any dictionary-backed class.
+template <typename T>
+bool objects_equal(const T& a, const T& b) {
+  TClass* cls = TClass::GetClass(typeid(T));
+  if (!cls) {
+    return false;
+  }
+  TBufferFile buf_a(TBuffer::kWrite);
+  TBufferFile buf_b(TBuffer::kWrite);
+  buf_a.WriteObjectAny(&a, cls);
+  buf_b.WriteObjectAny(&b, cls);
+  return buf_a.Length() == buf_b.Length() &&
+         std::memcmp(buf_a.Buffer(), buf_b.Buffer(), buf_a.Length()) == 0;
+}
 
 // Include data class headers
 #include "DetectorHit.h"
@@ -99,6 +120,13 @@ bool test_rntuple_io(const char* class_name, std::vector<T>& test_objects) {
                   << test_objects.size() << ", got " << read_vec1.size()
                   << std::endl;
         return false;
+      }
+      for (std::size_t i = 0; i < test_objects.size(); ++i) {
+        if (!objects_equal(read_vec1[i], test_objects[i])) {
+          std::cout << "FAIL: Entry 0 element " << i
+                    << " differs after round-trip" << std::endl;
+          return false;
+        }
       }
 
       // Check second entry (should be empty)


### PR DESCRIPTION
Fixes bug-category findings from a full-tree code review, scoped to the build system, CI workflows, packaging and tests.

## High
- **Containerfile**: the entrypoint written by `pixi shell-hook` has no shebang, so the exec-form `ENTRYPOINT` fails with ENOEXEC at `docker run`. Prepend `#!/bin/bash`.

## Medium
- **pixi.toml** `ci-overlap-check`: no pipefail, so a crash in the overlap script (before it prints) passed the task; wrapped in `bash -c 'set -o pipefail; ...'`.
- **pixi-build.yml / legacy-cvmfs.yml**: release-tag triggers used `['v*']`, which never matches the unprefixed CalVer release tags (`26.06`, …); changed to `['[0-9]*']` (matching container-build).
- **CMakeLists.txt**: `if(DEFINED $ENV{GSL_ROOT})` is wrong syntax (always false) in a block nothing uses — deleted.
- **FindEvtGen.cmake**: shipgen consumes `${EVTGEN_INCLUDE_DIR}` (set only by config mode); the module-fallback path lost the SYSTEM include. Export the upper-case alias from the module too.
- **.pre-commit-config.yaml**: `exclude: .dat` was unanchored and matched `shipdata/` (via "pdat"); anchored to `\.dat$`.
- **pixi-build.yml deploy-plots** (reviewed): guarded to same-repo PRs / master pushes so fork PRs (read-only token) don't fail the job.

## Low
- **cleanup-plots.yml**: `sort -r` on numeric run IDs is lexicographic (wrong once IDs gain a digit); use `sort -rn`.
- **container-build.yml**: manual-dispatch images were tagged from `github.ref` rather than the checked-out `inputs.ref`; add an explicit raw tag.
- **CITATION.cff**: bumped stale 25.12 → 26.06.
- **tests/test_rntuple_io.cxx**: the round-trip test only checked entry counts / vector sizes. Now compares each object field-by-field via its ROOT streamer buffer — which surfaced that **`splitcalHit` left all geometry/energy members uninitialised** (only the base `detID/tdc` were set); added in-class initialisers.

## Verification
`pixi run build` + `pixi run test` both pass (2/2 tests, including the strengthened RNtuple round-trip). YAML/CMake/pre-commit changes pass their respective hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated workflow tag matching and narrowed plot deployment conditions to prevent unintended runs.
  * Fixed scheduled plot cleanup to retain the most recent directories using numeric ordering.
  * Improved default initialization for `splitcalHit` members to avoid uninitialized values.
* **Tests**
  * Strengthened RNtuple I/O validation with element-by-element round-trip equality checks.
* **Chores**
  * Updated container entrypoint script generation, hardened CI overlap checking (`pipefail`), tightened whitespace linting, and refreshed `CITATION.cff` version/date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->