### PR TITLE
Fix correctness bugs in field/ and gconfig/

### DIFF
--- a/field/FairShipFields.cxx
+++ b/field/FairShipFields.cxx
@@ -29,13 +29,21 @@ TVector3 FairShipFields::get(const TVector3& pos) const {
 void FairShipFields::get(const double& x, const double& y, const double& z,
                          double& Bx, double& By, double& Bz) const {
   Double_t X[3] = {x, y, z};
-  Double_t B[3] = {Bx, By, Bz};
+  Double_t B[3] = {0., 0., 0.};
+  Bx = 0.;
+  By = 0.;
+  Bz = 0.;
   if (!gMC && !gField_) {
     cout << "no Field Manager instantiated" << endl;
     return;
   }
   if (gMC) {
-    gMC->GetMagField()->Field(X, B);
+    TVirtualMagField* magField = gMC->GetMagField();
+    if (!magField) {
+      cout << "no magnetic field set in the Virtual MC" << endl;
+      return;
+    }
+    magField->Field(X, B);
   } else {
     gField_->Field(X, B);
   }

--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -130,12 +130,13 @@ void ShipBFieldMap::Field(const Double_t* position, Double_t* B) {
   Float_t z = localCoords[2];
 
   // Now check to see if we have x-y quadrant symmetry (z has no symmetry):
-  // Bx is antisymmetric in x and y, By is symmetric and Bz has no symmetry
-  // so only Bx can change sign. This can happen if either x < 0 or y < 0:
-  // 1. x > 0, y > 0: Bx = Bx
-  // 2. x > 0, y < 0: Bx = -Bx
-  // 3. x < 0, y > 0: Bx = -Bx
-  // 4. x < 0, y < 0: Bx = Bx
+  // Bx is antisymmetric in both x and y, By is symmetric in both, while Bz is
+  // symmetric in x but antisymmetric in y (dipole physics). So Bx can change
+  // sign for x < 0 or y < 0, and Bz can change sign for y < 0:
+  // 1. x > 0, y > 0: Bx = +Bx, Bz = +Bz
+  // 2. x > 0, y < 0: Bx = -Bx, Bz = -Bz
+  // 3. x < 0, y > 0: Bx = -Bx, Bz = +Bz
+  // 4. x < 0, y < 0: Bx = +Bx, Bz = -Bz
 
   Float_t BxSign(1.0);
   Float_t BzSign = 1;
@@ -440,7 +441,8 @@ void ShipBFieldMap::setLimits() {
 
 ShipBFieldMap::binPair ShipBFieldMap::getBinInfo(
     Float_t u, ShipBFieldMap::CoordAxis theAxis) {
-  Float_t du(0.0), uMin(0.0), Nu(0);
+  Float_t du(0.0), uMin(0.0);
+  Int_t Nu(0);
 
   if (theAxis == ShipBFieldMap::xAxis) {
     du = dx_;
@@ -474,6 +476,14 @@ ShipBFieldMap::binPair ShipBFieldMap::getBinInfo(
   if (iBin < 0 || iBin >= Nu) {
     iBin = -1;
     fracL = 0.0;
+  } else if (iBin >= Nu - 1) {
+    // The point lies in the last bin along this axis. The trilinear
+    // interpolation uses the iBin+1 neighbour, which would fall outside the
+    // axis here, so clamp to the last valid cell (Nu-2) and use a fractional
+    // weight of 1 so the upper-edge (last valid) slice is used without reading
+    // the next, non-existent slice.
+    iBin = Nu - 2;
+    fracL = 1.0;
   }
 
   // Return the bin number and fractional distance of the point from the

--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -424,6 +424,13 @@ void ShipBFieldMap::setLimits() {
     Nz_ = static_cast<Int_t>(((zMax_ - zMin_) / dz_) + 1.5);
   }
 
+  // Trilinear interpolation needs at least two bins per axis; a smaller map
+  // would silently be treated as out of range for every point.
+  if (Nx_ < 2 || Ny_ < 2 || Nz_ < 2) {
+    LOG(fatal) << "ShipBFieldMap: field map needs at least 2 bins per axis; "
+               << "got Nx = " << Nx_ << ", Ny = " << Ny_ << ", Nz = " << Nz_;
+  }
+
   N_ = Nx_ * Ny_ * Nz_;
 
   LOG(info) << "x limits: " << xMin_ << ", " << xMax_ << ", dx = " << dx_;

--- a/field/ShipBellField.cxx
+++ b/field/ShipBellField.cxx
@@ -129,10 +129,14 @@ void ShipBellField::Print(Option_t*) const {
   cout << "======================================================" << endl;
   cout << "----  " << fTitle << " : " << fName << endl;
   cout << "----" << endl;
-  cout << "----  Field type    : constant" << endl;
+  cout << "----  Field type       : Bell" << endl;
   cout << "----" << endl;
-  cout << "----  Field regions : " << endl;
   cout.precision(4);
+  cout << "----  Peak field       : " << fPeak << " kG" << endl;
+  cout << "----  Middle (z centre) : " << fMiddle << " cm" << endl;
+  cout << "----  Btube            : " << fBtube << " cm" << endl;
+  cout << "----  Orientation      : " << fOrient << endl;
+  cout << "----  Include target   : " << (fInclTarget ? "yes" : "no") << endl;
   cout << "======================================================" << endl;
 }
 // -------------------------------------------------------------------------

--- a/field/ShipBellField.h
+++ b/field/ShipBellField.h
@@ -60,7 +60,7 @@ class ShipBellField : public FairField {
   Double_t fPeak;
   Double_t fMiddle;
   Double_t fBtube;
-  Int_t fOrient;
+  Int_t fOrient{1};
   Bool_t fInclTarget;
   Double_t targetXY;
   Double_t targetZ0;

--- a/field/ShipFieldMaker.cxx
+++ b/field/ShipFieldMaker.cxx
@@ -573,10 +573,10 @@ void ShipFieldMaker::defineComposite(const TString& name,
         }
         vectFields.push_back(aField);
       }
-
-      ShipCompField* composite = new ShipCompField(name.Data(), vectFields);
-      theFields_[name] = composite;
     }
+
+    ShipCompField* composite = new ShipCompField(name.Data(), vectFields);
+    theFields_[name] = composite;
 
   } else {
     std::cout << "We already have a composite field with the name "

--- a/field/ShipFieldPar.cxx
+++ b/field/ShipFieldPar.cxx
@@ -80,7 +80,7 @@ void ShipFieldPar::putParams(FairParamList* list) {
     list->add("Field Bx", fBx);
     list->add("Field By", fBy);
     list->add("Field Bz", fBz);
-  } else if (fType >= 1 && fType <= kMaxFieldMapType) {  //
+  } else if (fType == 1) {  //
     list->add("Field Peak", fPeak);
     list->add("Field Middle", fMiddle);
   } else if (fType >= 2 && fType <= kMaxFieldMapType) {  // field map
@@ -110,7 +110,7 @@ Bool_t ShipFieldPar::getParams(FairParamList* list) {
     if (!list->fill("Field By", &fBy)) return kFALSE;
     if (!list->fill("Field Bz", &fBz)) return kFALSE;
 
-  } else if (fType >= 1 && fType <= kMaxFieldMapType) {
+  } else if (fType == 1) {
     if (!list->fill("Field Peak", &fPeak)) return kFALSE;
     if (!list->fill("Field Middle", &fMiddle)) return kFALSE;
 

--- a/field/ShipFieldPar.h
+++ b/field/ShipFieldPar.h
@@ -83,7 +83,7 @@ class ShipFieldPar : public FairParGenericSet {
   /** field parameters**/
   Double_t fPeak;
   Double_t fMiddle;
-  Double_t fBtube;
+  Double_t fBtube{0};
 
   ShipFieldPar(const ShipFieldPar&) = delete;
   ShipFieldPar& operator=(const ShipFieldPar&) = delete;

--- a/field/add_noise_to_field.py
+++ b/field/add_noise_to_field.py
@@ -3,7 +3,6 @@
 
 import argparse
 import os
-import random
 
 import matplotlib.pylab as plt
 import numpy as np
@@ -38,11 +37,13 @@ def generate_file(input_fileName, output, xSpace=73, ySpace=128, zSpace=1214, st
     else:
         field_new[["bx", "by", "bz"]] = 0
         index_range = np.random.choice(field_new.index, size=args.nCores)
-        field_new.loc[index_range, "by"] = random.uniform(-args.peak, args.peak)
+        # Draw an independent value per noise core so --peak sets the amplitude;
+        # a single scalar (assigned to every core) was cancelled by the
+        # self-normalisation below, leaving --peak with no effect but its sign.
+        field_new.loc[index_range, "by"] = np.random.uniform(-args.peak, args.peak, size=args.nCores)
         temp_by = np.array(field_new["by"]).reshape([xSpace, ySpace, zSpace])
         temp_by = gaussian_filter(temp_by, sigma=args.sigma)
         field_new["by"] = temp_by.reshape(-1)
-        field_new["by"] = field_new["by"] / (field_new["by"].abs().max())  # *field_mask['by']
         field_new["by"] = field_new["by"] * field_mask["by"]
         rezult = field.copy()
         rezult["by"] = rezult["by"] + rezult["by"] * field_new["by"] * args.fraction

--- a/field/add_noise_to_field.py
+++ b/field/add_noise_to_field.py
@@ -19,7 +19,9 @@ def plot_my_hist(datum) -> None:
     plt.show()
 
 
-def generate_file(input_fileName, output, xSpace=73, ySpace=128, zSpace=1214, step=2.5, args=None) -> None:
+def generate_file(
+    input_fileName, output, xSpace=73, ySpace=128, zSpace=1214, step=2.5, *, args: argparse.Namespace
+) -> None:
     # (min, max, max/stepSize + 1)  in case of Z: (0, nSteps*2.5 - 2.5, nSteps)
     field = pd.read_csv(input_fileName, skiprows=1, sep=r"\s+", names=["x", "y", "z", "bx", "by", "bz"])
 
@@ -52,7 +54,7 @@ def generate_file(input_fileName, output, xSpace=73, ySpace=128, zSpace=1214, st
     # plot_my_hist(field)
     # plot_my_hist(field_new)
     # plot_my_hist(rezult)
-    rezult.to_csv(output, sep="\t", header=None, index=None)
+    rezult.to_csv(output, sep="\t", header=False, index=False)
 
 
 if __name__ == "__main__":

--- a/field/convertMisisMap.py
+++ b/field/convertMisisMap.py
@@ -80,8 +80,6 @@ def createRootMap(inFileName, rootFileName) -> None:
 
     # mm to cm conversion
     mm2cm = 0.1
-    # m to cm conversion
-    m2cm = 100.0
 
     # Open text file and process the information
     iLine = 0
@@ -153,11 +151,6 @@ def createRootMap(inFileName, rootFileName) -> None:
             # Field data values start from line 3
             elif iLine > 2:
                 sLine = line.split()
-
-                # Bin centre coordinates (m to cm), with origin shift (cm)
-                dStruct.x = float(sLine[0]) * m2cm - x0
-                dStruct.y = float(sLine[1]) * m2cm - y0
-                dStruct.z = float(sLine[2]) * m2cm - z0
 
                 # B field components (Tesla)
                 dStruct.Bx = float(sLine[3])

--- a/gconfig/DecayConfigNuAge.C
+++ b/gconfig/DecayConfigNuAge.C
@@ -35,7 +35,7 @@ void DecayConfig() {
   tp8->ReadString("421:mayDecay = off");
   gMC->SetUserDecay(4122);
   gMC->SetUserDecay(-4122);
-  tp8->ReadString("15:mayDecay = off");
+  tp8->ReadString("4122:mayDecay = off");
   gMC->SetUserDecay(431);
   gMC->SetUserDecay(-431);
   tp8->ReadString("431:mayDecay = off");

--- a/gconfig/UserDecay.C
+++ b/gconfig/UserDecay.C
@@ -9,12 +9,21 @@ void UserDecayConfig() {
 
   Int_t mode[6][3];
   Float_t bratio[6];
-  Int_t AlphaPDG, He5PDG;
+  Int_t AlphaPDG = 0, He5PDG = 0;
   p = db->GetParticle("Alpha");
   if (p) AlphaPDG = p->PdgCode();
   p = db->GetParticle("He5");
 
   if (p) He5PDG = p->PdgCode();
+
+  // Skip the decay configuration if either PDG lookup failed, otherwise we
+  // would configure a decay for an invalid particle type.
+  if (AlphaPDG == 0 || He5PDG == 0) {
+    cout << "UserDecayConfig: could not find Alpha and/or He5 in TDatabasePDG, "
+            "skipping decay configuration"
+         << endl;
+    return;
+  }
   for (Int_t kz = 0; kz < 6; kz++) {
     bratio[kz] = 0.;
     mode[kz][0] = 0;


### PR DESCRIPTION
Fixes bug-category findings from a full-tree code review, scoped to the magnetic-field code and decay configuration. Commits grouped by kind.

## Field construction / parameters
- **ShipFieldMaker**: `defineComposite` built a `ShipCompField` and inserted it into the field map inside the loop over member fields, leaking N-1 composites built from incomplete lists; build it once after the loop.
- **ShipFieldPar**: the Bell branch in `putParams`/`getParams` was gated on `fType in [1, kMaxFieldMapType]`, shadowing the field-map branch (`fType in [2, kMaxFieldMapType]`), so field-map parameters could never be persisted or read back. Gate Bell on `fType == 1`.
- **ShipBellField / ShipFieldPar**: `fOrient` and `fBtube` were read by `GetBx/GetBy` / `ShipBellField(fieldPar)` but left uninitialized by some constructors; added in-class initializers. `ShipBellField::Print()` (copied from ShipConstField) reported a constant field — now prints the Bell parameters.

## Field evaluation
- **FairShipFields::get**: seeded its work array from the caller's uninitialized outputs and never wrote `Bx/By/Bz` on the early-return paths (genfit got garbage); also dereferenced `gMC->GetMagField()` without a null check. Zero the outputs and guard the pointer.
- **ShipBFieldMap**: `getBinInfo` accepted the last bin so trilinear interpolation's `iBin+1` neighbour read the opposite corner of the next slice — clamp to `Nu-2` at the upper edge; `Nu` (a bin count) was `Float_t` → `Int_t`; corrected a misleading x-y symmetry comment (the code correctly flips Bz for `y<0`).

## Decay configuration
- **DecayConfigNuAge.C**: issued `15:mayDecay = off` (a copy of the tau line) instead of `4122:mayDecay = off`, so Lambda_c was decayed inside Pythia8 rather than returned to transport.
- **UserDecay.C**: `AlphaPDG`/`He5PDG` were uninitialized when the PDG lookups failed, configuring a decay for a random code; initialize them and skip on failed lookup.

## Field python tooling
- **add_noise_to_field.py** (reviewed): assigned a single scalar to every noise core then self-normalized, so `--peak` affected only the sign; draw an independent value per core and drop the renormalization so `--peak` sets the amplitude.
- **convertMisisMap.py**: removed dead `dStruct.x/y/z` writes (no such branches — PyROOT silently attached Python attributes).

## Verification
Built cleanly with pixi; `ci-sim` → `ci-reco` complete with no errors (exercises the field-map setup and evaluation). Python passes ruff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetic-field handling when no field is configured.
  * Fixed field-map boundary interpolation and invalid map configurations.
  * Corrected field composition, parameter handling, and default settings.
  * Improved field-map unit conversion and data export.
  * Made decay configuration safer and disabled unwanted particle decays.

* **Documentation**
  * Updated field descriptions and printouts to reflect configured settings.

* **New Features**
  * Added independent per-component noise generation for field data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->