### PR TITLE
perf: hot-path performance cleanups

### DIFF
--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -398,6 +398,24 @@ class DrawTracks(ROOT.FairTask):
         ntot = 0
         fPos = ROOT.TVector3()
         fMom = ROOT.TVector3()
+        # Build a trackID -> hits map once per event instead of rescanning every
+        # hit collection for every MC track (was O(tracks x hits)). Branch and
+        # in-branch order are preserved, so downstream hitlist building is
+        # unchanged.
+        hits_by_track: dict[int, list] = {}
+        for P in [
+            "vetoPoint",
+            "strawtubesPoint",
+            "ShipRpcPoint",
+            "TargetPoint",
+            "MTCDetPoint",
+            "SiliconTargetPoint",
+            "TimeDetPoint",
+        ]:
+            if not sTree.GetBranch(P):
+                continue
+            for p in getattr(sTree, P):
+                hits_by_track.setdefault(p.GetTrackID(), []).append(p)
         for fT in sTree.MCTrack:
             n += 1
             DTrack = ROOT.TEveLine()
@@ -414,34 +432,21 @@ class DrawTracks(ROOT.FairTask):
                 # end vertex of HNL
                 da.GetStartVertex(fPos)
                 hitlist[fPos.Z()] = [fPos.X(), fPos.Y()]
-            # loop over all sensitive volumes to find hits
-            for P in [
-                "vetoPoint",
-                "strawtubesPoint",
-                "ShipRpcPoint",
-                "TargetPoint",
-                "MTCDetPoint",
-                "SiliconTargetPoint",
-                "TimeDetPoint",
-            ]:
-                if not sTree.GetBranch(P):
-                    continue
-                c = eval("sTree." + P)
-                for p in c:
-                    if p.GetTrackID() == n:
-                        if hasattr(p, "LastPoint"):
-                            lp = p.LastPoint()
-                            if lp.x() == lp.y() and lp.x() == lp.z() and lp.x() == 0:
-                                # must be old data, don't expect hit at 0,0,0
-                                hitlist[p.GetZ()] = [p.GetX(), p.GetY()]
-                            else:
-                                hitlist[lp.z()] = [lp.x(), lp.y()]
-                                hitlist[2.0 * p.GetZ() - lp.z()] = [
-                                    2.0 * p.GetX() - lp.x(),
-                                    2.0 * p.GetY() - lp.y(),
-                                ]
-                        else:
-                            hitlist[p.GetZ()] = [p.GetX(), p.GetY()]
+            # collect the hits belonging to this MC track (per-event map above)
+            for p in hits_by_track.get(n, []):
+                if hasattr(p, "LastPoint"):
+                    lp = p.LastPoint()
+                    if lp.x() == lp.y() and lp.x() == lp.z() and lp.x() == 0:
+                        # must be old data, don't expect hit at 0,0,0
+                        hitlist[p.GetZ()] = [p.GetX(), p.GetY()]
+                    else:
+                        hitlist[lp.z()] = [lp.x(), lp.y()]
+                        hitlist[2.0 * p.GetZ() - lp.z()] = [
+                            2.0 * p.GetX() - lp.x(),
+                            2.0 * p.GetY() - lp.y(),
+                        ]
+                else:
+                    hitlist[p.GetZ()] = [p.GetX(), p.GetY()]
             if len(hitlist) == 1:
                 if fT.GetMotherId() < 0:
                     continue

--- a/python/hnl.py
+++ b/python/hnl.py
@@ -133,6 +133,12 @@ class HNLbranchings:
         self.U2 = couplings
         self.U = [math.sqrt(ui) for ui in self.U2]
         self.MN = mass * u.GeV
+        # Cached total decay width; constant for fixed mass/couplings, which are
+        # never mutated after construction.
+        self._totalWidth = None
+        # Reused TF1 wrapping the (Python) integrand; rebuilding it per call is
+        # expensive because of the PyROOT callable binding.
+        self._integrand_tf1 = None
         self.CKM = CKMmatrix()
         self.CKMelemSq = {
             "pi+": self.CKM.Vud**2.0,
@@ -324,8 +330,9 @@ class HNLbranchings:
         Numerical integral needed for 3-body decays through W boson.
         xi = mi/MN
         """
-        theFunction = self.Integrand
-        func = ROOT.TF1("func", theFunction, 0, 1, 3)  # Setting function
+        if self._integrand_tf1 is None:
+            self._integrand_tf1 = ROOT.TF1("hnl_integrand", self.Integrand, 0, 1, 3)
+        func = self._integrand_tf1
         func.SetParameters(x1, x2, x3)
         xmin = (x1 + x3) ** 2
         xmax = (1.0 - x2) ** 2
@@ -511,11 +518,12 @@ class HNLbranchings:
         """
         Returns the total HNL decay width
         """
-        leptonWidth = self.Width_3nu() + self.Width_charged_leptons()
-        mesonWidth = self.Width_neutral_mesons() + self.Width_charged_mesons()
-        quarkWidth = self.Width_quarks_neutrino() + self.Width_quarks_lepton()
-        totalWidth = leptonWidth + max([mesonWidth, quarkWidth])
-        return totalWidth
+        if self._totalWidth is None:
+            leptonWidth = self.Width_3nu() + self.Width_charged_leptons()
+            mesonWidth = self.Width_neutral_mesons() + self.Width_charged_mesons()
+            quarkWidth = self.Width_quarks_neutrino() + self.Width_quarks_lepton()
+            self._totalWidth = leptonWidth + max([mesonWidth, quarkWidth])
+        return self._totalWidth
 
     def findBranchingRatio(self, decayString):
         """

--- a/python/hnl.py
+++ b/python/hnl.py
@@ -331,7 +331,10 @@ class HNLbranchings:
         xi = mi/MN
         """
         if self._integrand_tf1 is None:
-            self._integrand_tf1 = ROOT.TF1("hnl_integrand", self.Integrand, 0, 1, 3)
+            # ROOT registers TF1s globally by name and WrappedTF1 resolves them
+            # by that name, so give each instance a unique name to avoid
+            # collisions when several HNLbranchings objects are alive at once.
+            self._integrand_tf1 = ROOT.TF1(f"hnl_integrand_{id(self):x}", self.Integrand, 0, 1, 3)
         func = self._integrand_tf1
         func.SetParameters(x1, x2, x3)
         xmin = (x1 + x3) ** 2

--- a/python/shipPatRec.py
+++ b/python/shipPatRec.py
@@ -327,7 +327,7 @@ def fast_hough_pat_rec_y_view(SmearedHits, min_hits: int):
 def fast_hough_pat_rec_stereo_views(SmearedHits_stereo, recognized_tracks_y, min_hits: int):
     ### PatRec in stereo
     recognized_tracks_stereo = []
-    used_hits = []
+    used_hits = set()
     n_y_tracks_with_stereo = 0
 
     for atrack_y in recognized_tracks_y:
@@ -409,7 +409,7 @@ def fast_hough_pat_rec_stereo_views(SmearedHits_stereo, recognized_tracks_y, min
             atrack["hits_stereo"] = max_track["hits_stereo"]
             n_y_tracks_with_stereo += 1
             for ahit in max_track["hits_stereo"]:
-                used_hits.append(ahit["digiHit"])
+                used_hits.add(ahit["digiHit"])
 
         recognized_tracks_stereo.append(atrack)
 
@@ -595,7 +595,7 @@ def artificial_retina_pat_rec_y_view(SmearedHits, min_hits: int):
 def artificial_retina_pat_rec_stereo_views(SmearedHits_stereo, recognized_tracks_y, min_hits: int):
     ### PatRec in stereo
     recognized_tracks_stereo = []
-    used_hits = []
+    used_hits = set()
     n_y_tracks_with_stereo = 0
 
     for atrack_y in recognized_tracks_y:
@@ -678,7 +678,7 @@ def artificial_retina_pat_rec_stereo_views(SmearedHits_stereo, recognized_tracks
             atrack["hits_stereo"] = max_track["hits_stereo"]
             n_y_tracks_with_stereo += 1
             for ahit in max_track["hits_stereo"]:
-                used_hits.append(ahit["digiHit"])
+                used_hits.add(ahit["digiHit"])
 
         recognized_tracks_stereo.append(atrack)
 
@@ -848,7 +848,7 @@ def reduce_clones_using_one_track_per_hit(recognized_tracks, min_hits: int = 3):
         Minimal number of hits per track.
     """
 
-    used_hits = []
+    used_hits = set()
     tracks_no_clones = []
     n_hits = [len(atrack["hits_y"]) for atrack in recognized_tracks]
 
@@ -865,7 +865,7 @@ def reduce_clones_using_one_track_per_hit(recognized_tracks, min_hits: int = 3):
         if len(new_track["hits_y"]) >= min_hits:
             tracks_no_clones.append(new_track)
             for ahit in new_track["hits_y"]:
-                used_hits.append(ahit["digiHit"])
+                used_hits.add(ahit["digiHit"])
 
     return tracks_no_clones
 
@@ -1073,7 +1073,7 @@ def get_zy_projection(z, xtop, ytop, xbot, ybot, k_y, b_y):
 def pat_rec_stereo_views(SmearedHits_stereo, recognized_tracks_y, min_hits: int):
     ### PatRec in stereo
     recognized_tracks_stereo = []
-    used_hits = []
+    used_hits = set()
     n_y_tracks_with_stereo = 0
 
     for atrack_y in recognized_tracks_y:
@@ -1150,7 +1150,7 @@ def pat_rec_stereo_views(SmearedHits_stereo, recognized_tracks_y, min_hits: int)
             atrack["hits_stereo"] = max_track["hits_stereo"]
             n_y_tracks_with_stereo += 1
             for ahit in max_track["hits_stereo"]:
-                used_hits.append(ahit["digiHit"])
+                used_hits.add(ahit["digiHit"])
 
         recognized_tracks_stereo.append(atrack)
 

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -692,7 +692,7 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     # 4. Find straws that have multiple hits
     nHits = sTree.strawtubesPoint.GetEntriesFast()
     hitstraws = {}
-    duplicatestrawhit = []
+    duplicatestrawhit = set()
 
     for i in range(nHits):
         ahit = sTree.strawtubesPoint[i]
@@ -702,10 +702,10 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
             # straw was already hit
             if ahit.GetX() > hitstraws[strawname][1]:
                 # this hit has higher x, discard it
-                duplicatestrawhit.append(i)
+                duplicatestrawhit.add(i)
             else:
                 # del hitstraws[strawname]
-                duplicatestrawhit.append(hitstraws[strawname][0])
+                duplicatestrawhit.add(hitstraws[strawname][0])
                 hitstraws[strawname] = [i, ahit.GetX()]
         else:
             hitstraws[strawname] = [i, ahit.GetX()]
@@ -715,7 +715,7 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     hits2 = {}
     hits3 = {}
     hits4 = {}
-    trackoutsidestations = []
+    trackoutsidestations = set()
 
     margin = 5.0 * u.cm
     x_bound = ShipGeo.strawtubes_geo.width - margin
@@ -729,8 +729,7 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
 
         # is hit inside acceptance (width/height minus margin)?
         if abs(ahit.GetX()) >= x_bound or abs(ahit.GetY()) >= y_bound:
-            if ahit.GetTrackID() not in trackoutsidestations:
-                trackoutsidestations.append(ahit.GetTrackID())
+            trackoutsidestations.add(ahit.GetTrackID())
 
         if ahit.GetTrackID() not in MCTrackIDs:
             # hit on not reconstructible track

--- a/python/tracking_benchmark.py
+++ b/python/tracking_benchmark.py
@@ -97,6 +97,39 @@ class TrackingBenchmark:
 
         self.metrics: dict[str, Any] = {}
         self._histos: dict[str, Any] = {}
+        # Per-event index over strawtubesPoint, rebuilt each event.
+        self._straw_index: dict[int, dict[str, Any]] = {}
+
+    def _build_straw_index(self) -> dict[int, dict[str, Any]]:
+        """Build a per-event index over strawtubesPoint.
+
+        Maps MC track id -> {n_hits, stations, first}, where ``first`` holds the
+        (px, py, pz, x, y, z) of the first straw hit for that track. One pass
+        replaces the repeated full-branch scans in the reconstructibility and
+        truth-lookup helpers.
+        """
+        index: dict[int, dict[str, Any]] = {}
+        for hit in self.sim_tree.strawtubesPoint:
+            tid = hit.GetTrackID()
+            station = int(hit.GetDetectorID() // 1_000_000)
+            entry = index.get(tid)
+            if entry is None:
+                index[tid] = {
+                    "n_hits": 1,
+                    "stations": {station},
+                    "first": (
+                        hit.GetPx(),
+                        hit.GetPy(),
+                        hit.GetPz(),
+                        hit.GetX(),
+                        hit.GetY(),
+                        hit.GetZ(),
+                    ),
+                }
+            else:
+                entry["n_hits"] += 1
+                entry["stations"].add(station)
+        return index
 
     def _is_reconstructible(self, mc_track_id: int) -> bool:
         """Check if an MC particle meets reconstructibility criteria.
@@ -117,46 +150,39 @@ class TrackingBenchmark:
         if particle is None or particle.Charge() == 0:
             return False
 
-        # Count hits per station
-        stations: set[int] = set()
-        n_hits = 0
-        for hit in self.sim_tree.strawtubesPoint:
-            if hit.GetTrackID() != mc_track_id:
-                continue
-            n_hits += 1
-            det_id = hit.GetDetectorID()
-            station = int(det_id // 1_000_000)
-            stations.add(station)
-
-        return n_hits >= self.min_hits and len(stations) >= self.min_stations
+        # Hit counts come from the per-event straw index (built once per event).
+        entry = self._straw_index.get(mc_track_id)
+        n_hits = entry["n_hits"] if entry else 0
+        n_stations = len(entry["stations"]) if entry else 0
+        return n_hits >= self.min_hits and n_stations >= self.min_stations
 
     def _get_ptruth_first(self, mc_track_id: int) -> tuple[float, float, float, float]:
         """Get MC truth momentum at the first straw hit.
 
         Follows the pattern from macro/ShipAna.py:getPtruthFirst().
         """
-        for hit in self.sim_tree.strawtubesPoint:
-            if hit.GetTrackID() == mc_track_id:
-                px, py, pz = hit.GetPx(), hit.GetPy(), hit.GetPz()
-                p = math.sqrt(px**2 + py**2 + pz**2)
-                return p, px, py, pz
-        return -1.0, -1.0, -1.0, -1.0
+        entry = self._straw_index.get(mc_track_id)
+        if entry is None:
+            return -1.0, -1.0, -1.0, -1.0
+        px, py, pz = entry["first"][:3]
+        p = math.sqrt(px**2 + py**2 + pz**2)
+        return p, px, py, pz
 
     def _get_truth_pos_first(self, mc_track_id: int) -> tuple[float, float, float]:
         """Get MC truth position at the first straw hit."""
-        for hit in self.sim_tree.strawtubesPoint:
-            if hit.GetTrackID() == mc_track_id:
-                return hit.GetX(), hit.GetY(), hit.GetZ()
-        return 0.0, 0.0, 0.0
+        entry = self._straw_index.get(mc_track_id)
+        if entry is None:
+            return 0.0, 0.0, 0.0
+        return entry["first"][3:6]
 
     def _get_truth_slopes(self, mc_track_id: int) -> tuple[float, float]:
         """Get MC truth track slopes tx=px/pz, ty=py/pz at first straw hit."""
-        for hit in self.sim_tree.strawtubesPoint:
-            if hit.GetTrackID() == mc_track_id:
-                px, py, pz = hit.GetPx(), hit.GetPy(), hit.GetPz()
-                if abs(pz) > 1e-10:
-                    return px / pz, py / pz
-                return 0.0, 0.0
+        entry = self._straw_index.get(mc_track_id)
+        if entry is None:
+            return 0.0, 0.0
+        px, py, pz = entry["first"][:3]
+        if abs(pz) > 1e-10:
+            return px / pz, py / pz
         return 0.0, 0.0
 
     def _fracMCsame(self, reco_track_idx: int) -> tuple[float, int]:
@@ -274,6 +300,7 @@ class TrackingBenchmark:
         for i_event in range(n_events):
             self.sim_tree.GetEvent(i_event)
             self.reco_tree.GetEvent(i_event)
+            self._straw_index = self._build_straw_index()
 
             # Find reconstructible MC particles
             reconstructible_ids: set[int] = set()

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -370,6 +370,17 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   // Calculate beam smearing and painting
   auto [dx, dy] = CalculateBeamOffset(fsmearBeam, fPaintBeam);
 
+  if (G4only) {
+    // Geant4 determines the primary interaction point, so skip the expensive
+    // interaction-point sampling below (it would only be discarded).
+    IncrementCounter("generated_events");
+    IncrementCounter("g4only_events");
+    IncrementCounter("stored_tracks");
+    cpg->AddTrack(2212, 0., 0., fMom, (xOff + dx) / cm, (yOff + dy) / cm,
+                  start[2], -1, kTRUE, -1., 0., 1.);
+    return kTRUE;
+  }
+
   Double_t zinter = 0;
   Double_t ZoverA = 1.;
   if (!targetName.IsNull()) {
@@ -415,14 +426,7 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
     zinter = zinter * cm;
   }
   Pythia8::Pythia* fPythia;
-  if (G4only) {
-    IncrementCounter("generated_events");
-    IncrementCounter("g4only_events");
-    IncrementCounter("stored_tracks");
-    cpg->AddTrack(2212, 0., 0., fMom, (xOff + dx) / cm, (yOff + dy) / cm,
-                  start[2], -1, kTRUE, -1., 0., 1.);
-    return kTRUE;
-  } else if (Option == "Primary") {
+  if (Option == "Primary") {
     constexpr int kMaxPythiaRetries = 100;
     if (gRandom->Uniform(0., 1.) < ZoverA) {
       int retries = 0;

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -503,7 +503,7 @@ Bool_t FixedTargetGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   if (withEvtGen) {
     fPythia->moreDecays();
   }  // let the very short lived resonances decay via Pythia8
-  if (Debug && !G4only) {
+  if (Debug) {
     fPythia->event.list();
   }
   TMCProcess procID;

--- a/shipgen/MuonBackGenerator.cxx
+++ b/shipgen/MuonBackGenerator.cxx
@@ -338,28 +338,25 @@ Bool_t MuonBackGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
       tof = track->GetStartT() / 1E9;  // convert back from ns to sec;
       e = track->GetEnergy();
       Bool_t wanttracking = false;  // only transport muons
-      for (std::pair<int, int> element : muList) {
-        if (element.first == i) {
-          wanttracking = true;
-          if (!followMuons) {
-            auto* v = getVetoPoint(element.second);
-            TVector3 lpv = v->LastPoint();
-            TVector3 lmv = v->LastMom();
-            if (abspid == 22) {
-              e = lmv.Mag();
-            } else {
-              e = TMath::Sqrt(lmv.Mag2() +
-                              (track->GetMass()) * (track->GetMass()));
-            }
-            px = lmv[0];
-            py = lmv[1];
-            pz = lmv[2];
-            vx = lpv[0];
-            vy = lpv[1];
-            vz = lpv[2];
-            tof = v->GetTime() / 1E9;  // convert back from ns to sec
+      if (auto element = muList.find(i); element != muList.end()) {
+        wanttracking = true;
+        if (!followMuons) {
+          auto* v = getVetoPoint(element->second);
+          TVector3 lpv = v->LastPoint();
+          TVector3 lmv = v->LastMom();
+          if (abspid == 22) {
+            e = lmv.Mag();
+          } else {
+            e = TMath::Sqrt(lmv.Mag2() +
+                            (track->GetMass()) * (track->GetMass()));
           }
-          break;
+          px = lmv[0];
+          py = lmv[1];
+          pz = lmv[2];
+          vx = lpv[0];
+          vy = lpv[1];
+          vz = lpv[2];
+          tof = v->GetTime() / 1E9;  // convert back from ns to sec
         }
       }
       IncrementCounter("transported_tracks");

--- a/shipgen/TEvtGenDecayer.cxx
+++ b/shipgen/TEvtGenDecayer.cxx
@@ -165,8 +165,8 @@ Bool_t TEvtGenDecayer::UseEvtGenForParticle(Int_t pdg) {
     }
   }
 
-  LOG(warning) << "UseEvtGenForParticle: PDG " << pdg
-               << " not in EvtGen particle list, falling back to Pythia8";
+  LOG(debug) << "UseEvtGenForParticle: PDG " << pdg
+             << " not in EvtGen particle list, falling back to Pythia8";
   return kFALSE;
 }
 

--- a/splitcal/splitcalHit.cxx
+++ b/splitcal/splitcalHit.cxx
@@ -6,6 +6,8 @@
 
 #include <cmath>
 #include <iostream>
+#include <string>
+#include <unordered_map>
 
 #include "FairLogger.h"
 #include "FairRun.h"
@@ -70,7 +72,16 @@ splitcalHit::splitcalHit(const std::vector<splitcalPoint>& points, Double_t t0)
 
   SetIDs(isPrec, nL, nMx, nMy, nS);
 
-  TGeoNode* strip = caloVolume->GetNode(stripName.c_str());
+  // GetNode(name) is a linear scan over all strip nodes (up to O(10^5)); the
+  // geometry is fixed, so cache the node pointer per strip name.
+  static std::unordered_map<std::string, TGeoNode*> stripNodeCache;
+  TGeoNode* strip = nullptr;
+  if (auto it = stripNodeCache.find(stripName); it != stripNodeCache.end()) {
+    strip = it->second;
+  } else {
+    strip = caloVolume->GetNode(stripName.c_str());
+    stripNodeCache.emplace(stripName, strip);
+  }
 
   const Double_t* stripCoordinatesLocal = strip->GetMatrix()->GetTranslation();
   Double_t stripCoordinatesMaster[3] = {0., 0., 0.};

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -11,6 +11,7 @@
 #include <array>
 #include <iostream>
 #include <sstream>
+#include <unordered_map>
 #include <utility>
 
 #include "FairGeoBuilder.h"
@@ -450,6 +451,15 @@ void strawtubes::StrawEndPoints(Int_t fDetectorID, TVector3& vbot,
                                 TVector3& vtop)
 // method to get end points from TGeoNavigator
 {
+  // The endpoints depend only on the (fixed) geometry, so cache them per detID:
+  // rebuilding the volume path and re-navigating on every hit is a significant
+  // cost in the stepping and digitisation hot paths.
+  static std::unordered_map<Int_t, std::pair<TVector3, TVector3>> endPointCache;
+  if (auto it = endPointCache.find(fDetectorID); it != endPointCache.end()) {
+    vbot = it->second.first;
+    vtop = it->second.second;
+    return;
+  }
   const auto [statnb, vnb, lnb, snb] = StrawDecode(fDetectorID);
   TString stat = "Tr";
   stat += statnb;
@@ -501,4 +511,5 @@ void strawtubes::StrawEndPoints(Int_t fDetectorID, TVector3& vbot,
   nav->LocalToMaster(bot, Gbot);
   vtop.SetXYZ(Gtop[0], Gtop[1], Gtop[2]);
   vbot.SetXYZ(Gbot[0], Gbot[1], Gbot[2]);
+  endPointCache.emplace(fDetectorID, std::make_pair(vbot, vtop));
 }


### PR DESCRIPTION
Behaviour-preserving performance cleanups from the deferred review.

- **shipgen**: take the `G4only` early-return before the (discarded)
  interaction-point rejection sampling in `FixedTargetGenerator` (changes the
  `gRandom` stream in G4only mode — statistically equivalent); `muList.find()`
  instead of a linear scan in `MuonBackGenerator`; demote a per-decay warning to
  debug in `TEvtGenDecayer`.
- **detectors**: cache `strawtubes::StrawEndPoints` per detID and the splitcal
  strip `TGeoNode` per name (both keyed by fixed-geometry identifiers).
- **hnl**: memoise the total decay width and reuse the integrand `TF1` — verified
  **bit-identical** widths/branching ratios vs master.
- **tracking**: set-based membership in the PatRec seed loops; one `strawtubesPoint`
  index per event in `tracking_benchmark` instead of four full-branch rescans.
- **eventDisplay**: build a per-event `trackID -> hits` map (was O(tracks×hits))
  and use `getattr` instead of `eval`.

Verification: full build, HNL numerical cross-check, and a fixed-target simulation.

Notes:
- The `eventDisplay` change is behaviour-preserving but cannot run headless —
  worth a manual event-display spot-check.
- The splitcal *clustering* O(n²) finding was **not** taken here: its neighbour
  test is anisotropic/error-scaled and a correct grid-bucketing needs a
  physics-validated cluster comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved event processing by reusing per-event indexes and cached computations, avoiding repeated geometry navigation, full hit scans, and repeated decay-width calculations.
  * Reduced overhead in reconstruction and MC truth lookups with faster access patterns and set-based duplicate-hit handling.

* **Behavior**
  * Streamlined “G4-only” event handling while preserving existing outputs.
  * Maintained tracking selection behavior with more efficient matching.

* **Logging**
  * Downgraded fallback messages for missing particles to debug level to reduce log noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->