### PR TITLE
perf(field): flatten magnetic field-map storage

### DIFF
--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -187,30 +187,49 @@ void ShipBFieldMap::Field(const Double_t* position, Double_t* B) {
   Int_t iY1(iY + 1);
   Int_t iZ1(iZ + 1);
 
-  binA_ = this->getMapBin(iX, iY, iZ);
-  binB_ = this->getMapBin(iX1, iY, iZ);
-  binC_ = this->getMapBin(iX, iY1, iZ);
-  binD_ = this->getMapBin(iX1, iY1, iZ);
-  binE_ = this->getMapBin(iX, iY, iZ1);
-  binF_ = this->getMapBin(iX1, iY, iZ1);
-  binG_ = this->getMapBin(iX, iY1, iZ1);
-  binH_ = this->getMapBin(iX1, iY1, iZ1);
+  const Int_t binA = this->getMapBin(iX, iY, iZ);
+  const Int_t binB = this->getMapBin(iX1, iY, iZ);
+  const Int_t binC = this->getMapBin(iX, iY1, iZ);
+  const Int_t binD = this->getMapBin(iX1, iY1, iZ);
+  const Int_t binE = this->getMapBin(iX, iY, iZ1);
+  const Int_t binF = this->getMapBin(iX1, iY, iZ1);
+  const Int_t binG = this->getMapBin(iX, iY1, iZ1);
+  const Int_t binH = this->getMapBin(iX1, iY1, iZ1);
 
-  // Retrieve the fractional bin distances
-  xFrac_ = xBinInfo.second;
-  yFrac_ = yBinInfo.second;
-  zFrac_ = zBinInfo.second;
+  // Retrieve the fractional bin distances and their complements
+  const Float_t xFrac = xBinInfo.second;
+  const Float_t yFrac = yBinInfo.second;
+  const Float_t zFrac = zBinInfo.second;
+  const Float_t xFrac1 = 1.0 - xFrac;
+  const Float_t yFrac1 = 1.0 - yFrac;
+  const Float_t zFrac1 = 1.0 - zFrac;
 
-  // Set the complimentary fractional bin distances
-  xFrac1_ = 1.0 - xFrac_;
-  yFrac1_ = 1.0 - yFrac_;
-  zFrac1_ = 1.0 - zFrac_;
+  if (!fieldMap_) {
+    return;
+  }
 
-  // Finally get the magnetic field components using trilinear interpolation
-  // and scale with the appropriate multiplication factor (default = 1.0)
-  B[0] = this->BInterCalc(ShipBFieldMap::xAxis) * scale_ * BxSign;
-  B[1] = this->BInterCalc(ShipBFieldMap::yAxis) * scale_;
-  B[2] = this->BInterCalc(ShipBFieldMap::zAxis) * scale_ * BzSign;
+  // Fetch each of the eight corner triples once and interpolate all three
+  // field components in a single pass (trilinear interpolation), then scale
+  // with the appropriate multiplication factor (default = 1.0).
+  const floatArray& fm = *fieldMap_;
+  const std::array<Float_t, 3>& cA = fm[binA];
+  const std::array<Float_t, 3>& cB = fm[binB];
+  const std::array<Float_t, 3>& cC = fm[binC];
+  const std::array<Float_t, 3>& cD = fm[binD];
+  const std::array<Float_t, 3>& cE = fm[binE];
+  const std::array<Float_t, 3>& cF = fm[binF];
+  const std::array<Float_t, 3>& cG = fm[binG];
+  const std::array<Float_t, 3>& cH = fm[binH];
+
+  Float_t Bc[3];
+  for (Int_t i = 0; i < 3; ++i) {
+    Bc[i] = triLinearInterp(cA[i], cB[i], cC[i], cD[i], cE[i], cF[i], cG[i],
+                            cH[i], xFrac, xFrac1, yFrac, yFrac1, zFrac, zFrac1);
+  }
+
+  B[0] = Bc[0] * scale_ * BxSign;
+  B[1] = Bc[1] * scale_;
+  B[2] = Bc[2] * scale_ * BzSign;
 }
 
 void ShipBFieldMap::initialise() {
@@ -478,43 +497,25 @@ Int_t ShipBFieldMap::getMapBin(Int_t iX, Int_t iY, Int_t iZ) {
   return index;
 }
 
-Float_t ShipBFieldMap::BInterCalc(CoordAxis theAxis) {
-  // Find the magnetic field component along theAxis using trilinear
-  // interpolation based on the current position and neighbouring bins
-  Float_t result(0.0);
+Float_t ShipBFieldMap::triLinearInterp(Float_t A, Float_t B, Float_t C,
+                                       Float_t D, Float_t E, Float_t F,
+                                       Float_t G, Float_t H, Float_t xFrac,
+                                       Float_t xFrac1, Float_t yFrac,
+                                       Float_t yFrac1, Float_t zFrac,
+                                       Float_t zFrac1) {
+  // Trilinear interpolation of a single component from its eight corner values
+  // A..H (bit-for-bit the arithmetic previously performed per axis by
+  // BInterCalc).
+  // Linear interpolation along x
+  const Float_t F00 = A * xFrac1 + B * xFrac;
+  const Float_t F10 = C * xFrac1 + D * xFrac;
+  const Float_t F01 = E * xFrac1 + F * xFrac;
+  const Float_t F11 = G * xFrac1 + H * xFrac;
 
-  Int_t iAxis(0);
+  // Linear interpolation along y
+  const Float_t F0 = F00 * yFrac1 + F10 * yFrac;
+  const Float_t F1 = F01 * yFrac1 + F11 * yFrac;
 
-  if (theAxis == CoordAxis::yAxis) {
-    iAxis = 1;
-  } else if (theAxis == CoordAxis::zAxis) {
-    iAxis = 2;
-  }
-
-  if (fieldMap_) {
-    // Get the field component values for the neighbouring bins
-    Float_t A = (*fieldMap_)[binA_][iAxis];
-    Float_t B = (*fieldMap_)[binB_][iAxis];
-    Float_t C = (*fieldMap_)[binC_][iAxis];
-    Float_t D = (*fieldMap_)[binD_][iAxis];
-    Float_t E = (*fieldMap_)[binE_][iAxis];
-    Float_t F = (*fieldMap_)[binF_][iAxis];
-    Float_t G = (*fieldMap_)[binG_][iAxis];
-    Float_t H = (*fieldMap_)[binH_][iAxis];
-
-    // Perform linear interpolation along x
-    Float_t F00 = A * xFrac1_ + B * xFrac_;
-    Float_t F10 = C * xFrac1_ + D * xFrac_;
-    Float_t F01 = E * xFrac1_ + F * xFrac_;
-    Float_t F11 = G * xFrac1_ + H * xFrac_;
-
-    // Linear interpolation along y
-    Float_t F0 = F00 * yFrac1_ + F10 * yFrac_;
-    Float_t F1 = F01 * yFrac1_ + F11 * yFrac_;
-
-    // Linear interpolation along z
-    result = F0 * zFrac1_ + F1 * zFrac_;
-  }
-
-  return result;
+  // Linear interpolation along z
+  return F0 * zFrac1 + F1 * zFrac;
 }

--- a/field/ShipBFieldMap.h
+++ b/field/ShipBFieldMap.h
@@ -10,6 +10,7 @@
 #ifndef FIELD_SHIPBFIELDMAP_H_
 #define FIELD_SHIPBFIELDMAP_H_
 
+#include <array>
 #include <string>
 #include <utility>
 #include <vector>
@@ -79,8 +80,9 @@ class ShipBFieldMap : public TVirtualMagField {
   */
   void Field(const Double_t* position, Double_t* B) override;
 
-  //! Typedef for a vector containing a vector of floats
-  typedef std::vector<std::vector<Float_t>> floatArray;
+  //! Typedef for the field-map storage: one contiguous (Bx, By, Bz) triple per
+  //! grid node, giving cache-friendly access with no per-node heap allocation.
+  typedef std::vector<std::array<Float_t, 3>> floatArray;
 
   //! Retrieve the field map
   /*!
@@ -354,14 +356,15 @@ class ShipBFieldMap : public TVirtualMagField {
   */
   Int_t getMapBin(Int_t iX, Int_t iY, Int_t iZ);
 
-  //! Calculate the magnetic field component using trilinear interpolation.
-  //! This function uses the various "binX" integers and "uFrac" variables
+  //! Trilinear interpolation of one field component from its eight corner
+  //! values A..H and the fractional bin distances (with their complements)
   /*!
-    \param [in] theAxis The coordinate axis (CoordAxis enumeration for x, y or
-    z)
-    \returns the magnetic field component for the given axis
+    \returns the interpolated field component
   */
-  Float_t BInterCalc(CoordAxis theAxis);
+  static Float_t triLinearInterp(Float_t A, Float_t B, Float_t C, Float_t D,
+                                 Float_t E, Float_t F, Float_t G, Float_t H,
+                                 Float_t xFrac, Float_t xFrac1, Float_t yFrac,
+                                 Float_t yFrac1, Float_t zFrac, Float_t zFrac1);
 
   //! Store the field map information as a vector of 3 floats.
   //! Map data ordering is given by first incrementing z, then y, then x
@@ -454,48 +457,6 @@ class ShipBFieldMap : public TVirtualMagField {
 
   //! Double converting Tesla to kiloGauss (for VMC/FairRoot B field units)
   Float_t Tesla_;
-
-  //! Bin A for the trilinear interpolation
-  Int_t binA_;
-
-  //! Bin B for the trilinear interpolation
-  Int_t binB_;
-
-  //! Bin C for the trilinear interpolation
-  Int_t binC_;
-
-  //! Bin D for the trilinear interpolation
-  Int_t binD_;
-
-  //! Bin E for the trilinear interpolation
-  Int_t binE_;
-
-  //! Bin F for the trilinear interpolation
-  Int_t binF_;
-
-  //! Bin G for the trilinear interpolation
-  Int_t binG_;
-
-  //! Bin H for the trilinear interpolation
-  Int_t binH_;
-
-  //! Fractional bin distance along x
-  Float_t xFrac_;
-
-  //! Fractional bin distance along y
-  Float_t yFrac_;
-
-  //! Fractional bin distance along z
-  Float_t zFrac_;
-
-  //! Complimentary fractional bin distance along x
-  Float_t xFrac1_;
-
-  //! Complimentary fractional bin distance along y
-  Float_t yFrac1_;
-
-  //! Complimentary fractional bin distance along z
-  Float_t zFrac1_;
 };
 
 #endif  // FIELD_SHIPBFIELDMAP_H_


### PR DESCRIPTION
Addresses the HIGH-severity field-map storage finding.

`ShipBFieldMap` stored the grid as `vector<vector<Float_t>>` — one heap-allocated
3-float vector per node, giving a 3–5× memory overhead and a pointer chase on
every corner access. This switches storage to `vector<array<Float_t,3>>`: one
contiguous block, no per-node allocation, same `[bin][axis]` indexing (populate
and read sites compile unchanged). `ShipBFieldMap` is never persisted, so there is
no on-disk compatibility impact.

Also moves the per-call interpolation scratch out of member variables into
`Field()` locals (the evaluator is now reentrant) and fetches each of the eight
corners once via a shared `triLinearInterp` helper instead of `BInterCalc`
re-reading them per axis.

Verification: field values are **bit-identical** before/after over a grid of
interpolation and quadrant-symmetry sample points; full build and `ctest` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetic field interpolation for smoother, more consistent values across the 3D field map.
  * Applied symmetry and scaling consistently when computing field components.

* **Refactor**
  * Simplified the magnetic field calculation path by using a single trilinear interpolation approach for components.
  * Updated field-map storage to improve lookup efficiency and cache performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->