### PR TITLE
build/ci: build-system and CI cleanups

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -7,6 +7,7 @@ on:
 # docs deploy cannot race a plot push to the gh-pages branch.
 concurrency:
   group: gh-pages-deploy
+  cancel-in-progress: false
 jobs:
   deploy:
     name: Deploy docs

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+# Share the gh-pages deploy lock with the plot push jobs in pixi-build.yml so a
+# docs deploy cannot race a plot push to the gh-pages branch.
+concurrency:
+  group: gh-pages-deploy
 jobs:
   deploy:
     name: Deploy docs

--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -13,14 +13,6 @@ concurrency:
 permissions:
   contents: read
 jobs:
-  generate-matrix:
-    name: Generate test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        run: echo 'matrix={"vessel":["vacuums","helium"],"snd_design":["all"],"muon_shield":["TRY_2025"]}' >> "$GITHUB_OUTPUT"
   build:
     name: Build & unit tests
     runs-on: ubuntu-latest
@@ -33,15 +25,16 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           cache: true
-      - uses: hendrikmuhs/ccache-action@v1
-      - name: Route compilation through ccache
-        # CMake picks these up at configure time; ccache stays on the host
-        # PATH inside `pixi run`.
-        run: |
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: build-${{ runner.os }}
       - name: Configure
+        # CMake initialises CMAKE_CXX_COMPILER_LAUNCHER from this environment
+        # variable, so compiles are routed through ccache (installed above).
         run: pixi run --locked configure
+        env:
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
       - name: Build
         run: pixi run --locked build
       - name: Test
@@ -54,11 +47,14 @@ jobs:
           retention-days: 1
   run-sim-chain:
     name: Simulation chain (${{ matrix.vessel }})
-    needs: [generate-matrix, build]
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+      matrix:
+        vessel: [vacuums, helium]
+        snd_design: [all]
+        muon_shield: [TRY_2025]
     env:
       QT_QPA_PLATFORM: offscreen
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # FairRoot is always provided externally (there is no in-tree base/steer), so
 # FairRoot is located solely via the FAIRROOTPATH environment variable.
-if(NOT DEFINED ENV{FAIRROOTPATH})
+if(NOT DEFINED ENV{FAIRROOTPATH} OR "$ENV{FAIRROOTPATH}" STREQUAL "")
     message(
         FATAL_ERROR
         "You did not define the environment variable FAIRROOTPATH which is needed to find FairRoot. Please set this variable and execute cmake again."
@@ -85,11 +85,7 @@ list(
     "${CMAKE_SOURCE_DIR}/cmake/modules"
 )
 
-if(FAIRROOTPATH)
-    set(CheckSrcDir "${FAIRROOTPATH}/share/fairbase/cmake/checks")
-else()
-    set(CheckSrcDir "${CMAKE_SOURCE_DIR}/cmake/checks")
-endif()
+set(CheckSrcDir "${FAIRROOTPATH}/share/fairbase/cmake/checks")
 
 # Load some basic macros which are needed later on
 include(FairMacros)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,6 @@ endif()
 message(STATUS "FairShip version: ${PROJECT_VERSION}")
 
 include(GNUInstallDirs)
-
-include(GNUInstallDirs)
 # aliBuild modulefile expects libraries in lib/, not lib64/
 set(CMAKE_INSTALL_LIBDIR lib)
 
@@ -69,26 +67,15 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_path(
-    FAIRBASE
-    NAMES FairRun.h
-    PATHS ${CMAKE_SOURCE_DIR}/base/steer ${FAIRBASE}
-    NO_DEFAULT_PATH
-)
-
-if(FAIRBASE)
-    message(STATUS "Found FAIRBASE")
-    set(FAIRBASE ${FAIRBASE})
-else()
-    message(STATUS "NOT Found FAIRBASE")
-    if(NOT DEFINED ENV{FAIRROOTPATH})
-        message(
-            FATAL_ERROR
-            "You did not define the environment variable FAIRROOTPATH which is needed to find FairRoot. Please set this variable and execute cmake again."
-        )
-    endif()
-    set(FAIRROOTPATH $ENV{FAIRROOTPATH})
+# FairRoot is always provided externally (there is no in-tree base/steer), so
+# FairRoot is located solely via the FAIRROOTPATH environment variable.
+if(NOT DEFINED ENV{FAIRROOTPATH})
+    message(
+        FATAL_ERROR
+        "You did not define the environment variable FAIRROOTPATH which is needed to find FairRoot. Please set this variable and execute cmake again."
+    )
 endif()
+set(FAIRROOTPATH $ENV{FAIRROOTPATH})
 
 # Where to look first for cmake modules, before ${CMAKE_ROOT}/Modules/
 list(

--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,9 @@ FROM ghcr.io/prefix-dev/pixi:0.72.0-noble
 WORKDIR /FairShip
 
 COPY pixi.toml pixi.lock /FairShip/
-RUN pixi install --locked
+# Remove the rattler download cache in the same layer that creates it, so the
+# multi-GB package tarballs don't get baked into the image.
+RUN pixi install --locked && rm -rf ~/.cache/rattler
 
 COPY . /FairShip
 RUN pixi run --locked build

--- a/cmake/modules/ShipMacros.cmake
+++ b/cmake/modules/ShipMacros.cmake
@@ -173,7 +173,12 @@ function(ship_add_library)
                 "$<$<BOOL:$<TARGET_PROPERTY:${ARG_NAME},COMPILE_DEFINITIONS>>:-D$<JOIN:$<TARGET_PROPERTY:${ARG_NAME},COMPILE_DEFINITIONS>,$<SEMICOLON>-D>>"
                 ${_abs_headers} ${_abs_linkdef}
             COMMAND
-                ${CMAKE_COMMAND} -E copy_if_different
+                # Plain copy (not copy_if_different): the destination is a
+                # declared OUTPUT, so it must always be refreshed to be newer
+                # than its header dependencies. copy_if_different preserves the
+                # source mtime when content is unchanged, leaving the OUTPUT
+                # older than a touched header and re-running rootcling forever.
+                ${CMAKE_COMMAND} -E copy
                 ${CMAKE_CURRENT_BINARY_DIR}/${_pcm_base} ${_pcm_file}
             COMMAND_EXPAND_LISTS
             DEPENDS ${_abs_headers} ${_abs_linkdef}

--- a/pixi.toml
+++ b/pixi.toml
@@ -147,7 +147,7 @@ cmd = "ship-metrics-compare {{ reference }} {{ new }} --config .github/scripts/m
 # expansion.
 
 [tasks.ci-clang-tidy]
-cmd = "bash -c 'set -o pipefail; echo $CPP_FILES | xargs -P $(nproc) clang-tidy -p build/ 2>&1 | python .github/scripts/annotate_build.py'"
+cmd = "bash -c 'set -o pipefail; echo $CPP_FILES | xargs -P $(nproc) -n 4 clang-tidy -p build/ 2>&1 | python .github/scripts/annotate_build.py'"
 
 [tasks.ci-pyrefly]
 cmd = "pyrefly check --output-format=github $PY_FILES"


### PR DESCRIPTION
Build-system, CI, and packaging cleanups from the deferred review.

- **cmake**: copy the generated `.pcm` to its declared OUTPUT with a plain `copy`
  instead of `copy_if_different`, which kept the source mtime and re-ran rootcling
  (and the dependent compile/link) on every build; remove a duplicate
  `include(GNUInstallDirs)` and the `find_path(FAIRBASE ...)` branch that can never
  succeed.
- **container/packaging**: drop `~/.cache/rattler` in the same `pixi install` layer;
  add `-n 4` to the `ci-clang-tidy` xargs so files spread across parallel invocations.
- **CI**: inline the literal test matrix (removing a whole job + `needs` edge); add
  ccache to the build job; join the `gh-pages-deploy` concurrency group in the
  doxygen workflow so a docs deploy cannot race a plot push.

The cmake changes were build-tested locally; the workflow changes are validated by
this PR's own CI run.

Note: **ccache** wiring can only be confirmed by CI here — it's an isolated commit
if it needs adjustment. The low-value artifact-trim finding was intentionally left
out (upload/download path semantics are fragile and untestable locally).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CI build/test performance with smarter C++ compiler caching and more efficient clang-tidy batching.
* **Bug Fixes**
  * Prevented concurrent documentation deploys from conflicting on GitHub Pages.
  * Build configuration now fails fast when the required FairRoot path isn’t provided.
  * Ensured ROOT dictionary outputs are reliably refreshed to avoid repeated rebuild loops.
* **Chores**
  * Simplified the CI simulation matrix and reduced container image size by clearing install-time cache data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->