### PR TITLE
refactor: simplifications and modernization

### DIFF
--- a/UpstreamTagger/UpstreamTagger.h
+++ b/UpstreamTagger/UpstreamTagger.h
@@ -17,9 +17,6 @@ class UpstreamTaggerPoint;
 class FairVolume;
 class TClonesArray;
 
-using ShipUnit::cm;
-using ShipUnit::m;
-
 /**
  * @brief Upstream Background Tagger (UBT) detector
  *
@@ -75,10 +72,10 @@ class UpstreamTagger : public SHiP::Detector<UpstreamTaggerPoint> {
 
   Double_t det_zPos;  //!  z-position of detector (set via SetZposition)
   // Detector box dimensions (set via SetBoxDimensions, defaults provided below)
-  Double_t xbox_fulldet = 4.4 * m;  //!  X dimension (default: 4.4 m)
-  Double_t ybox_fulldet = 6.4 * m;  //!  Y dimension (default: 6.4 m)
+  Double_t xbox_fulldet = 4.4 * ShipUnit::m;  //!  X dimension (default: 4.4 m)
+  Double_t ybox_fulldet = 6.4 * ShipUnit::m;  //!  Y dimension (default: 6.4 m)
   Double_t zbox_fulldet =
-      16.0 * cm;  //!  Z dimension/thickness (default: 16 cm)
+      16.0 * ShipUnit::cm;  //!  Z dimension/thickness (default: 16 cm)
 
  private:
   TGeoVolume* UpstreamTagger_fulldet;  // Timing_detector_1 object

--- a/field/ShipBellField.cxx
+++ b/field/ShipBellField.cxx
@@ -21,9 +21,8 @@ using std::setw;
 constexpr Double_t kilogauss = 1.;
 constexpr Double_t tesla = 10 * kilogauss;
 
-constexpr Double_t cm = 1;         // cm
-constexpr Double_t m = 100 * cm;   //  m
-constexpr Double_t mm = 0.1 * cm;  //  mm
+constexpr Double_t cm = 1;        // cm
+constexpr Double_t m = 100 * cm;  //  m
 
 // -----   Default constructor   -------------------------------------------
 ShipBellField::ShipBellField()

--- a/field/ShipBellField.cxx
+++ b/field/ShipBellField.cxx
@@ -18,12 +18,12 @@ using std::cout;
 using std::endl;
 using std::setw;
 
-Double_t kilogauss = 1.;
-Double_t tesla = 10 * kilogauss;
+constexpr Double_t kilogauss = 1.;
+constexpr Double_t tesla = 10 * kilogauss;
 
-Double_t cm = 1;         // cm
-Double_t m = 100 * cm;   //  m
-Double_t mm = 0.1 * cm;  //  mm
+constexpr Double_t cm = 1;         // cm
+constexpr Double_t m = 100 * cm;   //  m
+constexpr Double_t mm = 0.1 * cm;  //  mm
 
 // -----   Default constructor   -------------------------------------------
 ShipBellField::ShipBellField()

--- a/field/ShipConstField.cxx
+++ b/field/ShipConstField.cxx
@@ -137,6 +137,21 @@ Double_t ShipConstField::GetBz(Double_t x, Double_t y, Double_t z) {
 }
 // -------------------------------------------------------------------------
 
+// -----   Get all field components at once   ------------------------------
+void ShipConstField::GetFieldValue(const Double_t point[3], Double_t* bField) {
+  if (point[0] < fXmin || point[0] > fXmax || point[1] < fYmin ||
+      point[1] > fYmax || point[2] < fZmin || point[2] > fZmax) {
+    bField[0] = 0.;
+    bField[1] = 0.;
+    bField[2] = 0.;
+    return;
+  }
+  bField[0] = fBx;
+  bField[1] = fBy;
+  bField[2] = fBz;
+}
+// -------------------------------------------------------------------------
+
 // -----   Screen output   -------------------------------------------------
 void ShipConstField::Print(Option_t*) const {
   cout << "======================================================" << endl;

--- a/field/ShipConstField.h
+++ b/field/ShipConstField.h
@@ -64,6 +64,14 @@ class ShipConstField : public FairField {
   Double_t GetBy(Double_t x, Double_t y, Double_t z) override;
   Double_t GetBz(Double_t x, Double_t y, Double_t z) override;
 
+  /** Get all three field components at once, performing the in-region test a
+   ** single time (the default implementation calls GetBx/GetBy/GetBz, each of
+   ** which repeats the same six boundary comparisons).
+   ** @param point   Point coordinates [cm]
+   ** @param bField  (return) Field components [kG]
+   **/
+  void GetFieldValue(const Double_t point[3], Double_t* bField) override;
+
   /** Accessors to field region **/
   Double_t GetXmin() const { return fXmin; }
   Double_t GetXmax() const { return fXmax; }

--- a/field/ShipFieldMaker.cxx
+++ b/field/ShipFieldMaker.cxx
@@ -1095,41 +1095,12 @@ TVirtualMagField* ShipFieldMaker::getVolumeField(const TString& volName) const {
 }
 
 Bool_t ShipFieldMaker::gotField(const TString& name) const {
-  Bool_t result(kFALSE);
-
-  // Iterate over the internal map and see if we have a match
-  SFMap::const_iterator iter;
-  for (iter = theFields_.begin(); iter != theFields_.end(); ++iter) {
-    TString key = iter->first;
-    TVirtualMagField* theField = iter->second;
-
-    // Check that we have the key already stored and the pointer is not null
-    if (!key.CompareTo(name, TString::kExact) && theField) {
-      result = kTRUE;
-      break;
-    }
-  }
-
-  return result;
+  return this->getField(name) != nullptr;
 }
 
 TVirtualMagField* ShipFieldMaker::getField(const TString& name) const {
-  TVirtualMagField* theField(nullptr);
-
-  // Iterate over the internal map and see if we have a match
-  SFMap::const_iterator iter;
-  for (iter = theFields_.begin(); iter != theFields_.end(); ++iter) {
-    TString key = iter->first;
-    TVirtualMagField* BField = iter->second;
-
-    // Check that we have the key already stored
-    if (!key.CompareTo(name, TString::kExact)) {
-      theField = BField;
-      break;
-    }
-  }
-
-  return theField;
+  SFMap::const_iterator iter = theFields_.find(name);
+  return (iter != theFields_.end()) ? iter->second : nullptr;
 }
 
 void ShipFieldMaker::plotXYField(const TVector3& xAxis, const TVector3& yAxis,

--- a/gconfig/DecayConfigPy6.C
+++ b/gconfig/DecayConfigPy6.C
@@ -47,7 +47,7 @@ void DecayConfig() {
   // the decay product neutrino flavor, which is otherwise not preserved in
   // Geant3 decays.
   const Int_t npartnf = 9;
-  // mu-,mu+,pi+,pi-,K+,K-,K0L, Xi-
+  // mu-, mu+, pi+, pi-, K+, K-, K0L, Xi-, J/psi
   Int_t pdgnf[npartnf] = {13, -13, 211, -211, 321, -321, 130, 3312, 443};
   for (Int_t ipartnf = 0; ipartnf < npartnf; ipartnf++) {
     Int_t ipdg = pdgnf[ipartnf];
@@ -61,13 +61,11 @@ void DecayConfig() {
   // The following will print the decay modes
   pythia6.Pyupda(1, 6);
 
-  // rho0 (113), rho+ (213), rho- (-213) and
-  // D+(411) ,D-(-411),D0(421),D0bar(-421) have decay modes defined in
-  // TGeant3::DefineParticles, but for these particles
-  // those decay modes are overridden to make use of pythia6.
+  // D0 (421), Lambda (3122) and Lambda-bar (-3122) have decay modes defined in
+  // TGeant3::DefineParticles, but for these particles those decay modes are
+  // overridden to make use of pythia6.
   const Int_t nparthq = 3;
-  // rho0,rho+,rho-,D+,D-,D0,D0bar
-  // Int_t pdghq[nparthq] = {113,213,-213,411,-411,421,-421};
+  // D0, Lambda, Lambda-bar
   Int_t pdghq[nparthq] = {421, 3122, -3122};
   for (Int_t iparthq = 0; iparthq < nparthq; iparthq++) {
     Int_t ipdg = pdghq[iparthq];

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -30,9 +30,9 @@
 using std::cout;
 using std::endl;
 
-Double_t cm = 1;         // cm
-Double_t m = 100 * cm;   //  m
-Double_t mm = 0.1 * cm;  //  mm
+constexpr Double_t cm = 1;         // cm
+constexpr Double_t m = 100 * cm;   //  m
+constexpr Double_t mm = 0.1 * cm;  //  mm
 
 exitHadronAbsorber::exitHadronAbsorber(const char* Name, Bool_t Active)
     : Detector(Name, Active, kVETO),

--- a/python/SciFiMapping.py
+++ b/python/SciFiMapping.py
@@ -805,20 +805,20 @@ class SciFiMapping:
         fiber_to_sipm_map_U, _ = self.get_fibre_to_simp_map()
 
         print("Validating U plane mapping:")
-        for fiber_id, fibers in sipm_to_fiber_map_U.items():
-            for sipm_chan, chan_info in fibers.items():
+        for sipm_chan, fibers in sipm_to_fiber_map_U.items():
+            for fiber_id, chan_info in fibers.items():
                 weight = chan_info["weight"]
                 xpos = chan_info["xpos"]
                 print(
-                    f"""---- Fiber index: {fiber_id}, SiPM Channel: {sipm_chan},
+                    f"""---- SiPM Channel: {sipm_chan}, Fiber index: {fiber_id},
                     Weight: {weight}, X Position: {xpos}"""
                 )
-        for sipm_chan, sipm_fibers in fiber_to_sipm_map_U.items():
-            for fiber_id, fiber_info in sipm_fibers.items():
+        for fiber_id, sipm_fibers in fiber_to_sipm_map_U.items():
+            for sipm_chan, fiber_info in sipm_fibers.items():
                 weight = fiber_info["weight"]
                 xpos = fiber_info["xpos"]
                 print(
-                    f"""++++ SiPM Channel: {sipm_chan}, Fiber index: {fiber_id},
+                    f"""++++ Fiber index: {fiber_id}, SiPM Channel: {sipm_chan},
                     Weight: {weight}, X Position: {xpos}"""
                 )
 

--- a/python/method_logger.py
+++ b/python/method_logger.py
@@ -11,7 +11,7 @@ class MethodLogger:
     method calls and logs them to a file (default: `sys.stdout`).
 
     >>> import method_logger as ml
-    >>> from StringIO import StringIO
+    >>> from io import StringIO
     >>> class TestClass(object):
     ...     def __init__(self):
     ...         pass

--- a/python/pythia8darkphoton_conf.py
+++ b/python/pythia8darkphoton_conf.py
@@ -10,6 +10,7 @@ import readDecayTable
 import ROOT
 import shipunit as u
 from method_logger import MethodLogger
+from pythia8_conf_utils import make_particles_stable
 
 # Boundaries for production in meson decays
 # mass of the mesons
@@ -107,15 +108,7 @@ def configure(P8gen, mass, epsilon, inclusive, motherMode, deepCopy=False, debug
     ROOT.TDatabasePDG.Instance()
     if inclusive == "meson":
         # let strange particle decay in Geant4
-        p8 = P8gen.getPythiaInstance()
-        n = 1
-        while n != 0:
-            n = p8.particleData.nextId(n)
-            p = p8.particleData.particleDataEntryPtr(n)
-            if p.tau0() > 1:
-                command = str(n) + ":mayDecay = false"
-                p8.readString(command)
-                print("Pythia8 configuration: Made %s stable for Pythia, should decay in Geant4" % (p.name()))
+        make_particles_stable(P8gen, above_lifetime=1)
 
         # Configuring production
         P8gen.SetParameters("SoftQCD:nonDiffractive = on")
@@ -126,18 +119,11 @@ def configure(P8gen, mass, epsilon, inclusive, motherMode, deepCopy=False, debug
 
         if mass < P8gen.MinDPMass():
             print("WARNING! Mass is too small, minimum is set to %3.3f GeV." % P8gen.MinDPMass())
+            _exit_stack.close()
             return 0
 
         # produce a Z' from hidden valleys model
-        p8 = P8gen.getPythiaInstance()
-        n = 1
-        while n != 0:
-            n = p8.particleData.nextId(n)
-            p = p8.particleData.particleDataEntryPtr(n)
-            if p.tau0() > 1:
-                command = str(n) + ":mayDecay = false"
-                p8.readString(command)
-                print("Pythia8 configuration: Made %s stable for Pythia, should decay in Geant4" % (p.name()))
+        make_particles_stable(P8gen, above_lifetime=1)
 
         # Configuring production
         P8gen.SetParameters("HiddenValley:ffbar2Zv = on")
@@ -210,6 +196,7 @@ def configure(P8gen, mass, epsilon, inclusive, motherMode, deepCopy=False, debug
         selectedMum = manipulatePhysics(motherMode, mass, P8gen)
         print("selected mum is : %d" % selectedMum)
         if selectedMum == -1:
+            _exit_stack.close()
             return 0
 
     # P8gen.SetParameters("Check:particleData = on")

--- a/python/readDecayTable.py
+++ b/python/readDecayTable.py
@@ -68,8 +68,7 @@ def addHNLdecayChannels(P8Gen, hnl, conffile=os.path.expandvars("$FAIRSHIP/pytho
     # Add decay channels
     for dec in allowed:
         if dec not in wanted:
-            print("addHNLdecayChannels ERROR: channel not configured!\t", dec)
-            quit()
+            raise ValueError(f"addHNLdecayChannels: channel not configured: {dec}")
         if allowed[dec] == "yes" and wanted[dec] == "yes":
             particles = list(dec.replace("->", " ").split())
             children = particles[1:]
@@ -106,8 +105,7 @@ def addDarkPhotondecayChannels(
     for dec in allowed:
         print("channel allowed:", dec)
         if dec not in wanted:
-            print("addDarkPhotondecayChannels WARNING: channel not configured! Please add also in conf file.\t", dec)
-            quit()
+            raise ValueError(f"addDarkPhotondecayChannels: channel not configured (add it to the conf file): {dec}")
         print("channel wanted:", dec)
 
         if allowed[dec] == "yes" and wanted[dec] == "yes":

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -322,33 +322,10 @@ class Task:
                 )
                 dValue = ctypes.c_double()
                 dError = ctypes.c_double()
-                rc = gMinuit.GetParameter(0, dValue, dError)
-                values[0] = dValue.value
-                errors[0] = dError.value
-                rc = gMinuit.GetParameter(1, dValue, dError)
-                values[1] = dValue.value
-                errors[1] = dError.value
-                rc = gMinuit.GetParameter(2, dValue, dError)
-                values[2] = dValue.value
-                errors[2] = dError.value
-                rc = gMinuit.GetParameter(3, dValue, dError)
-                values[3] = dValue.value
-                errors[3] = dError.value
-                rc = gMinuit.GetParameter(4, dValue, dError)
-                values[4] = dValue.value
-                errors[4] = dError.value
-                rc = gMinuit.GetParameter(5, dValue, dError)
-                values[5] = dValue.value
-                errors[5] = dError.value
-                rc = gMinuit.GetParameter(6, dValue, dError)
-                values[6] = dValue.value
-                errors[6] = dError.value
-                rc = gMinuit.GetParameter(7, dValue, dError)
-                values[7] = dValue.value
-                errors[7] = dError.value
-                rc = gMinuit.GetParameter(8, dValue, dError)
-                values[8] = dValue.value
-                errors[8] = dError.value
+                for i in range(9):
+                    gMinuit.GetParameter(i, dValue, dError)
+                    values[i] = dValue.value
+                    errors[i] = dError.value
 
                 xFit = values[0]
                 yFit = values[1]

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -145,6 +145,8 @@ HNLPythia8Generator::~HNLPythia8Generator() {
     fInputFile = nullptr;
     fTree = nullptr;
   }
+  delete fPythia;
+  fPythia = nullptr;
 }
 // -------------------------------------------------------------------------
 

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -5,6 +5,8 @@
 #ifndef SHIPGEN_HNLPYTHIA8GENERATOR_H_
 #define SHIPGEN_HNLPYTHIA8GENERATOR_H_
 
+#include <memory>
+
 #include "FairLogger.h"  // for FairLogger, MESSAGE_ORIGIN
 #include "Generator.h"
 #include "Pythia8/Pythia.h"
@@ -19,24 +21,24 @@ class FairPrimaryGenerator;
 
 class PyTr1Rng : public Pythia8::RndmEngine {
  public:
-  PyTr1Rng() { rng = new TRandom1(gRandom->GetSeed()); };
+  PyTr1Rng() : rng(std::make_unique<TRandom1>(gRandom->GetSeed())) {}
   ~PyTr1Rng() override = default;
 
   Double_t flat() override { return rng->Rndm(); };
 
  private:
-  TRandom1* rng;  //!
+  std::unique_ptr<TRandom1> rng;  //!
 };
 
 class PyTr3Rng : public Pythia8::RndmEngine {
  public:
-  PyTr3Rng() { rng = new TRandom3(gRandom->GetSeed()); };
+  PyTr3Rng() : rng(std::make_unique<TRandom3>(gRandom->GetSeed())) {}
   ~PyTr3Rng() override = default;
 
   Double_t flat() override { return rng->Rndm(); };
 
  private:
-  TRandom3* rng;  //!
+  std::unique_ptr<TRandom3> rng;  //!
 };
 
 class HNLPythia8Generator : public SHiP::Generator {

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -50,9 +50,9 @@
 #include "TVirtualMC.h"
 #include "vetoPoint.h"
 
-Double_t cm = 1;         // cm
-Double_t m = 100 * cm;   //  m
-Double_t mm = 0.1 * cm;  //  mm
+constexpr Double_t cm = 1;         // cm
+constexpr Double_t m = 100 * cm;   //  m
+constexpr Double_t mm = 0.1 * cm;  //  mm
 
 /**
  * @brief Constructor for the Veto class.


### PR DESCRIPTION
Simplifications and modernizations from the deferred review.

- **linkage/ODR**: make the `cm/m/mm` (+ `kilogauss/tesla`) unit globals `constexpr`
  (internal linkage) across `veto`, `exitHadronAbsorber`, `ShipBellField`; drop the
  global-scope `using ShipUnit::…` from the public `UpstreamTagger.h`.
- **field**: `map::find` in `ShipFieldMaker::gotField/getField`; a single-test
  `ShipConstField::GetFieldValue` override (verified identical to the per-component
  getters).
- **shipgen**: hold the `PyTr1Rng/PyTr3Rng` `TRandom` in `unique_ptr` and delete
  `fPythia` in the `HNLPythia8Generator` destructor (leak fixes).
- **gconfig**: fix stale `DecayConfigPy6` particle-list comments.
- **python**: raise instead of `quit()` in `readDecayTable`; fix the Py2 doctest in
  `method_logger`; dedup the make-particles-stable loops via
  `pythia8_conf_utils.make_particles_stable` and close the debug-log `ExitStack` on
  the early-return paths; fix swapped SiPM/Fiber labels in `SciFiMapping`
  validation output; loop the nine `GetParameter` stanzas in `shipVertex`.

Verification: full build, `ctest` 100%, `ShipConstField` numeric check, `method_logger`
doctest, and Python import/compile checks.

Deferred as higher-risk/low-value: the `TEvtGenDecayer` engine deletes (EvtGen
ownership unverified), the `shipVertex` `getP()` closure hoist (physics-critical
numeric code), and the `SciFiMapping` triplicated-helper dedup (the three helpers
diverge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved constant-field queries to return all three components together and reliably zero results when evaluation points are outside the configured region.
  * Strengthened decay-channel configuration errors to raise exceptions with clear, channel-specific messages instead of terminating execution.
  * Improved particle-generation resource cleanup and stability handling for long-lived dark-sector particles in event configuration.

* **New Features**
  * Added an API to fetch the full magnetic-field vector in a single call for constant fields.

* **Style / Chores**
  * Refreshed validation output formatting and standardized unit/constants usage and internal cleanup patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->