### PR TITLE
refactor(SND): migrate MC point classes to SHiP::DetectorPoint

### DIFF
--- a/SND/EmulsionTarget/TTPoint.cxx
+++ b/SND/EmulsionTarget/TTPoint.cxx
@@ -4,34 +4,4 @@
 
 #include "TTPoint.h"
 
-#include <iostream>
-using std::cout;
-using std::endl;
-
-// -----   Default constructor   -------------------------------------------
-TTPoint::TTPoint() : FairMCPoint() {}
-// -------------------------------------------------------------------------
-
-TTPoint::TTPoint(Int_t trackID, Int_t detID, const TVector3& pos,
-                 const TVector3& mom, Double_t tof, Double_t length,
-                 Double_t eLoss, Int_t pdgcode)
-    : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
-      fPdgCode(pdgcode) {}
-
-// -------------------------------------------------------------------------
-
-// -----   Destructor   ----------------------------------------------------
-TTPoint::~TTPoint() = default;
-// -------------------------------------------------------------------------
-
-// -----   Public method Print   -------------------------------------------
-void TTPoint::Print(const Option_t* opt) const {
-  cout << "-I- TargetPoint: ShipRpc point for track " << fTrackID
-       << " in detector " << fDetectorID << endl;
-  cout << "    Position (" << fX << ", " << fY << ", " << fZ << ") cm" << endl;
-  cout << "    Momentum (" << fPx << ", " << fPy << ", " << fPz << ") GeV"
-       << endl;
-  cout << "    Time " << fTime << " ns,  Length " << fLength
-       << " cm,  Energy loss " << fELoss * 1.0e06 << " keV" << endl;
-}
-// -------------------------------------------------------------------------
+ClassImp(TTPoint)

--- a/SND/EmulsionTarget/TTPoint.h
+++ b/SND/EmulsionTarget/TTPoint.h
@@ -5,49 +5,30 @@
 #ifndef SND_EMULSIONTARGET_TTPOINT_H_
 #define SND_EMULSIONTARGET_TTPOINT_H_
 
-#include "FairMCPoint.h"
-#include "TObject.h"
+#include "DetectorPoint.h"
 #include "TVector3.h"
 
-class TTPoint : public FairMCPoint {
+class TTPoint : public SHiP::DetectorPoint {
  public:
   /** Default constructor **/
-  TTPoint();
+  TTPoint() = default;
 
   /** Constructor with arguments
    *@param trackID  Index of MCTrack
    *@param detID    Detector ID
-   *@param pos      Ccoordinates at entrance to active volume [cm]
+   *@param pos      Coordinates at entrance to active volume [cm]
    *@param mom      Momentum of track at entrance [GeV]
    *@param tof      Time since event start [ns]
    *@param length   Track length since creation [cm]
    *@param eLoss    Energy deposit [GeV]
+   *@param pdgCode  PDG code of the track
    **/
-
-  /*TargetPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
-                   Double_t tof, Double_t length, Double_t eLoss, Int_t pdgCode,
-              Bool_t emTop, Bool_t emBot,Bool_t emCESTop, Bool_t emCESBot,
-     Bool_t tt, Int_t nPlate, Int_t nColumn, Int_t nRow, Int_t nWall);*/
-
   TTPoint(Int_t trackID, Int_t detID, const TVector3& pos, const TVector3& mom,
-          Double_t tof, Double_t length, Double_t eLoss, Int_t pdgCode);
+          Double_t tof, Double_t length, Double_t eLoss, Int_t pdgCode)
+      : SHiP::DetectorPoint(0, trackID, detID, pos, mom, tof, length, eLoss,
+                            pdgCode) {}
 
-  /** Destructor **/
-  ~TTPoint() override;
-
-  /** Copy constructor **/
-  TTPoint(const TTPoint& point) = default;
-  TTPoint& operator=(const TTPoint& point) = default;
-
-  /** Output to screen **/
-  void Print(const Option_t* opt) const override;
-
-  Int_t PdgCode() const { return fPdgCode; }
-
- private:
-  Int_t fPdgCode;
-
-  ClassDefOverride(TTPoint, 3)
+  ClassDefOverride(TTPoint, 4)
 };
 
 #endif  // SND_EMULSIONTARGET_TTPOINT_H_

--- a/SND/EmulsionTarget/TargetPoint.cxx
+++ b/SND/EmulsionTarget/TargetPoint.cxx
@@ -4,48 +4,4 @@
 
 #include "TargetPoint.h"
 
-#include <iostream>
-using std::cout;
-using std::endl;
-
-// -----   Default constructor   -------------------------------------------
-TargetPoint::TargetPoint() : FairMCPoint() {}
-// -------------------------------------------------------------------------
-
-// -----   Standard constructor   ------------------------------------------
-/*
-TargetPoint::TargetPoint(Int_t trackID, Int_t detID,TVector3 pos, TVector3 mom,
-                         Double_t tof, Double_t length,
-                         Double_t eLoss, Int_t pdgcode,
-                         Bool_t emTop, Bool_t emBot,Bool_t emCESTop, Bool_t
-emCESBot, Bool_t tt, Int_t nPlate, Int_t nColumn, Int_t nRow, Int_t nWall) :
-FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),fPdgCode(pdgcode),
-    fEmTop(emTop), fEmBot(emBot), fEmCESTop(emCESTop),
-fEmCESBot(emCESBot),fTT(tt), fNPlate(nPlate),fNColumn(nColumn),
-fNRow(nRow),fNWall(nWall) {  }
-*/
-
-TargetPoint::TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
-                         const TVector3& mom, Double_t tof, Double_t length,
-                         Double_t eLoss, Int_t pdgcode)
-    : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
-      fPdgCode(pdgcode) {}
-
-// -------------------------------------------------------------------------
-
-//,  EmTop, EmBot, EmCESTop,EmCESBot,TT,NPlate,NColumn,NRow,NWall
-// -----   Destructor   ----------------------------------------------------
-TargetPoint::~TargetPoint() = default;
-// -------------------------------------------------------------------------
-
-// -----   Public method Print   -------------------------------------------
-void TargetPoint::Print(const Option_t* opt) const {
-  cout << "-I- TargetPoint: ShipRpc point for track " << fTrackID
-       << " in detector " << fDetectorID << endl;
-  cout << "    Position (" << fX << ", " << fY << ", " << fZ << ") cm" << endl;
-  cout << "    Momentum (" << fPx << ", " << fPy << ", " << fPz << ") GeV"
-       << endl;
-  cout << "    Time " << fTime << " ns,  Length " << fLength
-       << " cm,  Energy loss " << fELoss * 1.0e06 << " keV" << endl;
-}
-// -------------------------------------------------------------------------
+ClassImp(TargetPoint)

--- a/SND/EmulsionTarget/TargetPoint.h
+++ b/SND/EmulsionTarget/TargetPoint.h
@@ -5,50 +5,31 @@
 #ifndef SND_EMULSIONTARGET_TARGETPOINT_H_
 #define SND_EMULSIONTARGET_TARGETPOINT_H_
 
-#include "FairMCPoint.h"
-#include "TObject.h"
+#include "DetectorPoint.h"
 #include "TVector3.h"
 
-class TargetPoint : public FairMCPoint {
+class TargetPoint : public SHiP::DetectorPoint {
  public:
   /** Default constructor **/
-  TargetPoint();
+  TargetPoint() = default;
 
   /** Constructor with arguments
    *@param trackID  Index of MCTrack
    *@param detID    Detector ID
-   *@param pos      Ccoordinates at entrance to active volume [cm]
+   *@param pos      Coordinates at entrance to active volume [cm]
    *@param mom      Momentum of track at entrance [GeV]
    *@param tof      Time since event start [ns]
    *@param length   Track length since creation [cm]
    *@param eLoss    Energy deposit [GeV]
+   *@param pdgCode  PDG code of the track
    **/
-
-  /*TargetPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
-                   Double_t tof, Double_t length, Double_t eLoss, Int_t pdgCode,
-              Bool_t emTop, Bool_t emBot,Bool_t emCESTop, Bool_t emCESBot,
-     Bool_t tt, Int_t nPlate, Int_t nColumn, Int_t nRow, Int_t nWall);*/
-
   TargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
               const TVector3& mom, Double_t tof, Double_t length,
-              Double_t eLoss, Int_t pdgCode);
+              Double_t eLoss, Int_t pdgCode)
+      : SHiP::DetectorPoint(0, trackID, detID, pos, mom, tof, length, eLoss,
+                            pdgCode) {}
 
-  /** Destructor **/
-  ~TargetPoint() override;
-
-  /** Copy constructor **/
-  TargetPoint(const TargetPoint& point) = default;
-  TargetPoint& operator=(const TargetPoint& point) = default;
-
-  /** Output to screen **/
-  void Print(const Option_t* opt) const override;
-
-  Int_t PdgCode() const { return fPdgCode; }
-
- private:
-  Int_t fPdgCode;
-
-  ClassDefOverride(TargetPoint, 3)
+  ClassDefOverride(TargetPoint, 4)
 };
 
 #endif  // SND_EMULSIONTARGET_TARGETPOINT_H_

--- a/SND/MTC/MTCDetPoint.cxx
+++ b/SND/MTC/MTCDetPoint.cxx
@@ -4,34 +4,4 @@
 
 #include "MTCDetPoint.h"
 
-#include <iostream>
-using std::cout;
-using std::endl;
-
-// -----   Default constructor   -------------------------------------------
-MTCDetPoint::MTCDetPoint() : FairMCPoint() {}
-// -------------------------------------------------------------------------
-
-MTCDetPoint::MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
-                         const TVector3& mom, Double_t tof, Double_t length,
-                         Double_t eLoss, Int_t pdgcode)
-    : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
-      fPdgCode(pdgcode) {}
-
-// -------------------------------------------------------------------------
-
-// -----   Destructor   ----------------------------------------------------
-MTCDetPoint::~MTCDetPoint() = default;
-// -------------------------------------------------------------------------
-
-// -----   Public method Print   -------------------------------------------
-void MTCDetPoint::Print() const {
-  cout << "-I- MTCDetPoint: MTC point for track " << fTrackID << " in detector "
-       << fDetectorID << endl;
-  cout << "    Position (" << fX << ", " << fY << ", " << fZ << ") cm" << endl;
-  cout << "    Momentum (" << fPx << ", " << fPy << ", " << fPz << ") GeV"
-       << endl;
-  cout << "    Time " << fTime << " ns,  Length " << fLength
-       << " cm,  Energy loss " << fELoss * 1.0e06 << " keV" << endl;
-}
-// -------------------------------------------------------------------------
+ClassImp(MTCDetPoint)

--- a/SND/MTC/MTCDetPoint.h
+++ b/SND/MTC/MTCDetPoint.h
@@ -5,49 +5,38 @@
 #ifndef SND_MTC_MTCDETPOINT_H_
 #define SND_MTC_MTCDETPOINT_H_
 
-#include "FairMCPoint.h"
-#include "TObject.h"
+#include "DetectorPoint.h"
 #include "TVector3.h"
 
-class MTCDetPoint : public FairMCPoint {
+class MTCDetPoint : public SHiP::DetectorPoint {
  public:
   /** Default constructor **/
-  MTCDetPoint();
+  MTCDetPoint() = default;
 
   /** Constructor with arguments
    *@param trackID  Index of MCTrack
    *@param detID    Detector ID
-   *@param pos      Ccoordinates at entrance to active volume [cm]
+   *@param pos      Coordinates at entrance to active volume [cm]
    *@param mom      Momentum of track at entrance [GeV]
    *@param tof      Time since event start [ns]
    *@param length   Track length since creation [cm]
    *@param eLoss    Energy deposit [GeV]
+   *@param pdgCode  PDG code of the track
    **/
-
   MTCDetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
               const TVector3& mom, Double_t tof, Double_t length,
-              Double_t eLoss, Int_t pdgcode);
+              Double_t eLoss, Int_t pdgCode)
+      : SHiP::DetectorPoint(0, trackID, detID, pos, mom, tof, length, eLoss,
+                            pdgCode) {}
 
-  /** Destructor **/
-  ~MTCDetPoint() override;
-
-  /** Copy constructor **/
-  MTCDetPoint(const MTCDetPoint& point) = default;
-  MTCDetPoint& operator=(const MTCDetPoint& point) = default;
-
-  /** Output to screen **/
-  using FairMCPoint::Print;
-  virtual void Print() const;
-  Int_t PdgCode() const { return fPdgCode; }
   Int_t GetLayer() const {
     return static_cast<int>(fDetectorID / 1000000) % 100;
   }
   Int_t GetLayerType() const {
     return static_cast<int>(fDetectorID / 100000) % 10;
   }
-  Int_t fPdgCode;
 
-  ClassDefOverride(MTCDetPoint, 3)
+  ClassDefOverride(MTCDetPoint, 4)
 };
 
 #endif  // SND_MTC_MTCDETPOINT_H_

--- a/SND/SiliconTarget/SiliconTargetPoint.cxx
+++ b/SND/SiliconTarget/SiliconTargetPoint.cxx
@@ -4,35 +4,4 @@
 
 #include "SiliconTargetPoint.h"
 
-#include <iostream>
-using std::cout;
-using std::endl;
-
-// -----   Default constructor   -------------------------------------------
-SiliconTargetPoint::SiliconTargetPoint() : FairMCPoint() {}
-// -------------------------------------------------------------------------
-
-SiliconTargetPoint::SiliconTargetPoint(Int_t trackID, Int_t detID,
-                                       const TVector3& pos, const TVector3& mom,
-                                       Double_t tof, Double_t length,
-                                       Double_t eLoss, Int_t pdgcode)
-    : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss),
-      fPdgCode(pdgcode) {}
-
-// -------------------------------------------------------------------------
-
-// -----   Destructor   ----------------------------------------------------
-SiliconTargetPoint::~SiliconTargetPoint() = default;
-// -------------------------------------------------------------------------
-
-// -----   Public method Print   -------------------------------------------
-void SiliconTargetPoint::Print() const {
-  cout << "-I- SiliconTargetPoint: point for track " << fTrackID
-       << " in detector " << fDetectorID << endl;
-  cout << "    Position (" << fX << ", " << fY << ", " << fZ << ") cm" << endl;
-  cout << "    Momentum (" << fPx << ", " << fPy << ", " << fPz << ") GeV"
-       << endl;
-  cout << "    Time " << fTime << " ns,  Length " << fLength
-       << " cm,  Energy loss " << fELoss * 1.0e06 << " keV" << endl;
-}
-// -------------------------------------------------------------------------
+ClassImp(SiliconTargetPoint)

--- a/SND/SiliconTarget/SiliconTargetPoint.h
+++ b/SND/SiliconTarget/SiliconTargetPoint.h
@@ -5,41 +5,31 @@
 #ifndef SND_SILICONTARGET_SILICONTARGETPOINT_H_
 #define SND_SILICONTARGET_SILICONTARGETPOINT_H_
 
-#include "FairMCPoint.h"
-#include "TObject.h"
+#include <cmath>
+
+#include "DetectorPoint.h"
 #include "TVector3.h"
 
-class SiliconTargetPoint : public FairMCPoint {
+class SiliconTargetPoint : public SHiP::DetectorPoint {
  public:
   /** Default constructor **/
-  SiliconTargetPoint();
+  SiliconTargetPoint() = default;
 
   /** Constructor with arguments
    *@param trackID  Index of MCTrack
    *@param detID    Detector ID
-   *@param pos      Ccoordinates at entrance to active volume [cm]
+   *@param pos      Coordinates at entrance to active volume [cm]
    *@param mom      Momentum of track at entrance [GeV]
    *@param tof      Time since event start [ns]
    *@param length   Track length since creation [cm]
    *@param eLoss    Energy deposit [GeV]
-   *@param pdgcode  PDG code of MCTrack
+   *@param pdgCode  PDG code of the track
    **/
-
   SiliconTargetPoint(Int_t trackID, Int_t detID, const TVector3& pos,
                      const TVector3& mom, Double_t tof, Double_t length,
-                     Double_t eLoss, Int_t pdgcode);
-
-  /** Destructor **/
-  ~SiliconTargetPoint() override;
-
-  /** Copy constructor **/
-  SiliconTargetPoint(const SiliconTargetPoint& point) = default;
-  SiliconTargetPoint& operator=(const SiliconTargetPoint& point) = default;
-
-  /** Output to screen **/
-  using FairMCPoint::Print;
-  virtual void Print() const;
-  Int_t PdgCode() const { return fPdgCode; }
+                     Double_t eLoss, Int_t pdgCode)
+      : SHiP::DetectorPoint(0, trackID, detID, pos, mom, tof, length, eLoss,
+                            pdgCode) {}
 
   constexpr int GetLayer() const { return floor(fDetectorID >> 17); }
   constexpr int GetPlane() const {
@@ -56,10 +46,7 @@ class SiliconTargetPoint : public FairMCPoint {
   }
   constexpr int GetModule() const { return GetRow() + 1 + 2 * GetColumn(); }
 
- private:
-  Int_t fPdgCode;
-
-  ClassDefOverride(SiliconTargetPoint, 2)
+  ClassDefOverride(SiliconTargetPoint, 3)
 };
 
 #endif  // SND_SILICONTARGET_SILICONTARGETPOINT_H_


### PR DESCRIPTION
Removes the duplicated "FairMCPoint + fPdgCode" boilerplate in four SND MC-point
classes (review finding #16, Part 4) by inheriting the existing
`SHiP::DetectorPoint` base — the same base already used by `vetoPoint`,
`strawtubesPoint`, `splitcalPoint`, `TimeDetPoint`, and `UpstreamTaggerPoint`.

`TTPoint`, `TargetPoint`, `MTCDetPoint`, and `SiliconTargetPoint` now:
- inherit `SHiP::DetectorPoint` (so `fPdgCode`, `PdgCode()`, and `Print` come
  from the base);
- keep a thin 8-arg forwarding constructor, so the `AddHit` call sites, the
  `LinkDef`s, and the IO tests are **unchanged** and the stored eventID stays 0
  as before;
- keep their detID-decoder helpers (`GetLayer`/`GetLayerType`,
  `GetPlane`/`GetColumn`/`GetRow`/`GetStrip`/`GetModule`).

Net ~196 lines removed. `ClassDef` versions are bumped.

Verification: full build plus the `DataClassIO` and `RNtupleIO` round-trip tests,
which construct and read back all four classes (checking `PdgCode()` and the
decoders).

Note on I/O: the migrated points now also carry the base's `fLpos`/`fLmom`
(defaulted to the entrance pos/mom), so new files are slightly larger. `fPdgCode`
moves into the `DetectorPoint` base; reading **legacy** files relies on ROOT's
by-name schema evolution (member-moved-to-base) — worth a read-back check against
an existing legacy file with these branches if one is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated several detector point types to use a shared point base class for more consistent behavior.
  * Simplified point class interfaces by removing now-unneeded custom methods and members.
  * Registered updated classes with the runtime metadata system for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->