### PR TITLE
fix: unroll install-hooks loop so deno_task_shell can parse it

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -175,9 +175,8 @@ lint = "prek run --all-files"
 install-hooks = '''
 prek install --hook-type pre-commit --hook-type commit-msg
 hooks=$(git rev-parse --git-path hooks)
-for h in pre-commit commit-msg; do
-  sed -i 's#"$PREK" hook-impl#pixi run -e lint prek hook-impl#' "$hooks/$h"
-done
+sed -i 's#"$PREK" hook-impl#pixi run -e lint prek hook-impl#' "$hooks/pre-commit"
+sed -i 's#"$PREK" hook-impl#pixi run -e lint prek hook-impl#' "$hooks/commit-msg"
 '''
 
 [environments]


### PR DESCRIPTION
## Problem

`pixi run -e lint install-hooks` fails with a shell parse error, so the git hooks are never installed and prek does not run on commit.

pixi executes task scripts with `deno_task_shell`, a cross-platform mini-shell with no control-flow constructs. The `for … do … done` loop uses unsupported reserved words, so pixi aborts at *parse* time — before `prek install` runs.

## Fix

Replace the loop with two explicit `sed` calls (one per hook). `deno_task_shell` supports sequential commands, variable assignment, and command substitution — just not loops.

Verified: `pixi run -e lint install-hooks` now succeeds, both `pre-commit` and `commit-msg` hooks are installed and rewritten to route through `pixi run -e lint prek hook-impl`, and hooks fire on commit.