### PR TITLE
ci: ccache for pixi builds, demote legacy CVMFS CI to push+nightly

### DIFF
--- a/.github/workflows/legacy-cvmfs.yml
+++ b/.github/workflows/legacy-cvmfs.yml
@@ -1,14 +1,13 @@
 name: Legacy CVMFS CI
 on:
-  pull_request:
-    branches: [master]
   push:
     branches: [master]
     tags: ['v*']
   workflow_dispatch:
-  merge_group:
+  schedule:
+    - cron: 30 2 * * *
 concurrency:
-  group: legacy-cvmfs-${{ github.event.pull_request.number || github.ref }}
+  group: legacy-cvmfs-${{ github.ref }}
   cancel-in-progress: true
 permissions:
   contents: read

--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -33,6 +33,13 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           cache: true
+      - uses: hendrikmuhs/ccache-action@v1
+      - name: Route compilation through ccache
+        # CMake picks these up at configure time; ccache stays on the host
+        # PATH inside `pixi run`.
+        run: |
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
       - name: Configure
         run: pixi run --locked configure
       - name: Build


### PR DESCRIPTION
Routes the pixi build through ccache (large speedup on warm caches) and moves the legacy aliBuild/CVMFS matrix off the PR critical path to master pushes plus a nightly schedule.