### PR TITLE
ci: wire physics-metrics tracking into CI

### DIFF
--- a/.github/scripts/compare_metrics.py
+++ b/.github/scripts/compare_metrics.py
@@ -283,7 +283,7 @@ def main() -> int:
         if args.fail_on_diff:
             return 1
     else:
-        print("\nNo differences found")
+        print("\nNo significant differences found")
         print("=" * 80)
 
     return 0

--- a/.github/scripts/generate_pr_comment.py
+++ b/.github/scripts/generate_pr_comment.py
@@ -99,7 +99,7 @@ def generate_comment(comparison_dir) -> str:
             target = parts[-1]
             config = f"{vessel}-{snd}-{shield}-{target}"
         else:
-            config = comp_file.stem
+            config = comp_file.stem.replace("comparison_", "")
 
         results[config] = parse_comparison_file(comp_file)
 

--- a/.github/scripts/metrics_config.yaml
+++ b/.github/scripts/metrics_config.yaml
@@ -7,9 +7,9 @@ files:
   # ROOT files to process for metrics extraction
   # Add or remove files as needed for your simulation/reconstruction chain
   process:
-    - ship.conical.Pythia8-TGeant4.root
-    - ship.conical.Pythia8-TGeant4_rec.root
-    - ship.conical.Pythia8-TGeant4_ana.root
+    - sim_ci-test.root
+    - sim_ci-test_rec.root
+    - sim_ci-test_ana.root
     - recohists.root
 extraction:
   # Maximum directory depth for recursive histogram extraction

--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -79,6 +79,8 @@ jobs:
         run: pixi run --locked ci-ana
       - name: Analysis example
         run: pixi run --locked ci-analysis-example
+      - name: Extract metrics
+        run: pixi run --locked ci-extract-metrics ${{ matrix.vessel }}-${{ matrix.snd_design }}-${{ matrix.muon_shield }}
       - name: Render plots
         run: pixi run --locked ci-render-plots-sim-chain ${{ matrix.vessel }}-${{ matrix.snd_design }}-${{ matrix.muon_shield }}
       - name: Upload plot images
@@ -86,6 +88,11 @@ jobs:
         with:
           name: plots-sim-chain-${{ matrix.vessel }}-${{ matrix.snd_design }}-${{ matrix.muon_shield }}
           path: plots/
+      - name: Upload metrics
+        uses: actions/upload-artifact@v7
+        with:
+          name: metrics-${{ matrix.vessel }}-${{ matrix.snd_design }}-${{ matrix.muon_shield }}
+          path: metrics-*.json
   run-tracking-benchmark:
     name: Tracking benchmark
     needs: build
@@ -250,6 +257,130 @@ jobs:
       - name: pyrefly
         continue-on-error: true
         run: pixi run --locked -- pyrefly check --output-format=github python macro
+  store-metrics:
+    name: Store metrics reference
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: run-sim-chain
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: metrics-*
+          path: metrics/
+          merge-multiple: true
+      - name: Store metrics in git notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          for f in metrics/metrics-*.json; do
+            config=$(basename "$f" .json)
+            config=${config#metrics-}
+            ref="refs/notes/ci/physics-metrics/$config"
+            stored=false
+            for attempt in 1 2 3 4 5; do
+              git fetch origin "+$ref:$ref" || true
+              git notes --ref="$ref" add -f -F "$f" "$GITHUB_SHA"
+              if git push origin "$ref"; then
+                stored=true
+                break
+              fi
+              echo "Push failed (attempt $attempt), retrying..."
+              sleep $((attempt * 5))
+            done
+            if ! $stored; then
+              echo "::error::Failed to store metrics for $config after 5 attempts"
+              exit 1
+            fi
+          done
+  compare-metrics:
+    name: Compare physics metrics
+    if: github.event_name == 'pull_request'
+    needs: run-sim-chain
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          cache: true
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: metrics-*
+          path: metrics/
+          merge-multiple: true
+      - name: Fetch metrics references
+        run: git fetch origin '+refs/notes/ci/physics-metrics/*:refs/notes/ci/physics-metrics/*' || true
+      - name: Compare against reference
+        run: |
+          mkdir -p comparisons
+          for f in metrics/metrics-*.json; do
+            config=$(basename "$f" .json)
+            config=${config#metrics-}
+            ref="ci/physics-metrics/$config"
+            # The tip of master may not have a note yet (its CI run might
+            # still be going), so walk back to the newest commit that has one.
+            reference=""
+            for commit in $(git rev-list --first-parent -n 50 origin/master); do
+              if git notes --ref="$ref" show "$commit" > "reference-$config.json" 2>/dev/null; then
+                reference="$commit"
+                break
+              fi
+            done
+            {
+              echo "Configuration: $config"
+              if [ -n "$reference" ]; then
+                echo "Reference commit: $reference"
+                pixi run --locked ci-compare-metrics "reference-$config.json" "$f"
+              else
+                echo "No reference metrics found for $config"
+              fi
+            } | tee "comparisons/comparison_$config.txt"
+          done
+      - name: Generate summary
+        run: |
+          python3 .github/scripts/generate_pr_comment.py comparisons/ -o comment-body.md
+          {
+            echo '<!-- physics-metrics-comment -->'
+            cat comment-body.md
+          } > comment.md
+          cat comment.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Post PR comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- physics-metrics-comment -->';
+            const body = fs.readFileSync('comment.md', 'utf8');
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
   deploy-plots:
     name: Deploy plots
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'

--- a/pixi.toml
+++ b/pixi.toml
@@ -125,6 +125,19 @@ cmd = "python .github/scripts/render_plots.py tracking_benchmark_histos.root --o
 [tasks.ci-render-plots-fixed-target]
 cmd = "python .github/scripts/render_plots.py *_run_fixedTarget_1/*.root --output-dir plots/fixed-target/pixi --job fixed-target --config pixi"
 
+# --- CI physics-metrics tasks ---
+# Extract per-configuration physics metrics from the sim-chain outputs and
+# compare them against a reference (stored in git notes by the CI workflow,
+# see .github/scripts/README.md).
+
+[tasks.ci-extract-metrics]
+args = [{ arg = "config", default = "pixi-default" }]
+cmd = "python .github/scripts/extract_physics_metrics.py . -o metrics-{{ config }}.json --pretty"
+
+[tasks.ci-compare-metrics]
+args = [{ arg = "reference" }, { arg = "new" }]
+cmd = "python .github/scripts/compare_metrics.py {{ reference }} {{ new }}"
+
 # --- CI static analysis tasks ---
 # clang-tidy and pyrefly take file lists via the CPP_FILES / PY_FILES env vars
 # so the workflow can pass them in without fighting pixi's positional-args


### PR DESCRIPTION
Fixes the stale filenames in metrics_config.yaml (and a string mismatch between compare_metrics and the PR-comment parser), then wires the documented but dormant metrics flow into CI: extraction per matrix config, reference storage in git notes on master pushes, and an informational comparison comment on PRs. No --fail-on-diff yet; gating can be flipped once tolerances have soaked.