### PR TITLE
ci: seed the CI simulation for reproducible metrics

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -84,7 +84,7 @@ args = [
   { arg = "snd_design", default = "all" },
   { arg = "muon_shield", default = "TRY_2025" },
 ]
-cmd = "python macro/run_simScript.py --test --debug 2 --{{ vessel }} --SND --SND_design={{ snd_design }} --shieldName {{ muon_shield }} --EvtGenDecayer --tag ci-test"
+cmd = "python macro/run_simScript.py --test --debug 2 --{{ vessel }} --SND --SND_design={{ snd_design }} --shieldName {{ muon_shield }} --EvtGenDecayer --seed 42 --tag ci-test"
 
 [tasks.ci-overlap-check]
 cmd = "python python/experimental/check_overlaps.py --geofile geo_ci-test.root | tee overlap.log && ! grep -q Overlap overlap.log"


### PR DESCRIPTION
The first physics-metrics comparisons showed multi-sigma differences on a tooling-only PR because ci-sim ran with a time-based seed. Seeding makes the reference comparison sensitive to real regressions; the first post-merge master run will store a seeded reference.