### PR TITLE
Snd fixes

### DIFF
--- a/SND/MTC/MTCDetector.cxx
+++ b/SND/MTC/MTCDetector.cxx
@@ -412,7 +412,7 @@ Bool_t MTCDetector::ProcessHits(FairVolume* vol) {
     TLorentzVector Mom;
     gMC->TrackMomentum(Mom);
     Double_t x, y, z;
-    if (fVolumeID / 100000 == 3) {
+    if ((fVolumeID / 100000) % 10 == 2) {
       x = (fPos.X() + Pos.X()) / 2.;
       y = (fPos.Y() + Pos.Y()) / 2.;
       z = (fPos.Z() + Pos.Z()) / 2.;

--- a/SND/MTC/MTCDetector.cxx
+++ b/SND/MTC/MTCDetector.cxx
@@ -318,6 +318,7 @@ void MTCDetector::ConstructGeometry() {
   ShipGeo::InitMedium("SciFiMat");
   ShipGeo::InitMedium("Epoxy");
   ShipGeo::InitMedium("air");
+  ShipGeo::InitMedium("iron");
   TGeoMedium* air = gGeoManager->GetMedium("air");
   TGeoMedium* ironMed = gGeoManager->GetMedium("iron");
   // For the scintillator, you may use the same medium as SciFiMat or another if

--- a/SND/MTC/MTCDetector.cxx
+++ b/SND/MTC/MTCDetector.cxx
@@ -412,6 +412,7 @@ Bool_t MTCDetector::ProcessHits(FairVolume* vol) {
     TLorentzVector Mom;
     gMC->TrackMomentum(Mom);
     Double_t x, y, z;
+    // 0 and 1 are for SciFi planes, 2 is for scintillating tiles
     if ((fVolumeID / 100000) % 10 == 2) {
       x = (fPos.X() + Pos.X()) / 2.;
       y = (fPos.Y() + Pos.Y()) / 2.;

--- a/python/detectors/SiliconTargetDetector.py
+++ b/python/detectors/SiliconTargetDetector.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+from collections import defaultdict
+
+import ROOT
+from BaseDetector import BaseDetector
+
+
+class SiliconTargetDetector(BaseDetector):
+    def __init__(self, name, intree, branchName=None, outtree=None) -> None:
+        super().__init__(name, intree, branchName, outtree=outtree)
+
+    def digitize(self) -> None:
+        """Group SiliconTargetPoints by detector ID and build one SiliconTargetHit per ID."""
+        pointsByDetID = defaultdict(list)
+        for point in self.intree.SiliconTargetPoint:
+            pointsByDetID[point.GetDetectorID()].append(point)
+
+        for detID, pts in pointsByDetID.items():
+            allPoints = ROOT.std.vector("SiliconTargetPoint*")()
+            for p in pts:
+                allPoints.push_back(p)
+            det_hit = ROOT.SiliconTargetHit(detID, allPoints)
+            self.det.push_back(det_hit)

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -58,8 +58,7 @@ class ShipDigiReco:
         self.fTrackletsArray = ROOT.std.vector("Tracklet")()
         self.Tracklets = self.recoTree.Branch("Tracklets", self.fTrackletsArray, 32000, -1)
         #
-        self.has_strawtubes = "strawtubes" in global_variables.modules
-        if self.has_strawtubes:
+        if "strawtubes" in global_variables.modules:
             self.strawtubes = strawtubesDetector("strawtubes", self.sTree, outtree=self.recoTree)
 
         if self.sTree.GetBranch("MTCDetPoint"):
@@ -78,7 +77,7 @@ class ShipDigiReco:
             self.upstreamTaggerDetector = UpstreamTaggerDetector("UpstreamTagger", self.sTree, outtree=self.recoTree)
 
         # for the digitizing step
-        if self.has_strawtubes:
+        if hasattr(self, "strawtubes"):
             self.v_drift = global_variables.modules["strawtubes"].StrawVdrift()
             self.sigma_spatial = global_variables.modules["strawtubes"].StrawSigmaSpatial()
         # optional if present, splitcalCluster
@@ -121,7 +120,7 @@ class ShipDigiReco:
         shipPatRec.initialize(fgeo)
 
     def reconstruct(self) -> None:
-        if not self.has_strawtubes:
+        if not hasattr(self, "strawtubes"):
             return
         n_tracks = self.findTracks()
         n_good_tracks = self.findGoodTracks()
@@ -154,7 +153,7 @@ class ShipDigiReco:
         self.header.SetMCEntryNumber(self.sTree.MCEventHeader.GetEventID())  # counts from 1
         if hasattr(self, "digiSBT"):
             self.digiSBT.process()
-        if self.has_strawtubes:
+        if hasattr(self, "strawtubes"):
             self.strawtubes.process()
         if hasattr(self, "timeDetector"):
             self.timeDetector.process()

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -13,6 +13,7 @@ import shipVertex
 import validationTools as validation_tools
 from detectors.MTCDetector import MTCDetector
 from detectors.SBTDetector import SBTDetector
+from detectors.SiliconTargetDetector import SiliconTargetDetector
 from detectors.splitcalDetector import splitcalDetector
 from detectors.strawtubesDetector import strawtubesDetector
 from detectors.timeDetector import timeDetector
@@ -57,10 +58,16 @@ class ShipDigiReco:
         self.fTrackletsArray = ROOT.std.vector("Tracklet")()
         self.Tracklets = self.recoTree.Branch("Tracklets", self.fTrackletsArray, 32000, -1)
         #
-        self.strawtubes = strawtubesDetector("strawtubes", self.sTree, outtree=self.recoTree)
+        self.has_strawtubes = "strawtubes" in global_variables.modules
+        if self.has_strawtubes:
+            self.strawtubes = strawtubesDetector("strawtubes", self.sTree, outtree=self.recoTree)
 
         if self.sTree.GetBranch("MTCDetPoint"):
             self.digiMTC = MTCDetector("MTCDet", self.sTree, "MTC", outtree=self.recoTree)
+        if self.sTree.GetBranch("SiliconTargetPoint"):
+            self.digiSiliconTarget = SiliconTargetDetector(
+                "SiliconTarget", self.sTree, "SiliconTarget", outtree=self.recoTree
+            )
         if self.sTree.GetBranch("vetoPoint"):
             self.digiSBT = SBTDetector("veto", self.sTree, "SBT", mcBranchName="digiSBT2MC", outtree=self.recoTree)
             self.vetoHitOnTrackArray = ROOT.std.vector("vetoHitOnTrack")()
@@ -71,8 +78,9 @@ class ShipDigiReco:
             self.upstreamTaggerDetector = UpstreamTaggerDetector("UpstreamTagger", self.sTree, outtree=self.recoTree)
 
         # for the digitizing step
-        self.v_drift = global_variables.modules["strawtubes"].StrawVdrift()
-        self.sigma_spatial = global_variables.modules["strawtubes"].StrawSigmaSpatial()
+        if self.has_strawtubes:
+            self.v_drift = global_variables.modules["strawtubes"].StrawVdrift()
+            self.sigma_spatial = global_variables.modules["strawtubes"].StrawSigmaSpatial()
         # optional if present, splitcalCluster
         if self.sTree.GetBranch("splitcalPoint"):
             self.splitcalDetector = splitcalDetector("splitcal", self.sTree, outtree=self.recoTree)
@@ -113,6 +121,8 @@ class ShipDigiReco:
         shipPatRec.initialize(fgeo)
 
     def reconstruct(self) -> None:
+        if not self.has_strawtubes:
+            return
         n_tracks = self.findTracks()
         n_good_tracks = self.findGoodTracks()
         if hasattr(self, "digiSBT"):
@@ -144,13 +154,16 @@ class ShipDigiReco:
         self.header.SetMCEntryNumber(self.sTree.MCEventHeader.GetEventID())  # counts from 1
         if hasattr(self, "digiSBT"):
             self.digiSBT.process()
-        self.strawtubes.process()
+        if self.has_strawtubes:
+            self.strawtubes.process()
         if hasattr(self, "timeDetector"):
             self.timeDetector.process()
         if hasattr(self, "upstreamTaggerDetector"):
             self.upstreamTaggerDetector.process()
         if hasattr(self, "digiMTC"):
             self.digiMTC.process()
+        if hasattr(self, "digiSiliconTarget"):
+            self.digiSiliconTarget.process()
         if self.sTree.GetBranch("splitcalPoint"):
             self.splitcalDetector.process()
         if self.validation:


### PR DESCRIPTION
Some fixes and updates for SND.
1. Fix the issues of scint tile hit processing pointed by Oliver (#1307 )
2. Add the SiTarget digitiser class for symmetry
3. Provide some fixes to make the stand-alone SND simulation possible (when most of the subsystems are removed):
1) iron material is defined in MTC instead of wiring it from the muon shield class
2) python/shipDigiReco.py gates if there are no containers that the reconstructor and digitiser have to process

## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added optional silicon target digitization: groups silicon target points by detector and produces silicon target hits when the input branch is present.

* **Bug Fixes**
  * Improved MTC hit position handling for a specific volume case to use the intended entry/exit averaging behavior.
  * Ensured iron medium initialization occurs before retrieving the iron medium for geometry.
  * Made straw-tube digitization and reconstruction run only when straw-tube support is available, avoiding unintended execution when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->