### PR TITLE
feat: Add TRY_2026 MS design

### DIFF
--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         vessel: [vacuums, helium]
         snd_design: [all]
-        muon_shield: [TRY_2025]
+        muon_shield: [TRY_2026]
     env:
       QT_QPA_PLATFORM: offscreen
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ it in future.
 ### Added
 * Add option to split kaons and pions right before they decay, to increase the number of muons
 
+* Added TRY_2026 MS version.
+
 ### Changed
 
 ### Fixed

--- a/files/TRY_2026.root
+++ b/files/TRY_2026.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ea81163b81353ccd6ebd0e18c0f4e9d9a7187b16f1c6ca6372791eda0a542bd
+size 17081903

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -133,8 +133,8 @@ ap.add_argument(
 ap.add_argument(
     "--shieldName",
     help="Name of the shield in the database.",
-    default="TRY_2025",
-    choices=["TRY_2025"],
+    default="TRY_2026",
+    choices=["TRY_2025", "TRY_2026"],
 )
 ap.add_argument(
     "--AddMuonShield",

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -325,8 +325,8 @@ parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajecto
 parser.add_argument(
     "--shieldName",
     help="The name of the muon shield in the database to use.",
-    default="TRY_2025",
-    choices=["TRY_2025"],
+    default="TRY_2026",
+    choices=["TRY_2025", "TRY_2026"],
 )
 parser.add_argument(
     "--MesonMother", dest="MM", help="Choose DP production meson source: pi0, eta, omega, eta1, eta11", default="pi0"

--- a/macro/run_tracking_benchmark.py
+++ b/macro/run_tracking_benchmark.py
@@ -88,7 +88,7 @@ sim_cmd = [
     "--SND_design",
     "2",
     "--shieldName",
-    "TRY_2025",
+    "TRY_2026",
     "--tag",
     tag,
     "-o",

--- a/pixi.toml
+++ b/pixi.toml
@@ -84,7 +84,7 @@ test = { cmd = "ctest --test-dir build --output-on-failure", depends-on = ["buil
 args = [
   { arg = "vessel", default = "vacuums" },
   { arg = "snd_design", default = "all" },
-  { arg = "muon_shield", default = "TRY_2025" },
+  { arg = "muon_shield", default = "TRY_2026" },
 ]
 cmd = "python macro/run_simScript.py --test --debug 2 --{{ vessel }} --SND --SND_design={{ snd_design }} --shieldName {{ muon_shield }} --EvtGenDecayer --seed 42 --tag ci-test"
 

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -17,6 +17,20 @@ from ShipGeoConfig import AttrDict, Config
 # The first row is the length of the magnets
 # The other rows are the transverse dimensions of the magnets:  dXIn[i], dXOut[i] , dYIn[i], dYOut[i], gapIn[i], gapOut[i].
 shield_db = {
+    "TRY_2026": {
+        "hybrid": False,
+        "WithConstField": False,
+        "params": [
+            [0.0, 115.0, 40.0, 40.0, 119.0, 119.0, 61.5, 61.5, 1.5375, 1.5375, 50.0, 50.0, 0.0, 0.0, 2.05],
+            [15, 150, 62, 62, 11, 11, 12, 12, 1, 1.0, 69, 69, 0, 0, 1.87],
+            [15, 225, 70, 70, 12, 12, 9, 9, 1, 1.0, 77, 77, 0, 0, 1.865],
+            [16, 225, 64, 64, 14, 14, 8, 8, 1.3, 1.3, 71, 71, 0, 0, 1.92],
+            [15, 225, 42, 42, 13, 13, 8, 8, 2.6, 2.6, 47, 47, 0, 0, 1.89],
+            [16, 131, 20, 20, 30, 30, 0, 0, 5.5, 5.5, 22, 22, 0, 0, 0],
+            [15, 168, 20, 30, 20, 30, 22, 12, 5.4, 3.6, 33, 33, 0, 0, -1.42],
+            [19, 200, 38, 69, 51, 51, 8, 8, 3.2894736842105265, 1.36231884057971, 76, 76, 0, 0, -2.035],
+        ],
+    },
     "TRY_2025": {
         "hybrid": False,
         "WithConstField": False,


### PR DESCRIPTION
## Checklist

- [ ] Change the location of MTC
- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **TRY_2026** muon shield option, including a new configuration preset and expanded command-line selection.
* **Documentation**
  * Updated **CHANGELOG** with a new **Unreleased → Added** entry for **TRY_2026**.
* **CI / Build**
  * Updated simulation settings to run using **TRY_2026** by default, including workflow matrix and CI task defaults.
* **Assets**
  * Added the **TRY_2026** shield data to the repository via Git LFS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->