### PR TITLE
refactor: drop redundant ClassImp macros

### DIFF
--- a/Detector/DetectorPoint.cxx
+++ b/Detector/DetectorPoint.cxx
@@ -42,5 +42,3 @@ void SHiP::DetectorPoint::Print() const {
 void SHiP::DetectorPoint::extraPrintInfo() const {
   LOG(info) << "Nothing to see here";
 }
-
-ClassImp(SHiP::DetectorPoint)

--- a/SND/EmulsionTarget/CMakeLists.txt
+++ b/SND/EmulsionTarget/CMakeLists.txt
@@ -3,8 +3,10 @@
 
 ship_add_library(
   NAME EmulsionTarget
-  SOURCES Target.cxx TargetPoint.cxx TargetTracker.cxx TTPoint.cxx
+  SOURCES Target.cxx TargetTracker.cxx
   LINKDEF EmulsionTargetLinkDef.h
   EXTRA_DICT_HEADERS ${CMAKE_SOURCE_DIR}/Detector/Detector.h
+                     ${CMAKE_CURRENT_SOURCE_DIR}/TargetPoint.h
+                     ${CMAKE_CURRENT_SOURCE_DIR}/TTPoint.h
   DEPENDENCIES Detector Base ShipData GeoBase ParBase Geom Core FairLogger::FairLogger
 )

--- a/SND/EmulsionTarget/TTPoint.cxx
+++ b/SND/EmulsionTarget/TTPoint.cxx
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
-// SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
-// Collaboration
-
-#include "TTPoint.h"
-
-ClassImp(TTPoint)

--- a/SND/EmulsionTarget/TargetPoint.cxx
+++ b/SND/EmulsionTarget/TargetPoint.cxx
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
-// SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
-// Collaboration
-
-#include "TargetPoint.h"
-
-ClassImp(TargetPoint)

--- a/SND/MTC/CMakeLists.txt
+++ b/SND/MTC/CMakeLists.txt
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
 ship_add_library(NAME MTCDetector
-  SOURCES MTCDetector.cxx MTCDetPoint.cxx MTCDetHit.cxx
+  SOURCES MTCDetector.cxx MTCDetHit.cxx
   LINKDEF MTCDetectorLinkDef.h
   EXTRA_DICT_HEADERS ${CMAKE_SOURCE_DIR}/Detector/Detector.h
+                     ${CMAKE_CURRENT_SOURCE_DIR}/MTCDetPoint.h
   DEPENDENCIES Detector Base ShipData Detector GeoBase ParBase Geom Core FairLogger::FairLogger
 )

--- a/SND/MTC/MTCDetPoint.cxx
+++ b/SND/MTC/MTCDetPoint.cxx
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
-// SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
-// Collaboration
-
-#include "MTCDetPoint.h"
-
-ClassImp(MTCDetPoint)

--- a/SND/SiliconTarget/CMakeLists.txt
+++ b/SND/SiliconTarget/CMakeLists.txt
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
 
 ship_add_library(NAME SiliconTarget
-  SOURCES SiliconTarget.cxx SiliconTargetPoint.cxx SiliconTargetHit.cxx
+  SOURCES SiliconTarget.cxx SiliconTargetHit.cxx
   LINKDEF SiliconTargetLinkDef.h
   EXTRA_DICT_HEADERS ${CMAKE_SOURCE_DIR}/Detector/Detector.h
+                     ${CMAKE_CURRENT_SOURCE_DIR}/SiliconTargetPoint.h
   DEPENDENCIES Detector Base ShipData Detector GeoBase ParBase Geom Core FairLogger::FairLogger
 )

--- a/SND/SiliconTarget/SiliconTargetPoint.cxx
+++ b/SND/SiliconTarget/SiliconTargetPoint.cxx
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
-// SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP
-// Collaboration
-
-#include "SiliconTargetPoint.h"
-
-ClassImp(SiliconTargetPoint)


### PR DESCRIPTION
## Summary

Removes all `ClassImp` usages in the tree. In modern ROOT the rootcling-generated dictionary provides the class registration, so `ClassImp` only records cosmetic impl-file metadata. Every affected class already has a `ClassDefOverride` in its header **and** a `LinkDef` dictionary entry, making `ClassImp` redundant.

An inventory found exactly **5** usages:

- `Detector/DetectorPoint.cxx` — a real source file with out-of-line methods; only the trailing `ClassImp` line is dropped.
- `MTCDetPoint`, `TargetPoint`, `TTPoint`, `SiliconTargetPoint` — header-only point classes whose `.cxx` files existed *solely* to host `ClassImp`. These stubs are deleted, and their headers moved to `EXTRA_DICT_HEADERS` in the three affected `CMakeLists.txt` (needed because `ship_add_library` derives dictionary headers from `SOURCES`).

## Verification

- The four affected libraries (`Detector`, `MTCDetector`, `EmulsionTarget`, `SiliconTarget`) build and their dictionaries generate cleanly.
- Loading the libraries in PyROOT confirms every class is still registered with its correct schema version — `SHiP::DetectorPoint` v1, `MTCDetPoint`/`TargetPoint`/`TTPoint` v4, `SiliconTargetPoint` v3 — so the change is behaviour-neutral (schema evolution via the `+` LinkDef entries is unaffected).