### PR TITLE
Fix/remove ha field map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ it in future.
 * Restore `tPythia6Generator` instantiation from Python — broken since 26.02 by the `SHiP::Generator` base-class refactor leaving the file-based `Init` overloads pure virtual without a stub override (#1272)
 * Fix call to next Pythia event generation
 
-* fix eliminate redundant hadron absorber field map
+* Eliminate redundant hadron absorber field map
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ it in future.
 
 * Restore `tPythia6Generator` instantiation from Python — broken since 26.02 by the `SHiP::Generator` base-class refactor leaving the file-based `Init` overloads pure virtual without a stub override (#1272)
 * Fix call to next Pythia event generation
+
+* fix eliminate redundant hadron absorber field map
+
 ### Removed
 
 * Remove unused legacy `Pythia6Generator` (custom text-format event-record reader from 2008, zero callsites anywhere in the tree). `tPythia6Generator` is unaffected.

--- a/files/FieldHadronStopper_raised_20190411.root
+++ b/files/FieldHadronStopper_raised_20190411.root
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a06a09a117f402cda5be51f5b2d96de899d69f98b9ab1132fe51a025e9d6ba2c
-size 73932

--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -190,14 +190,6 @@ def addVMCFields(shipGeo, controlFile: str = "", verbose: bool = False, withVirt
         )
         fieldsList.append("muonShieldField")
 
-    elif not shipGeo.hadronAbsorber.WithConstField:
-        fieldMaker.defineFieldMap(
-            "HadronAbsorberMap",
-            "files/FieldHadronStopper_raised_20190411.root",
-            ROOT.TVector3(0.0, 0.0, shipGeo.hadronAbsorber.z),
-        )
-        fieldsList.append("HadronAbsorberMap")
-
     # Combine the fields to obtain the global field
     if len(fieldsList) > 1:
         fieldMaker.defineComposite("TotalField", *fieldsList)  # fieldsList MUST have length <=4


### PR DESCRIPTION
## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Noted the fix for a redundant hadron absorber field map in the unreleased section of the changelog.
- **Maintenance**
  - Removed an obsolete hadron absorber field-map asset from the project.
- **Style**
  - Improved readability in the magnetic-field configuration by adjusting spacing between related configuration blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->