### PR TITLE
ci: fix Doxygen gh-pages deploy concurrency deadlock

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -3,11 +3,10 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-# Share the gh-pages deploy lock with the plot push jobs in pixi-build.yml so a
-# docs deploy cannot race a plot push to the gh-pages branch.
-concurrency:
-  group: gh-pages-deploy
-  cancel-in-progress: false
+# The reusable deploy job below already serializes on the gh-pages-deploy
+# concurrency group (shared with the plot push jobs in pixi-build.yml), so a
+# docs deploy cannot race a plot push. Declaring the same group at the caller
+# run level would deadlock against the job-level one and fail before any step.
 jobs:
   deploy:
     name: Deploy docs


### PR DESCRIPTION
The **Deploy Doxygen Docs** workflow has failed on every push since 2026-07-06, dying in 1–11 s with **zero steps executed** (healthy runs take ~50 s) — a startup failure, not a build error.

## Cause

The caller `.github/workflows/doxygen-gh-pages.yml` declared a run-level concurrency group:

```yaml
concurrency:
  group: gh-pages-deploy
  cancel-in-progress: false
```

identical to the `concurrency: gh-pages-deploy` already set on the `deploy` job of the reusable `ShipSoft/.github/.github/workflows/doxygen-gh-pages.yml@main` it calls. A job cannot acquire a concurrency group its parent run already holds, so GitHub fails the run before any step executes.

The caller-level lock was also redundant: the reusable `deploy` job already serializes on `gh-pages-deploy`, the same group used by the `deploy-plots` job in `pixi-build.yml` and by `cleanup-plots.yml`.

## Fix

Drop the caller-level `concurrency` block. Docs deploys and plot pushes remain serialized via the reusable job's group; the run can now start.

## Verification

Once merged, check:

```
gh run list --workflow=doxygen-gh-pages.yml --limit 3
```

The `Deploy docs / deploy` job should run its steps (~50 s) and succeed instead of failing in seconds.