### PR TITLE
ci: point CI at main after renaming master branch

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -9,7 +9,7 @@ The metrics tracking system provides lightweight monitoring of simulation and re
 - **Metrics extraction** (~8KB JSON per configuration vs 10MB+ ROOT files)
 - **Git notes storage** (metrics attached to commits, don't clutter history)
 - **Self-documenting comparison** (each metric specifies its comparison mode)
-- **Automated CI integration** (runs on every PR and master commit)
+- **Automated CI integration** (runs on every PR and main commit)
 
 ## JSON Format
 
@@ -107,7 +107,7 @@ The CI workflow has three jobs for metrics tracking:
    - Runs for all matrix configurations
    - Uploads metrics as artifacts
 
-2. **`store-metrics`**: Stores metrics in git notes (master branch only)
+2. **`store-metrics`**: Stores metrics in git notes (main branch only)
    - Downloads metrics artifacts
    - Stores in `refs/notes/ci/physics-metrics/<config>`
    - Pushes to remote

--- a/.github/scripts/annotate_build.py
+++ b/.github/scripts/annotate_build.py
@@ -43,9 +43,10 @@ def make_relative_path(file_path, repo_name="FairShip") -> str:
     Convert absolute path to relative path from repo root.
 
     aliBuild creates paths like:
-    /__w/FairShip/FairShip/sw/SOURCES/FairShip/master/0/shipdata/ShipHit.cxx
+    /__w/FairShip/FairShip/sw/SOURCES/FairShip/<branch>/0/shipdata/ShipHit.cxx
 
-    We need to extract the part after 'SOURCES/FairShip/master/0/'
+    We need to extract the part after 'SOURCES/FairShip/<branch>/0/', where
+    <branch> is the branch aliBuild checked out (e.g. main).
     """
     # Strip any aliBuild debug prefix
     # (format: "YYYY-MM-DD@HH:MM:SS:DEBUG:package:package:N: ")
@@ -59,17 +60,12 @@ def make_relative_path(file_path, repo_name="FairShip") -> str:
     path = Path(file_path)
     parts = path.parts
 
-    # Look for the pattern: SOURCES/FairShip/master/0/...
+    # Look for the pattern: SOURCES/FairShip/<branch>/0/...
     try:
         sources_idx = parts.index("SOURCES")
-        # Verify this is followed by FairShip/master/0
-        if (
-            sources_idx + 3 < len(parts)
-            and parts[sources_idx + 1] == repo_name
-            and parts[sources_idx + 2] == "master"
-            and parts[sources_idx + 3] == "0"
-        ):
-            # Extract everything after SOURCES/FairShip/master/0/
+        # Verify this is followed by FairShip/<branch>/0 (any branch name)
+        if sources_idx + 3 < len(parts) and parts[sources_idx + 1] == repo_name and parts[sources_idx + 3] == "0":
+            # Extract everything after SOURCES/FairShip/<branch>/0/
             relative_parts = parts[sources_idx + 4 :]
             if relative_parts:
                 return str(Path(*relative_parts))

--- a/.github/workflows/cleanup-plots.yml
+++ b/.github/workflows/cleanup-plots.yml
@@ -54,11 +54,11 @@ jobs:
                 console.log(`Skipping ${prNum}: ${e.message}`);
               }
             }
-      - name: Keep only last 10 master plot directories
+      - name: Keep only last 10 main plot directories
         run: |
-          if [ -d plots/master ]; then
-            ls -1 plots/master | sort -r | tail -n +11 | while read dir; do
-              rm -rf "plots/master/$dir"
+          if [ -d plots/main ]; then
+            ls -1 plots/main | sort -r | tail -n +11 | while read dir; do
+              rm -rf "plots/main/$dir"
             done
           fi
       - name: Push cleanup

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       ref:
         description: 'Git ref to build'
-        default: 'master'
+        default: 'main'
 concurrency:
   group: container-${{ inputs.ref || github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,7 +1,7 @@
 name: Deploy Doxygen Docs
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 # Share the gh-pages deploy lock with the plot push jobs in pixi-build.yml so a
 # docs deploy cannot race a plot push to the gh-pages branch.

--- a/.github/workflows/legacy-cvmfs.yml
+++ b/.github/workflows/legacy-cvmfs.yml
@@ -1,7 +1,7 @@
 name: Legacy CVMFS CI
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ['v*']
   workflow_dispatch:
   schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,9 @@
 name: Lint
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
   merge_group:
 concurrency:

--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
-    branches: [master]
+    branches: [main]
     tags: ['v*']
   workflow_dispatch:
   merge_group:
@@ -262,7 +262,7 @@ jobs:
         run: pixi run --locked -- pyrefly check --output-format=github python macro
   store-metrics:
     name: Store metrics reference
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: run-sim-chain
     runs-on: ubuntu-latest
     permissions:
@@ -328,10 +328,10 @@ jobs:
             config=$(basename "$f" .json)
             config=${config#metrics-}
             ref="ci/physics-metrics/$config"
-            # The tip of master may not have a note yet (its CI run might
+            # The tip of main may not have a note yet (its CI run might
             # still be going), so walk back to the newest commit that has one.
             reference=""
-            for commit in $(git rev-list --first-parent -n 50 origin/master); do
+            for commit in $(git rev-list --first-parent -n 50 origin/main); do
               if git notes --ref="$ref" show "$commit" > "reference-$config.json" 2>/dev/null; then
                 reference="$commit"
                 break
@@ -386,7 +386,7 @@ jobs:
             }
   deploy-plots:
     name: Deploy plots
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [run-tracking-benchmark, run-sim-chain, run-fixed-target]
     concurrency:
@@ -414,7 +414,7 @@ jobs:
           else
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
             TITLE="CI Plots for $SHORT_SHA"
-            BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/plots/master/${{ github.run_id }}-$SHORT_SHA"
+            BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/plots/main/${{ github.run_id }}-$SHORT_SHA"
           fi
           python3 .github/scripts/generate_plot_index.py all-plots/ \
             --title "$TITLE" --base-url "$BASE_URL"
@@ -429,7 +429,7 @@ jobs:
             DEST="gh-pages-checkout/plots/pr/${{ github.event.pull_request.number }}/${{ github.run_id }}"
           else
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
-            DEST="gh-pages-checkout/plots/master/${{ github.run_id }}-$SHORT_SHA"
+            DEST="gh-pages-checkout/plots/main/${{ github.run_id }}-$SHORT_SHA"
           fi
           mkdir -p "$DEST"
           cp -r all-plots/* "$DEST/"

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -8,4 +8,4 @@ jobs:
     name: Update pixi lock
     uses: ShipSoft/.github/.github/workflows/pixi-lock-update.yml@main
     with:
-      base: master
+      base: main

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ documentation.
 ### Branches
 
 <dl>
-  <dt><code>master</code></dt>
+  <dt><code>main</code></dt>
   <dd>Main development branch.
       All python code is <b>required to be python 3</b>. Python 2 is no longer supported.</dd>
   <dt><code>charmdet</code></dt>


### PR DESCRIPTION
The default branch was renamed from `master` to `main`. Several CI workflows and one helper script still hardcoded `master`, so on `main` they would silently stop doing their job. This points all in-repo CI at `main` and hardens the aliBuild path parser against future renames.

## Changes
- **Workflow triggers** `branches: [master]` → `[main]` — `pixi-build.yml`, `lint.yml`, `doxygen-gh-pages.yml`, `legacy-cvmfs.yml`. Without this, no CI runs on the default branch.
- **Branch-ref job conditions** `refs/heads/master` → `refs/heads/main` — `store-metrics` and `deploy-plots` jobs in `pixi-build.yml`.
- **Metrics comparison walk** `git rev-list … origin/master` → `origin/main`.
- **Base / dispatch defaults** — `update-lock-files.yml` (`base: main`) and `container-build.yml` (workflow_dispatch `default: 'main'`).
- **gh-pages plot directory** `plots/master/` → `plots/main/`, kept consistent across `pixi-build.yml` (write) and `cleanup-plots.yml` (prune).
- **`annotate_build.py`** — made branch-agnostic. It parsed aliBuild's `SOURCES/FairShip/<branch>/0/` paths by matching the literal `master` segment, which silently fell through to the fallback on `main`; it now validates the path structure instead, surviving future renames.
- **Docs** — README "Branches" table and `.github/scripts/README.md` prose.

## Verification
- `git grep master` over `.github/` and `README.md` is clean (only unrelated code/external links remain elsewhere).
- Parser sanity-checked: `main`, `master`, and arbitrary branch names all resolve `SOURCES/FairShip/<branch>/0/shipdata/ShipHit.cxx` → `shipdata/ShipHit.cxx`.

## Out of scope (external follow-ups)

- **ShipDist recipe** (`ShipSoft/ShipDist`, `FairShip.sh`): if its `tag:`/source pins `master`, legacy aliBuild builds may still target the old branch — check separately.
