### PR TITLE
fix: add GENIE headers to the ROOT_INCLUDE_PATH

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -59,7 +59,7 @@ pyrefly = "*"
 
 [activation]
 scripts = ["activate.sh"]
-env = { FAIRROOTPATH = "$CONDA_PREFIX", ROOT_INCLUDE_PATH = "$CONDA_PREFIX/include:$CONDA_PREFIX/include/geant4vmc:$CONDA_PREFIX/include/Geant4:$CONDA_PREFIX/include/vmc" }
+env = { FAIRROOTPATH = "$CONDA_PREFIX", ROOT_INCLUDE_PATH = "$CONDA_PREFIX/include:$CONDA_PREFIX/include/geant4vmc:$CONDA_PREFIX/include/Geant4:$CONDA_PREFIX/include/vmc:$CONDA_PREFIX/include/GENIE" }
 
 [tasks]
 configure = { cmd = """cmake -S . -B build -G Ninja \


### PR DESCRIPTION
## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass

Check out the https://github.com/ShipSoft/FairShip/issues/1344 caused by pixi overwriting the ROOT_INCLUDE_PATH leaving the GENIE headers unknown. Another part of the fix is in the conda-recipes https://github.com/ShipSoft/ship-conda-recipes/pull/129.