### PR TITLE
perf: replace ShipStack track maps with dense vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ it in future.
 
 ### Changed
 
+* Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
+
 ### Fixed
 
 ### Removed

--- a/Detector/Detector.h
+++ b/Detector/Detector.h
@@ -57,13 +57,11 @@ class Detector : public FairDetector, public ISTLPointContainer {
 
   TClonesArray* GetCollection(Int_t iColl) const override { return nullptr; }
 
-  void UpdatePointTrackIndices(
-      const std::map<Int_t, Int_t>& indexMap) override {
+  void UpdatePointTrackIndices(const std::vector<Int_t>& indexMap) override {
     for (auto& point : *fDetPoints) {
       Int_t oldTrackID = point.GetTrackID();
-      auto iter = indexMap.find(oldTrackID);
-      if (iter != indexMap.end()) {
-        point.SetTrackID(iter->second);
+      if (oldTrackID >= 0 && oldTrackID < static_cast<Int_t>(indexMap.size())) {
+        point.SetTrackID(indexMap[oldTrackID]);
       }
     }
   }

--- a/shipdata/ISTLPointContainer.h
+++ b/shipdata/ISTLPointContainer.h
@@ -1,7 +1,7 @@
 #ifndef SHIPDATA_ISTLPOINTCONTAINER_H_
 #define SHIPDATA_ISTLPOINTCONTAINER_H_
 
-#include <map>
+#include <vector>
 
 #include "RtypesCore.h"
 
@@ -17,11 +17,10 @@ class ISTLPointContainer {
  public:
   /**
    * @brief Update track indices in point collection after track filtering
-   * @param indexMap Map from old (particle) track index to new (stored) track
-   * index
+   * @param indexMap Old (particle) track index to new (stored) track index,
+   * indexed by old track index; -2 marks tracks that were not stored
    */
-  virtual void UpdatePointTrackIndices(
-      const std::map<Int_t, Int_t>& indexMap) = 0;
+  virtual void UpdatePointTrackIndices(const std::vector<Int_t>& indexMap) = 0;
 
   virtual ~ISTLPointContainer() = default;
 };

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -34,10 +34,8 @@ ShipStack::ShipStack(Int_t size)
       fStack(),
       fParticles(new TClonesArray("TParticle", size)),
       fTracks(nullptr),
-      fStoreMap(),
-      fStoreIter(),
+      fStoreFlags(),
       fIndexMap(),
-      fIndexIter(),
       fPointsMap(),
       fCurrentTrack(-1),
       fNPrimaries(0),
@@ -225,8 +223,8 @@ void ShipStack::FillTrackArray() {
 
   Int_t evtNo = -1;
 
-  // --> Reset index map and number of output tracks
-  fIndexMap.clear();
+  // --> Reset index map (-2 = not stored) and number of output tracks
+  fIndexMap.assign(fNParticles, -2);
   fNTracks = 0;
 
   // --> Check tracks for selection criteria
@@ -236,26 +234,15 @@ void ShipStack::FillTrackArray() {
 
   // --> Loop over fParticles array and copy selected tracks
   for (Int_t iPart = 0; iPart < fNParticles; iPart++) {
-    fStoreIter = fStoreMap.find(iPart);
-    if (fStoreIter == fStoreMap.end()) {
-      LOGF(fatal, "ShipStack: Particle %i not found in storage map! ", iPart);
-    }
-    Bool_t store = (*fStoreIter).second;
-
-    if (store) {
+    if (fStoreFlags[iPart]) {
       fTracks->emplace_back(dynamic_cast<TParticle*>(GetParticle(iPart)));
       ShipMCTrack& track = fTracks->back();
       fIndexMap[iPart] = fNTracks;
       track.SetTrackID(fNTracks);
       track.SetEventID(evtNo);
       fNTracks++;
-    } else {
-      fIndexMap[iPart] = -2;
     }
   }
-
-  // --> Map index for primary mothers
-  fIndexMap[-1] = -1;
 
   // --> Screen output
   // Print(1);
@@ -271,12 +258,11 @@ void ShipStack::UpdateTrackIndex(TRefArray* detList) {
   for (Int_t i = 0; i < fNTracks; i++) {
     ShipMCTrack& track = (*fTracks)[i];
     Int_t iMotherOld = track.GetMotherId();
-    fIndexIter = fIndexMap.find(iMotherOld);
-    if (fIndexIter == fIndexMap.end()) {
+    if (iMotherOld >= static_cast<Int_t>(fIndexMap.size())) {
       LOGF(fatal, "ShipStack: Particle index %i not found in dex map! ",
            iMotherOld);
     }
-    track.SetMotherId((*fIndexIter).second);
+    track.SetMotherId(iMotherOld < 0 ? -1 : fIndexMap[iMotherOld]);
   }
 
   if (fDetList == nullptr) {
@@ -308,12 +294,11 @@ void ShipStack::UpdateTrackIndex(TRefArray* detList) {
           FairMCPoint* point = dynamic_cast<FairMCPoint*>(hitArray->At(iPoint));
           Int_t iTrack = point->GetTrackID();
 
-          fIndexIter = fIndexMap.find(iTrack);
-          if (fIndexIter == fIndexMap.end()) {
+          if (iTrack < -1 || iTrack >= static_cast<Int_t>(fIndexMap.size())) {
             LOGF(fatal, "ShipStack: Particle index %i not found in index map! ",
                  iTrack);
           }
-          point->SetTrackID((*fIndexIter).second);
+          point->SetTrackID(iTrack < 0 ? -1 : fIndexMap[iTrack]);
         }
 
       }  // Collections of this detector
@@ -399,8 +384,8 @@ TParticle* ShipStack::GetParticle(Int_t trackID) const {
 
 // -----   Private method SelectTracks   -----------------------------------
 void ShipStack::SelectTracks() {
-  // --> Clear storage map
-  fStoreMap.clear();
+  // --> Reset storage flags
+  fStoreFlags.assign(fNParticles, kFALSE);
 
   // --> Check particles in the fParticle array
   for (Int_t i = 0; i < fNParticles; i++) {
@@ -444,7 +429,7 @@ void ShipStack::SelectTracks() {
       }
     }
     // --> Set storage flag
-    fStoreMap[i] = store;
+    fStoreFlags[i] = store;
     // special case for Ship generators, want to keep all original particles
     // with their mother daughter relationship independent if tracked or not.
     // apply a dirty trick and use second mother to identify original generator
@@ -455,11 +440,11 @@ void ShipStack::SelectTracks() {
   // --> If flag is set, flag recursively mothers of selected tracks
   if (fStoreMothers) {
     for (Int_t i = 0; i < fNParticles; i++) {
-      if (fStoreMap[i]) {
+      if (fStoreFlags[i]) {
         Int_t iMother = GetParticle(i)->GetMother(0);
         {
           while (iMother >= 0) {
-            fStoreMap[iMother] = kTRUE;
+            fStoreFlags[iMother] = kTRUE;
             iMother = GetParticle(iMother)->GetMother(0);
           }
         }

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -182,13 +182,11 @@ class ShipStack : public FairGenericStack {
   /** Array of FairMCTracks containing the tracks written to the output **/
   std::vector<ShipMCTrack>* fTracks;
 
-  /** STL map from particle index to storage flag  **/
-  std::map<Int_t, Bool_t> fStoreMap;             //!
-  std::map<Int_t, Bool_t>::iterator fStoreIter;  //!
+  /** Storage flag per particle index  **/
+  std::vector<Bool_t> fStoreFlags;  //!
 
-  /** STL map from particle index to track index  **/
-  std::map<Int_t, Int_t> fIndexMap;             //!
-  std::map<Int_t, Int_t>::iterator fIndexIter;  //!
+  /** Output track index per particle index (-2 if not stored)  **/
+  std::vector<Int_t> fIndexMap;  //!
 
   /** STL map from track index and detector ID to number of MCPoints **/
   std::map<std::pair<Int_t, Int_t>, Int_t> fPointsMap;  //!


### PR DESCRIPTION
## Motivation

Investigating memory growth in `run_fixedTarget.py` with high `--kaon-pion-splits` levels showed that RSS ratchets with the largest event seen (no true leak), at ~300 B per stack particle. About a third of that, and a surprisingly large share of CPU time, came from `ShipStack`'s two per-event `std::map`s (`fStoreMap`, `fIndexMap`): with per-step splitting, events reach millions of particles, so the maps cost millions of O(log n) lookups and ~96 B/particle of node churn that fragments the allocator arenas.

## Change

Both maps are keyed by track indices, which are contiguous in `[0, fNParticles)`, so they are replaced by vectors indexed by particle id:

- `fStoreMap` → `std::vector<Bool_t> fStoreFlags`
- `fIndexMap` → `std::vector<Int_t>` (value `-2` = track not stored, unchanged semantics)
- the former `fIndexMap[-1] = -1` sentinel for primary mothers becomes an explicit `< 0` branch at the lookup sites
- `ISTLPointContainer::UpdatePointTrackIndices` takes `const std::vector<Int_t>&`; the sole implementer (`SHiP::Detector<PointType>`) does a bounds-checked direct index
- the "particle not found in storage map" fatal is dropped (impossible by construction); the out-of-range fatals in `UpdateTrackIndex` are kept

## Results

400-event benchmark (`run_fixedTarget.py -n 400 --kaon-pion-splits 100 --multiple-kpi-splits -rs 1234`):

- CPU time: 478 s → 249 s (~1.9×)
- RSS at the largest event (3.35M particles): 2558 MB → 2278 MB (~84 B/particle)

## Verification

- Simulation output is identical: a 50-event before/after comparison (same seed) matches event by event in all MCTrack PDG codes, mother IDs, momenta and weights, and all PlaneHAPoint track IDs
- ctest (DataClassIO, RNtupleIO), `ci-fixed-target` and `ci-sim` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved track selection and index remapping performance for high-multiplicity events.
  * Reduced CPU usage and peak memory consumption during particle splitting and track processing.
* **Bug Fixes**
  * Improved handling of track and detector-hit index updates, including unmapped and out-of-range track identifiers.
* **Documentation**
  * Added changelog documentation describing the performance and memory improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->