### PR TITLE
perf: per-track MC point counts and early-exit mother flagging in ShipStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ it in future.
 * Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
 * Deduplicate the charm/beauty over min-bias cross-section scaling shared by `makeDecay` and `run_fixedTarget` into `python/heavyFlavourScaling.py`
 * Make `--chicc` and `--chibb` mutually exclusive in `makeDecay` and `run_fixedTarget`, and raise a clear error when the override does not match the run type (e.g. `--chicc` for a beauty run) instead of silently ignoring it
+* Count ShipStack MC points per track instead of per (track, detector) and stop the mother-flagging walk at already-flagged ancestors, further reducing track-selection CPU time for high-multiplicity events
 
 ### Fixed
 

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -427,16 +427,17 @@ void ShipStack::SelectTracks() {
     // GetParticle(i)->GetMother(1); maybe should set Mother2 to -1 in the
     // generator if (iMother == iMother2) {fStoreMap[i] = kTRUE;}
   }
-  // --> If flag is set, flag recursively mothers of selected tracks
+  // --> If flag is set, flag recursively mothers of selected tracks.
+  // A mother always has a smaller index than its daughters and every walk
+  // continues to the root, so an already-flagged mother implies its whole
+  // ancestor chain is flagged and the walk can stop early.
   if (fStoreMothers) {
     for (Int_t i = 0; i < fNParticles; i++) {
       if (fStoreFlags[i]) {
         Int_t iMother = GetParticle(i)->GetMother(0);
-        {
-          while (iMother >= 0) {
-            fStoreFlags[iMother] = kTRUE;
-            iMother = GetParticle(iMother)->GetMother(0);
-          }
+        while (iMother >= 0 && !fStoreFlags[iMother]) {
+          fStoreFlags[iMother] = kTRUE;
+          iMother = GetParticle(iMother)->GetMother(0);
         }
       }
     }

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -26,7 +26,6 @@
 
 using std::cout;
 using std::endl;
-using std::pair;
 
 // -----   Default constructor   -------------------------------------------
 ShipStack::ShipStack(Int_t size)
@@ -36,7 +35,7 @@ ShipStack::ShipStack(Int_t size)
       fTracks(nullptr),
       fStoreFlags(),
       fIndexMap(),
-      fPointsMap(),
+      fPointsPerTrack(),
       fCurrentTrack(-1),
       fNPrimaries(0),
       fNParticles(0),
@@ -318,7 +317,7 @@ void ShipStack::Reset() {
   }
   fParticles->Clear();
   fTracks->clear();
-  fPointsMap.clear();
+  fPointsPerTrack.clear();
 }
 // -------------------------------------------------------------------------
 
@@ -342,22 +341,18 @@ void ShipStack::Print(Int_t iVerbose) const {
 // -------------------------------------------------------------------------
 
 // -----   Public method AddPoint (for current track)   --------------------
-void ShipStack::AddPoint(DetectorId detId) {
-  Int_t iDet = detId;
-  // cout << "Add point for Detektor" << iDet << endl;
-  pair<Int_t, Int_t> a(fCurrentTrack, iDet);
-  ++fPointsMap[a];
-}
+void ShipStack::AddPoint(DetectorId detId) { AddPoint(detId, fCurrentTrack); }
 // -------------------------------------------------------------------------
 
 // -----   Public method AddPoint (for arbitrary track)  -------------------
-void ShipStack::AddPoint(DetectorId detId, Int_t iTrack) {
+void ShipStack::AddPoint(DetectorId /*detId*/, Int_t iTrack) {
   if (iTrack < 0) {
     return;
   }
-  Int_t iDet = detId;
-  pair<Int_t, Int_t> a(iTrack, iDet);
-  ++fPointsMap[a];
+  if (iTrack >= static_cast<Int_t>(fPointsPerTrack.size())) {
+    fPointsPerTrack.resize(iTrack + 1, 0);
+  }
+  ++fPointsPerTrack[iTrack];
 }
 // -------------------------------------------------------------------------
 
@@ -401,14 +396,9 @@ void ShipStack::SelectTracks() {
     //    Double_t mass   = thisPart->GetMass();
     Double_t eKin = energy - mass;
 
-    // --> Calculate number of points
-    Int_t nPoints = 0;
-    for (Int_t iDet = kVETO; iDet < kEndOfList; iDet++) {
-      pair<Int_t, Int_t> a(i, iDet);
-      if (fPointsMap.contains(a)) {
-        nPoints += fPointsMap[a];
-      }
-    }
+    // --> Get number of points
+    Int_t nPoints =
+        i < static_cast<Int_t>(fPointsPerTrack.size()) ? fPointsPerTrack[i] : 0;
 
     // --> Check for cuts (store primaries in any case)
     if (iMother < 0) {

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -153,13 +153,17 @@ class ShipStack : public FairGenericStack {
   void StoreMothers(Bool_t choice = kTRUE) { fStoreMothers = choice; }
   void SetSplitting() { fSplitting = kTRUE; }
 
-  /** Increment number of points for the current track in a given detector
-   *@param iDet  Detector unique identifier
+  /** Increment the point total for the current track.
+   ** The count is per track, aggregated across all detectors; iDet is retained
+   ** for call-site compatibility but ignored for counting.
+   *@param iDet  Detector unique identifier (ignored)
    **/
   void AddPoint(DetectorId iDet);
 
-  /** Increment number of points for an arbitrary track in a given detector
-   *@param iDet    Detector unique identifier
+  /** Increment the point total for an arbitrary track.
+   ** The count is per track, aggregated across all detectors; iDet is retained
+   ** for call-site compatibility but ignored for counting.
+   *@param iDet    Detector unique identifier (ignored)
    *@param iTrack  Track number
    **/
   void AddPoint(DetectorId iDet, Int_t iTrack);

--- a/shipdata/ShipStack.h
+++ b/shipdata/ShipStack.h
@@ -27,10 +27,8 @@
 #ifndef SHIPDATA_SHIPSTACK_H_
 #define SHIPDATA_SHIPSTACK_H_
 
-#include <map>      // for map, map<>::iterator
-#include <stack>    // for stack
-#include <utility>  // for pair
-#include <vector>   // for vector
+#include <stack>   // for stack
+#include <vector>  // for vector
 
 #include "FairGenericStack.h"  // for FairGenericStack
 #include "Rtypes.h"            // for Int_t, Double_t, Bool_t, etc
@@ -188,8 +186,8 @@ class ShipStack : public FairGenericStack {
   /** Output track index per particle index (-2 if not stored)  **/
   std::vector<Int_t> fIndexMap;  //!
 
-  /** STL map from track index and detector ID to number of MCPoints **/
-  std::map<std::pair<Int_t, Int_t>, Int_t> fPointsMap;  //!
+  /** Number of MCPoints per track index, summed over all detectors **/
+  std::vector<Int_t> fPointsPerTrack;  //!
 
   /** Some indizes and counters **/
   Int_t fCurrentTrack;  //! Index of current track


### PR DESCRIPTION
Stacked on #1350 (base branch `shipstack-dense-index-maps`; retarget to `main` once #1350 merges).

Two further reductions of per-particle cost in the `ShipStack` track-selection path, motivated by the same kaon/pion-splitting profiling as #1350 (events with millions of stack particles):

1. **Count MC points per track instead of per (track, detector).** `fPointsMap` was keyed by (track index, detector id), but the only consumer, `SelectTracks`, sums over all detectors per track for the `fMinPoints` cut — the per-detector breakdown is never read anywhere (no accessor exists in ShipStack or FairGenericStack). The map is replaced by a vector indexed by track, removing 21 map probes per stack particle. The `AddPoint(DetectorId)` detector-facing interface is unchanged (10 call sites untouched).
2. **Stop the mother-flagging walk at already-flagged ancestors.** Mothers always have smaller indices than daughters and every walk runs to the root, so an already-flagged mother implies its whole chain is flagged; breaking there avoids re-walking shared ancestor chains.

## Results

400-event benchmark (`run_fixedTarget.py -n 400 --kaon-pion-splits 100 --multiple-kpi-splits -rs 1234`), on top of #1350:

- CPU time: 249 s → 195 s (478 s before #1350)
- RSS unchanged (the point-count map held only ~10³ entries per event; this is a CPU fix)

## Verification

- Simulation output identical to the pre-#1350 baseline: 50-event comparison (same seed) matches event by event in all MCTrack PDG codes, mother IDs, momenta and weights, and all PlaneHAPoint track IDs
- ctest (DataClassIO, RNtupleIO) and `ci-fixed-target` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved track selection efficiency for high-multiplicity events by counting MC points per track across detectors.
  * Reduced CPU usage during mother-track flag propagation by stopping at already-flagged ancestors.
* **Documentation**
  * Updated the unreleased changelog with these performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->