### PR TITLE
ci: test 26.07 instead of 26.06 in legacy CVMFS CI

### DIFF
--- a/.github/workflows/legacy-cvmfs.yml
+++ b/.github/workflows/legacy-cvmfs.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["26.02", "26.06"]
+        version: ["26.02", "26.07"]
     container:
       image: registry.cern.ch/ship/gha-runner:latest
       volumes:


### PR DESCRIPTION
The 26.07 SHiP software release is now available on CVMFS. Update the legacy CVMFS CI matrix to build FairShip against the newest release (26.07) alongside the older stable baseline (26.02), replacing the now-superseded 26.06.

The `$version` matrix value flows directly into the CVMFS path (`/cvmfs/ship.cern.ch/$version/setUp.sh`) in both the Build and Run-sim steps, so no other changes are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the legacy build and test workflow to validate against CalVer version 26.07.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->