### PR TITLE
feat(geometry): add LAB liquid scintillator medium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ it in future.
 
 ### Changed
 
+* SBT sensitive medium is now LAB-based liquid scintillator (`LiquidScintillator`) rather than the plastic `Scintillator`, which remains in use by SplitCal
 * Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
 
 ### Fixed
+
+* `veto` now registers the configured `sensitiveMed` instead of a hardcoded medium name; previously any other value resolved to a null `TGeoMedium`
 
 ### Removed
 

--- a/geometry/media.geo
+++ b/geometry/media.geo
@@ -166,6 +166,22 @@ Inconel718	    6 51.9961 55.845 95.96 92.906 58.6934 47.867 24 26 42 41 28 22 8.
 		    0
 
 
+// ----- SBT materials -----
+
+// Liquid scintillator filling the SBT cells: linear alkylbenzene (LAB) doped
+// with 2 g/l PPO. LAB = C6H5-CnH2n+1 with n = 10-13, i.e. <C17.2H28.4>, giving
+// an H/C atom ratio of 1.65. PPO (C15H11NO) is 0.23 % by mass and is neglected
+// here; the bulk properties are those of the LAB solvent.
+// rho = 0.86 g/cm3 (20 C); X0 = 44.4 g/cm2 = 51.6 cm; lambda_I = 79.5 g/cm2 = 92 cm.
+// NB: this is NOT "Scintillator", defined further down inside the ecal block,
+// which is the plastic C8H8 at 1.032 g/cm3. Do not use that one for the SBT.
+// Ref: SHiP SBT, arXiv:2311.07340, arXiv:2503.10250
+LiquidScintillator 2  1.00794 12.011 1. 6. 0.86 0.1216 0.8784
+                   1  0  20.  .001
+                   0
+
+// ----- End SBT materials -----
+
 // ----- MVD materials -----
 carbonfoam2       1  12.011  6.0  0.2265
                   0  1  20.  .001

--- a/geometry/veto_config_helium.yaml
+++ b/geometry/veto_config_helium.yaml
@@ -6,7 +6,7 @@ outerSupport: 0.8 # cm
 outerSupportMed: "Aluminum"
 lidThickness: 0.0 # cm
 sensitiveThickness: 20 # cm
-sensitiveMed: "Scintillator"
+sensitiveMed: "LiquidScintillator"
 decayMed: "helium"
 rib: 1.5 # cm
 ribMed: "Aluminum"

--- a/geometry/veto_config_vacuums.yaml
+++ b/geometry/veto_config_vacuums.yaml
@@ -6,7 +6,7 @@ outerSupport: 2 # cm
 outerSupportMed: "steel"
 lidThickness: 0.0 # cm
 sensitiveThickness: 20 # cm
-sensitiveMed: "Scintillator"
+sensitiveMed: "LiquidScintillator"
 decayMed: "vacuums"
 rib: 1.5 # cm
 ribMed: "steel"

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -68,6 +68,7 @@ transparentMaterials = {
     "steel": 80,
     "Aluminum": 80,
     "Scintillator": 80,
+    "LiquidScintillator": 80,
     #                        tau nu detector
     "CoilCopper": 70,
     "copper": 90,

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -831,7 +831,7 @@ void veto::ConstructGeometry() {
   ShipGeo::InitMedium("vacuums");
   ShipGeo::InitMedium("Aluminum");
   ShipGeo::InitMedium("helium");
-  ShipGeo::InitMedium("Scintillator");
+  ShipGeo::InitMedium(vetoMed_name.Data());
   ShipGeo::InitMedium("steel");
 
   gGeoManager->SetNsegments(100);


### PR DESCRIPTION
<html><head></head><body><h1>feat(veto): use LAB liquid scintillator for the SBT</h1>
&lt;!-- Suggested retitle: the change now spans veto/ and geometry/, not geometry alone. --&gt;
<h2>Summary</h2>
<p>The SBT sensitive medium was <code>"Scintillator"</code> — a plastic entry, C8H8 at
1.032 g/cm3, defined in the legacy ecal block of <code>media.geo</code> — whereas the SBT
baseline is liquid scintillator: LAB with 2 g/l PPO. <code>media.geo</code> contained no
liquid scintillator at all, so the configuration had nothing else to point at.</p>
<p>Traced through:</p>
<pre><code>geometry/veto_config_{helium,vacuums}.yaml  sensitiveMed
  -&gt; python/shipDet_conf.py                 veto_geo.sensitiveMed
  -&gt; veto/veto.h                            vetoMed_name
  -&gt; veto/veto.cxx                          GetMedium(vetoMed_name)
  -&gt; geometry/media.geo                     Scintillator (C8H8, 1.032)
</code></pre>
<p>Both decay-volume variants are affected. SplitCal keeps using <code>Scintillator</code>,
which is correct for it.</p>
<h2>Why it matters</h2>
<p>Calculated from the compositions and densities (PDG element values); no
simulation is claimed here.</p>

  | plastic (C8H8, 1.032) | LAB (~C17H28, 0.86) | delta
-- | -- | -- | --
H:C atom ratio | 1.00 | 1.65 | +65 %
density (g/cm3) | 1.032 | 0.86 | -17 %
n_H (1e22 cm^-3) | 4.8 | 6.3 | +31 %
X0 | 42.4 cm | 51.6 cm | +21 %
lambda_int | 79 cm | 92 cm | +16 %
dE/dx (min) | 2.00 MeV/cm | 1.74 MeV/cm | -13 %


<p>The <code>veto.cxx</code> change is a prerequisite, not a cosmetic one: <code>InitMedium</code> is
what pulls a medium out of <code>media.geo</code>, and it was called with a hardcoded
<code>"Scintillator"</code> while the lookup used the configurable <code>vetoMed_name</code>. Any
other value resolved to a null <code>TGeoMedium</code>, so the config key could not work
before this.</p>
<p>The <code>eventDisplay.py</code> entry is inert if anything is wrong: <code>transparentMode</code>
calls <code>GetMaterial(m)</code> and skips names it cannot resolve.</p>
<h2>Scope: the SBT only</h2>
<p>The UBT is a separate class in <code>UpstreamTagger/</code>, built as a vacuum box, and
never sees <code>vetoMed_name</code>:</p>
<pre><code>UpstreamTagger/UpstreamTagger.h: * The UBT is a simplified scoring plane detector implemented as a vacuum box.
UpstreamTagger/UpstreamTagger.cxx: MakeBox("Upstream_Tagger", Vacuum_box, ...)
</code></pre>
<p><code>vetoMed</code> reaches only the sensitive cells — all six consumers are segment
volumes, and the support structure has its own configured media
(<code>outerSupportMed</code>, <code>ribMed</code>, <code>decayMed</code>):</p>
<pre><code>$ grep -n 'vetoMed\b' veto/veto.cxx
552:        kMagenta - 10, vetoMed, true);
565:        kMagenta - 10, vetoMed, true);
589:            zi_x2 - zi_x1, zi_y2 - zi_y1, kMagenta - 10, vetoMed, true);
615:        vetoMed, true);
630:        vetoMed, true);
654:            zi_x2 - zi_x1, zi_y2 - zi_y1, kMagenta - 10, vetoMed, true);
839:  vetoMed = gGeoManager-&gt;GetMedium(
</code></pre>
<p>SplitCal registers and consumes <code>Scintillator</code> itself, so dropping veto's
registration cannot strand it:</p>
<pre><code>$ grep -rn 'InitMedium("Scintillator")\|GetMedium("Scintillator")' --include=*.cxx . | grep -v '^./sw/'
./splitcal/splitcal.cxx:156:  ShipGeo::InitMedium("Scintillator");
./splitcal/splitcal.cxx:163:  TGeoMedium* A1 = gGeoManager-&gt;GetMedium("Scintillator");
</code></pre>
<p>After this change <code>grep -rn 'Scintillator' veto/</code> returns a single hit:
<code>veto.h</code>'s <code>fLiquidVeto</code> doc comment.</p>
<h2>Validation</h2>
<p>Not yet run: geometry construction, to confirm the new <code>media.geo</code> entry
parses into the intended material. <code>media.geo</code> is a positional format with no
schema, so a miscounted field misparses silently. To check:</p>
<pre><code class="language-python">import ROOT
ROOT.TFile.Open("&lt;geofile&gt;.root")
for n in ("LiquidScintillator", "Scintillator"):
    m = ROOT.gGeoManager.GetMaterial(n)
    print(n, m.GetDensity(), m.GetRadLen(), m.GetIntLen()) if m else print(n, "MISSING")
</code></pre>
<p>Expected: rho = 0.86, X0 ~ 52 cm, lambda ~ 92 cm for the new medium, and the
plastic entry unchanged at 1.032 / ~42 cm / ~79 cm. TGeo uses its own
approximate formulae, so a few percent offset from the table above is normal.</p>
<h2>Notes for reviewers</h2>
<ol>
<li><strong>Composition.</strong> LAB is a mix of homologues (n = 10-13); I used the
literature mean, H/C = 1.65 at 0.86 g/cm3. If there is a supplier spec for
the LAB being procured, those numbers should replace mine.</li>
<li><strong>Reproducibility.</strong> Earlier samples reproduce by setting <code>sensitiveMed</code>
back to <code>"Scintillator"</code> — no new switch needed, and with the <code>InitMedium</code>
fix that path now works properly rather than by coincidence.</li>
<li><strong>Thresholds.</strong> Any SBT threshold tuned against the old material should be
revisited. Flagged, not changed here.</li>
<li><strong>Optical properties.</strong> <code>npckov = 0</code>, as before — no scintillation or
Cherenkov photon transport. <code>Marcol82</code> is the template if that is added.</li>
<li><strong>Out of scope, tracked in #XXXX:</strong> <code>supportMedIn_name</code>,
<code>supportMedOut_name</code> and <code>decayVolumeMed_name</code> have the same null-medium
hazard, working only because the remaining hardcoded <code>InitMedium</code> calls
happen to cover the configured values; <code>fLiquidVeto</code> is written but never
read; and <code>macro/eventDisplay.py</code> gates <code>hidePlasticScintillator()</code> on a
volume named <code>T2LiSc</code>. The same plastic/liquid confusion, in three places.</li>
</ol>
<h2>Checklist</h2>
<ul>
<li>[x] <code>Scintillator</code> unchanged; SplitCal unaffected</li>
<li>[x] UBT unaffected (separate class, vacuum box)</li>
<li>[x] Both veto configs updated</li>
<li>[x] CHANGELOG entry added</li>
<li>[ ] Geometry builds and the new material resolves as expected</li>
<li>[ ] CI reference comparison passes or updated with rationale</li>
</ul></body></html>