### PR TITLE
Adding a pvc vessel to contain helium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ it in future.
 
 ### Changed
 
+* He Balloon added with configurable thickness and material. 
 * SBT sensitive medium is now LAB-based liquid scintillator (`LiquidScintillator`) rather than the plastic `Scintillator`, which remains in use by SplitCal
 * Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
 
 ### Fixed
 
+* All materials in the veto class now registers the configured media instead of a hardcoded medium name.
 * `veto` now registers the configured `sensitiveMed` instead of a hardcoded medium name; previously any other value resolved to a null `TGeoMedium`
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ it in future.
 
 ### Added
 
+* He Balloon added with configurable thickness and material.
 * 2026 BDF target design (33 pure tungsten disks with a larger rear block, steel core with serpentine He cooling grooves, jacket tube, flanges, upstream beam window and cover plate, and domed rear endcap), extracted from CATIA model ST1A07710_01_AB.02. Select with `--target-yaml geometry/target_config_2026.yaml`; the legacy design remains the default. Downstream elements are positioned using the nominal legacy target length so both designs can be compared directly.
 
 ### Changed
-
-* He Balloon added with configurable thickness and material. 
+ 
 * SBT sensitive medium is now LAB-based liquid scintillator (`LiquidScintillator`) rather than the plastic `Scintillator`, which remains in use by SplitCal
 * Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
 * Deduplicate the charm/beauty over min-bias cross-section scaling shared by `makeDecay` and `run_fixedTarget` into `python/heavyFlavourScaling.py`
@@ -27,7 +27,6 @@ it in future.
 
 ### Fixed
 
-* All materials in the veto class now registers the configured media instead of a hardcoded medium name.
 * `veto` now registers the configured `sensitiveMed` instead of a hardcoded medium name; previously any other value resolved to a null `TGeoMedium`
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ it in future.
 * 2026 BDF target design (33 pure tungsten disks with a larger rear block, steel core with serpentine He cooling grooves, jacket tube, flanges, upstream beam window and cover plate, and domed rear endcap), extracted from CATIA model ST1A07710_01_AB.02. Select with `--target-yaml geometry/target_config_2026.yaml`; the legacy design remains the default. Downstream elements are positioned using the nominal legacy target length so both designs can be compared directly.
 
 ### Changed
- 
+
+* Fiducial volume "DecayVacuum_block{N}" renamed as "decay_medium_block{N}".
 * SBT sensitive medium is now LAB-based liquid scintillator (`LiquidScintillator`) rather than the plastic `Scintillator`, which remains in use by SplitCal
 * Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
 * Deduplicate the charm/beauty over min-bias cross-section scaling shared by `makeDecay` and `run_fixedTarget` into `python/heavyFlavourScaling.py`

--- a/geometry/veto_config_helium.yaml
+++ b/geometry/veto_config_helium.yaml
@@ -8,6 +8,8 @@ lidThickness: 0.0 # cm
 sensitiveThickness: 20 # cm
 sensitiveMed: "LiquidScintillator"
 decayMed: "helium"
+he_balloon_thickness: 0.1 # cm
+he_balloon_med: "PVC"
 rib: 1.5 # cm
 ribMed: "Aluminium"
 xstartInner: 100.0 # cm

--- a/geometry/veto_config_vacuums.yaml
+++ b/geometry/veto_config_vacuums.yaml
@@ -8,6 +8,8 @@ lidThickness: 0.0 # cm
 sensitiveThickness: 20 # cm
 sensitiveMed: "LiquidScintillator"
 decayMed: "vacuums"
+he_balloon_thickness: 0.1 # cm
+he_balloon_med: "PVC"
 rib: 1.5 # cm
 ribMed: "steel"
 xstartInner: 100.0 # cm

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -227,7 +227,7 @@ def dist2InnerWall(X, Y, Z):
     dist = 0
     # return distance to inner wall perpendicular to z-axis, if outside decayVolume return 0.
     node = sGeo.FindNode(X, Y, Z)
-    if "DecayVacuum" not in node.GetName():
+    if "decay_medium" not in node.GetName():
         return dist
     start = array("d", [X, Y, Z])
     nsteps = 8

--- a/python/experimental/analysis_toolkit.py
+++ b/python/experimental/analysis_toolkit.py
@@ -187,7 +187,7 @@ class selection_check:
 
         vertex_node = ROOT.gGeoManager.FindNode(candidate_pos.X(), candidate_pos.Y(), candidate_pos.Z())
         vertex_elem = vertex_node.GetVolume().GetName()
-        return vertex_elem.startswith("DecayVacuum_")
+        return vertex_elem.startswith("decay_medium_")
 
     def chi2nDOF(self, candidate):
         """Return the reduced chi^2 of the particle's daughter tracks."""

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -207,7 +207,7 @@ def configure_veto(yaml_file: str, z0) -> None:
         veto_geo.decayMed,
         veto_geo.rib,
         veto_geo.he_balloon_thickness,
-        veto_geo.he_balloon_med
+        veto_geo.he_balloon_med,
     )
 
     detectorList.append(Veto)

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -206,6 +206,8 @@ def configure_veto(yaml_file: str, z0) -> None:
         veto_geo.outerSupportMed,
         veto_geo.decayMed,
         veto_geo.rib,
+        veto_geo.he_balloon_thickness,
+        veto_geo.he_balloon_med
     )
 
     detectorList.append(Veto)

--- a/python/shipVeto.py
+++ b/python/shipVeto.py
@@ -121,11 +121,11 @@ class Task:
         if aNode:
             cNode = aNode.GetName()
         if cNode not in (
-            "DecayVacuum_block4_0",
-            "DecayVacuum_block5_0",
-            "DecayVacuum_block3_0",
-            "DecayVacuum_block2_0",
-            "DecayVacuum_block1_0",
+            "decay_medium_block4_0",
+            "decay_medium_block5_0",
+            "decay_medium_block3_0",
+            "decay_medium_block2_0",
+            "decay_medium_block1_0",
         ):
             distmin = 0.0
         else:

--- a/stubs/ROOT/__init__.pyi
+++ b/stubs/ROOT/__init__.pyi
@@ -1257,6 +1257,8 @@ class veto:  # Partial stub
         outerSupportMed: str,
         decayMed: str,
         rib: float,
+        he_balloon_thickness: float,
+        he_balloon_med: str,
     ) -> None: ...
     def GetName(self) -> str: ...
 

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -396,62 +396,57 @@ void veto::AddBlock(TGeoVolumeAssembly* tInnerWall,
                          wy(z1), wy(z2),
                          ribColor, supportMedIn);
   tInnerWall->AddNode(TIW, 0, new TGeoTranslation(0, 0, Zshift));
-  
+
   /// PVC He Balloon
-  /// First block geom (first 80 cm)
-  if (blockNr == 1){
-    /// PVC walls
-    TString pvc_layer_name = "pvc_walls_" + blockName;
-    TGeoVolume* pvc_walls = GeoTrapezoidHollow(pvc_layer_name, f_he_balloon_thickness, wz - f_he_balloon_thickness, 
-                                          wx(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wx(z2) - 2 *f_he_balloon_thickness, 
-                                          wy(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wy(z2) - 2 *f_he_balloon_thickness, 
-                                          kGreen, f_he_balloon_med);
-    tHeBalloon->AddNode(pvc_walls, 0, new TGeoTranslation(0, 0, Zshift + f_he_balloon_thickness/2));
+  TString lid_name;
+  Double_t z_start_wall, z_end_wall, z_start_lid, z_end_lid, wall_shift, lid_shift;
 
-    /// PVC front lid 
-    TString pvc_front_lid_name = "pvc_front_lid";
-    TGeoVolume* pvc_front_lid = GeoTrapezoid(pvc_front_lid_name, f_he_balloon_thickness, 
-                                          wx(z1), wx(z1 + f_he_balloon_thickness), 
-                                          wy(z1), wy(z1 + f_he_balloon_thickness), 
-                                          kGreen, f_he_balloon_med);
-    tHeBalloon->AddNode(pvc_front_lid, 0, new TGeoTranslation(0, 0, Zshift - wz/2 + f_he_balloon_thickness/2));
-
-    /// decay medium
-    TString nameDecayVol = "decay_medium_" + blockName;
-    TGeoVolume* decay_volume = GeoTrapezoid(nameDecayVol, wz - f_he_balloon_thickness,
-                                  wx(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wx(z2) - 2 *f_he_balloon_thickness,
-                                  wy(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wy(z2) - 2 *f_he_balloon_thickness,
-                                  1, decayVolumeMed);
-    decay_volume->SetVisibility(kFALSE);
-    tHeBalloon->AddNode(decay_volume, 0, new TGeoTranslation(0, 0, Zshift + f_he_balloon_thickness/2));
+  // Encoding the geometry of each block
+  if (blockNr == 1) {
+      lid_name     = "pvc_front_lid";
+      z_start_wall = z1 + f_he_balloon_thickness;
+      z_end_wall   = z2;
+      z_start_lid  = z1;
+      z_end_lid    = z1 + f_he_balloon_thickness;
+      wall_shift   = Zshift + f_he_balloon_thickness / 2;
+      lid_shift    = Zshift - wz / 2 + f_he_balloon_thickness / 2;
+  } 
+  else if (blockNr == 2) {
+      lid_name     = "pvc_back_lid";
+      z_start_wall = z1;
+      z_end_wall   = z2 - f_he_balloon_thickness;
+      z_start_lid  = z2 - f_he_balloon_thickness;
+      z_end_lid    = z2;
+      wall_shift   = Zshift - f_he_balloon_thickness / 2;
+      lid_shift    = Zshift + wz / 2 - f_he_balloon_thickness / 2;
   }
 
-  /// Second block geom (next 49.2 m)
-  if (blockNr == 2){
-    /// PVC walls
-    TString pvc_layer_name = "pvc_walls_" + blockName;
-    TGeoVolume* pvc_walls = GeoTrapezoidHollow(pvc_layer_name, f_he_balloon_thickness, wz - f_he_balloon_thickness, 
-                                          wx(z1) - 2 *f_he_balloon_thickness, wx(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness, 
-                                          wy(z1) - 2 *f_he_balloon_thickness, wy(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness, 
-                                          kGreen, f_he_balloon_med);
-    tHeBalloon->AddNode(pvc_walls, 0, new TGeoTranslation(0, 0, Zshift - f_he_balloon_thickness/2));
+  // Build the geometry once 
+  if (blockNr == 1 || blockNr == 2) {
+      
+      /// PVC walls
+      TString pvc_layer_name = "pvc_walls_" + blockName;
+      TGeoVolume* pvc_walls = GeoTrapezoidHollow(pvc_layer_name, f_he_balloon_thickness, wz - f_he_balloon_thickness, 
+                                            wx(z_start_wall) - 2 * f_he_balloon_thickness, wx(z_end_wall) - 2 * f_he_balloon_thickness, 
+                                            wy(z_start_wall) - 2 * f_he_balloon_thickness, wy(z_end_wall) - 2 * f_he_balloon_thickness, 
+                                            kGreen, f_he_balloon_med);
+      tHeBalloon->AddNode(pvc_walls, 0, new TGeoTranslation(0, 0, wall_shift));
 
-    /// PVC back lid
-    TString pvc_back_lid_name = "pvc_back_lid";
-    TGeoVolume* pvc_back_lid = GeoTrapezoid(pvc_back_lid_name, f_he_balloon_thickness, 
-                                          wx(z2 - f_he_balloon_thickness), wx(z2), 
-                                          wy(z2 - f_he_balloon_thickness), wy(z2), 
-                                          kGreen, f_he_balloon_med);
-    tHeBalloon->AddNode(pvc_back_lid, 0, new TGeoTranslation(0, 0, Zshift + wz/2 - f_he_balloon_thickness/2));
+      /// PVC lid (Front or Back depending on blockNr)
+      TGeoVolume* pvc_lid = GeoTrapezoid(lid_name, f_he_balloon_thickness, 
+                                            wx(z_start_lid), wx(z_end_lid), 
+                                            wy(z_start_lid), wy(z_end_lid), 
+                                            kGreen, f_he_balloon_med);
+      tHeBalloon->AddNode(pvc_lid, 0, new TGeoTranslation(0, 0, lid_shift));
 
-    /// decay medium
-    TString nameDecayVol = "decay_medium_" + blockName;
-    TGeoVolume* decay_volume = GeoTrapezoid(nameDecayVol, wz - f_he_balloon_thickness,
-                                  wx(z1) - 2 *f_he_balloon_thickness, wx(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness,
-                                  wy(z1) - 2 *f_he_balloon_thickness, wy(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness,
-                                  1, decayVolumeMed);
-    decay_volume->SetVisibility(kFALSE);
-    tHeBalloon->AddNode(decay_volume, 0, new TGeoTranslation(0, 0, Zshift - f_he_balloon_thickness/2));
+      /// decay medium
+      TString nameDecayVol = "decay_medium_" + blockName;
+      TGeoVolume* decay_volume = GeoTrapezoid(nameDecayVol, wz - f_he_balloon_thickness,
+                                            wx(z_start_wall) - 2 * f_he_balloon_thickness, wx(z_end_wall) - 2 * f_he_balloon_thickness,
+                                            wy(z_start_wall) - 2 * f_he_balloon_thickness, wy(z_end_wall) - 2 * f_he_balloon_thickness,
+                                            1, decayVolumeMed);
+      decay_volume->SetVisibility(kFALSE);
+      tHeBalloon->AddNode(decay_volume, 0, new TGeoTranslation(0, 0, wall_shift));
   }
 
   /// outer wall

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -364,7 +364,7 @@ int veto::liscId(const TString& ShapeTypeName, int blockNr, int Zlayer,
 }
 
 void veto::AddBlock(TGeoVolumeAssembly* tInnerWall,
-                    TGeoVolumeAssembly* tDecayVacuum,
+                    TGeoVolumeAssembly* tHeBalloon,
                     TGeoVolumeAssembly* tOuterWall,
                     TGeoVolumeAssembly* tLongitRib,
                     TGeoVolumeAssembly* tVerticalRib,
@@ -391,16 +391,68 @@ void veto::AddBlock(TGeoVolumeAssembly* tInnerWall,
   /// inner wall
   TString nameInnerWall = (TString)tInnerWall->GetName() + "_" + blockName;
   TGeoVolume* TIW =
-      GeoTrapezoidHollow(nameInnerWall, wallThick, wz, wx(z1), wx(z2), wy(z1),
-                         wy(z2), ribColor, supportMedIn);
+      GeoTrapezoidHollow(nameInnerWall, wallThick, wz,
+                         wx(z1), wx(z2),
+                         wy(z1), wy(z2),
+                         ribColor, supportMedIn);
   tInnerWall->AddNode(TIW, 0, new TGeoTranslation(0, 0, Zshift));
+  
+  /// PVC He Balloon
+  /// First block geom (first 80 cm)
+  if (blockNr == 1){
+    /// PVC walls
+    TString pvc_layer_name = "pvc_walls_" + blockName;
+    TGeoVolume* pvc_walls = GeoTrapezoidHollow(pvc_layer_name, f_he_balloon_thickness, wz - f_he_balloon_thickness, 
+                                          wx(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wx(z2) - 2 *f_he_balloon_thickness, 
+                                          wy(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wy(z2) - 2 *f_he_balloon_thickness, 
+                                          kGreen, f_he_balloon_med);
+    tHeBalloon->AddNode(pvc_walls, 0, new TGeoTranslation(0, 0, Zshift + f_he_balloon_thickness/2));
 
-  /// decay vacuum
-  TString nameDecayVacuum = (TString)tDecayVacuum->GetName() + "_" + blockName;
-  TGeoVolume* TDV = GeoTrapezoid(nameDecayVacuum, wz, wx(z1), wx(z2), wy(z1),
-                                 wy(z2), 1, decayVolumeMed);
-  TDV->SetVisibility(kFALSE);
-  tDecayVacuum->AddNode(TDV, 0, new TGeoTranslation(0, 0, Zshift));
+    /// PVC front lid 
+    TString pvc_front_lid_name = "pvc_front_lid";
+    TGeoVolume* pvc_front_lid = GeoTrapezoid(pvc_front_lid_name, f_he_balloon_thickness, 
+                                          wx(z1), wx(z1 + f_he_balloon_thickness), 
+                                          wy(z1), wy(z1 + f_he_balloon_thickness), 
+                                          kGreen, f_he_balloon_med);
+    tHeBalloon->AddNode(pvc_front_lid, 0, new TGeoTranslation(0, 0, Zshift - wz/2 + f_he_balloon_thickness/2));
+
+    /// decay medium
+    TString nameDecayVol = "decay_medium_" + blockName;
+    TGeoVolume* decay_volume = GeoTrapezoid(nameDecayVol, wz - f_he_balloon_thickness,
+                                  wx(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wx(z2) - 2 *f_he_balloon_thickness,
+                                  wy(z1 + f_he_balloon_thickness) - 2 *f_he_balloon_thickness, wy(z2) - 2 *f_he_balloon_thickness,
+                                  1, decayVolumeMed);
+    decay_volume->SetVisibility(kFALSE);
+    tHeBalloon->AddNode(decay_volume, 0, new TGeoTranslation(0, 0, Zshift + f_he_balloon_thickness/2));
+  }
+
+  /// Second block geom (next 49.2 m)
+  if (blockNr == 2){
+    /// PVC walls
+    TString pvc_layer_name = "pvc_walls_" + blockName;
+    TGeoVolume* pvc_walls = GeoTrapezoidHollow(pvc_layer_name, f_he_balloon_thickness, wz - f_he_balloon_thickness, 
+                                          wx(z1) - 2 *f_he_balloon_thickness, wx(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness, 
+                                          wy(z1) - 2 *f_he_balloon_thickness, wy(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness, 
+                                          kGreen, f_he_balloon_med);
+    tHeBalloon->AddNode(pvc_walls, 0, new TGeoTranslation(0, 0, Zshift - f_he_balloon_thickness/2));
+
+    /// PVC back lid
+    TString pvc_back_lid_name = "pvc_back_lid";
+    TGeoVolume* pvc_back_lid = GeoTrapezoid(pvc_back_lid_name, f_he_balloon_thickness, 
+                                          wx(z2 - f_he_balloon_thickness), wx(z2), 
+                                          wy(z2 - f_he_balloon_thickness), wy(z2), 
+                                          kGreen, f_he_balloon_med);
+    tHeBalloon->AddNode(pvc_back_lid, 0, new TGeoTranslation(0, 0, Zshift + wz/2 - f_he_balloon_thickness/2));
+
+    /// decay medium
+    TString nameDecayVol = "decay_medium_" + blockName;
+    TGeoVolume* decay_volume = GeoTrapezoid(nameDecayVol, wz - f_he_balloon_thickness,
+                                  wx(z1) - 2 *f_he_balloon_thickness, wx(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness,
+                                  wy(z1) - 2 *f_he_balloon_thickness, wy(z2 - f_he_balloon_thickness) - 2 *f_he_balloon_thickness,
+                                  1, decayVolumeMed);
+    decay_volume->SetVisibility(kFALSE);
+    tHeBalloon->AddNode(decay_volume, 0, new TGeoTranslation(0, 0, Zshift - f_he_balloon_thickness/2));
+  }
 
   /// outer wall
   TString nameOuterWall = (TString)tOuterWall->GetName() + "_" + blockName;
@@ -412,7 +464,6 @@ void veto::AddBlock(TGeoVolumeAssembly* tInnerWall,
   tOuterWall->AddNode(TOW, 0, new TGeoTranslation(0, 0, Zshift));
 
   /// define longitudinal ribs
-
   std::vector<TGeoVolume*> vLongitRibX(nx);
   std::vector<TGeoVolume*> vLongitRibY(ny);
 
@@ -677,8 +728,8 @@ TGeoVolume* veto::MakeSegments() {
   TString nameInnerWall = "VetoInnerWall";
   TGeoVolumeAssembly* tInnerWall = new TGeoVolumeAssembly(nameInnerWall);
 
-  TString nameDecayVacuum = "DecayVacuum";
-  TGeoVolumeAssembly* tDecayVacuum = new TGeoVolumeAssembly(nameDecayVacuum);
+  TString nameDecayVol = "HeBalloon";
+  TGeoVolumeAssembly* tHeBalloon = new TGeoVolumeAssembly(nameDecayVol);
 
   TString nameOuterWall = "VetoOuterWall";
   TGeoVolumeAssembly* tOuterWall = new TGeoVolumeAssembly(nameOuterWall);
@@ -707,7 +758,7 @@ TGeoVolume* veto::MakeSegments() {
 
   double Zshift = wz / 2;  // calibration of Z position
 
-  AddBlock(tInnerWall, tDecayVacuum, tOuterWall, tLongitRib, tVerticalRib,
+  AddBlock(tInnerWall, tHeBalloon, tOuterWall, tLongitRib, tVerticalRib,
            ttLiSc, 1, nx, ny, z1, z2, Zshift, cell_thickness_z0, wallThick,
            liscThick, liscThick, ribThick);
 
@@ -722,7 +773,7 @@ TGeoVolume* veto::MakeSegments() {
 
   Zshift += wz / 2;
 
-  AddBlock(tInnerWall, tDecayVacuum, tOuterWall, tLongitRib, tVerticalRib,
+  AddBlock(tInnerWall, tHeBalloon, tOuterWall, tLongitRib, tVerticalRib,
            ttLiSc, 2, nx, ny, z1, z2, Zshift, cell_thickness_z, wallThick,
            liscThick, liscThick, ribThick);
 
@@ -739,7 +790,7 @@ TGeoVolume* veto::MakeSegments() {
   tVerticalRib->AddNode(TVR, 0, new TGeoTranslation(0, 0, tZ));
 
   tTankVol->AddNode(tInnerWall, 0, new TGeoTranslation(0, 0, 0));
-  tTankVol->AddNode(tDecayVacuum, 0, new TGeoTranslation(0, 0, 0));
+  tTankVol->AddNode(tHeBalloon, 0, new TGeoTranslation(0, 0, 0));
   tTankVol->AddNode(tOuterWall, 0, new TGeoTranslation(0, 0, 0));
   tTankVol->AddNode(tVerticalRib, 0, new TGeoTranslation(0, 0, 0));
   tTankVol->AddNode(tLongitRib, 0, new TGeoTranslation(0, 0, 0));
@@ -828,11 +879,11 @@ void veto::PreTrack() {
 void veto::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
 
-  ShipGeo::InitMedium("vacuums");
-  ShipGeo::InitMedium("Aluminium");
-  ShipGeo::InitMedium("helium");
+  ShipGeo::InitMedium(supportMedOut_name.Data());
+  ShipGeo::InitMedium(supportMedIn_name.Data());
   ShipGeo::InitMedium(vetoMed_name.Data());
-  ShipGeo::InitMedium("steel");
+  ShipGeo::InitMedium(decayVolumeMed_name.Data());
+  ShipGeo::InitMedium(f_he_balloon_med_name.Data());
 
   gGeoManager->SetNsegments(100);
 
@@ -844,6 +895,8 @@ void veto::ConstructGeometry() {
       supportMedOut_name);  //! medium of support structure, aluminium, balloon
   decayVolumeMed = gGeoManager->GetMedium(
       decayVolumeMed_name);  // decay volume, air/helium/vacuum
+  f_he_balloon_med = gGeoManager->GetMedium(
+      f_he_balloon_med_name);  // He Balloon medium, pvc
   LOG(info) << "veto: Decay Volume medium set as: " << decayVolumeMed_name;
   TGeoVolume* tDecayVol = new TGeoVolumeAssembly("DecayVolume");
 

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -391,62 +391,68 @@ void veto::AddBlock(TGeoVolumeAssembly* tInnerWall,
   /// inner wall
   TString nameInnerWall = (TString)tInnerWall->GetName() + "_" + blockName;
   TGeoVolume* TIW =
-      GeoTrapezoidHollow(nameInnerWall, wallThick, wz,
-                         wx(z1), wx(z2),
-                         wy(z1), wy(z2),
-                         ribColor, supportMedIn);
+      GeoTrapezoidHollow(nameInnerWall, wallThick, wz, wx(z1), wx(z2), wy(z1),
+                         wy(z2), ribColor, supportMedIn);
   tInnerWall->AddNode(TIW, 0, new TGeoTranslation(0, 0, Zshift));
 
   /// PVC He Balloon
   TString lid_name;
-  Double_t z_start_wall, z_end_wall, z_start_lid, z_end_lid, wall_shift, lid_shift;
+  Double_t z_start_wall, z_end_wall, z_start_lid, z_end_lid, wall_shift,
+      lid_shift;
 
   // Encoding the geometry of each block
   if (blockNr == 1) {
-      lid_name     = "pvc_front_lid";
-      z_start_wall = z1 + f_he_balloon_thickness;
-      z_end_wall   = z2;
-      z_start_lid  = z1;
-      z_end_lid    = z1 + f_he_balloon_thickness;
-      wall_shift   = Zshift + f_he_balloon_thickness / 2;
-      lid_shift    = Zshift - wz / 2 + f_he_balloon_thickness / 2;
-  } 
-  else if (blockNr == 2) {
-      lid_name     = "pvc_back_lid";
-      z_start_wall = z1;
-      z_end_wall   = z2 - f_he_balloon_thickness;
-      z_start_lid  = z2 - f_he_balloon_thickness;
-      z_end_lid    = z2;
-      wall_shift   = Zshift - f_he_balloon_thickness / 2;
-      lid_shift    = Zshift + wz / 2 - f_he_balloon_thickness / 2;
+    lid_name = "pvc_front_lid";
+    z_start_wall = z1 + f_he_balloon_thickness;
+    z_end_wall = z2;
+    z_start_lid = z1;
+    z_end_lid = z1 + f_he_balloon_thickness;
+    wall_shift = Zshift + f_he_balloon_thickness / 2;
+    lid_shift = Zshift - wz / 2 + f_he_balloon_thickness / 2;
+  } else if (blockNr == 2) {
+    lid_name = "pvc_back_lid";
+    z_start_wall = z1;
+    z_end_wall = z2 - f_he_balloon_thickness;
+    z_start_lid = z2 - f_he_balloon_thickness;
+    z_end_lid = z2;
+    wall_shift = Zshift - f_he_balloon_thickness / 2;
+    lid_shift = Zshift + wz / 2 - f_he_balloon_thickness / 2;
   }
 
-  // Build the geometry once 
+  // Build the geometry once
   if (blockNr == 1 || blockNr == 2) {
-      
-      /// PVC walls
-      TString pvc_layer_name = "pvc_walls_" + blockName;
-      TGeoVolume* pvc_walls = GeoTrapezoidHollow(pvc_layer_name, f_he_balloon_thickness, wz - f_he_balloon_thickness, 
-                                            wx(z_start_wall) - 2 * f_he_balloon_thickness, wx(z_end_wall) - 2 * f_he_balloon_thickness, 
-                                            wy(z_start_wall) - 2 * f_he_balloon_thickness, wy(z_end_wall) - 2 * f_he_balloon_thickness, 
-                                            kGreen, f_he_balloon_med);
-      tHeBalloon->AddNode(pvc_walls, 0, new TGeoTranslation(0, 0, wall_shift));
+    /// PVC walls
+    TString pvc_layer_name = "pvc_walls_" + blockName;
+    TGeoVolume* pvc_walls = GeoTrapezoidHollow(
+        pvc_layer_name, f_he_balloon_thickness, wz - f_he_balloon_thickness,
+        wx(z_start_wall) - 2 * f_he_balloon_thickness,
+        wx(z_end_wall) - 2 * f_he_balloon_thickness,
+        wy(z_start_wall) - 2 * f_he_balloon_thickness,
+        wy(z_end_wall) - 2 * f_he_balloon_thickness, kGreen, f_he_balloon_med);
+    tHeBalloon->AddNode(pvc_walls, 0, new TGeoTranslation(0, 0, wall_shift));
 
-      /// PVC lid (Front or Back depending on blockNr)
-      TGeoVolume* pvc_lid = GeoTrapezoid(lid_name, f_he_balloon_thickness, 
-                                            wx(z_start_lid), wx(z_end_lid), 
-                                            wy(z_start_lid), wy(z_end_lid), 
-                                            kGreen, f_he_balloon_med);
-      tHeBalloon->AddNode(pvc_lid, 0, new TGeoTranslation(0, 0, lid_shift));
+    /// PVC lid (Front or Back depending on blockNr)
+    TGeoVolume* pvc_lid = GeoTrapezoid(
+        lid_name, f_he_balloon_thickness, wx(z_start_lid), wx(z_end_lid),
+        wy(z_start_lid), wy(z_end_lid), kGreen, f_he_balloon_med);
+    tHeBalloon->AddNode(pvc_lid, 0, new TGeoTranslation(0, 0, lid_shift));
 
-      /// decay medium
-      TString nameDecayVol = "decay_medium_" + blockName;
-      TGeoVolume* decay_volume = GeoTrapezoid(nameDecayVol, wz - f_he_balloon_thickness,
-                                            wx(z_start_wall) - 2 * f_he_balloon_thickness, wx(z_end_wall) - 2 * f_he_balloon_thickness,
-                                            wy(z_start_wall) - 2 * f_he_balloon_thickness, wy(z_end_wall) - 2 * f_he_balloon_thickness,
-                                            1, decayVolumeMed);
-      decay_volume->SetVisibility(kFALSE);
-      tHeBalloon->AddNode(decay_volume, 0, new TGeoTranslation(0, 0, wall_shift));
+    /// decay medium
+    TString nameDecayVol = "decay_medium_" + blockName;
+    TGeoVolume* decay_volume = GeoTrapezoid(
+        nameDecayVol, wz - f_he_balloon_thickness,
+        wx(z_start_wall) - 2 * f_he_balloon_thickness,
+        wx(z_end_wall) - 2 * f_he_balloon_thickness,
+        wy(z_start_wall) - 2 * f_he_balloon_thickness,
+        wy(z_end_wall) - 2 * f_he_balloon_thickness, 1, decayVolumeMed);
+    decay_volume->SetVisibility(kFALSE);
+    tHeBalloon->AddNode(decay_volume, 0, new TGeoTranslation(0, 0, wall_shift));
+  }
+
+  else {
+    LOG(fatal)
+        << "veto::AddBlock: Invalid blockNr " << blockNr
+        << " requested. Only blockNr 1 and 2 are supported for the He balloon!";
   }
 
   /// outer wall
@@ -753,9 +759,9 @@ TGeoVolume* veto::MakeSegments() {
 
   double Zshift = wz / 2;  // calibration of Z position
 
-  AddBlock(tInnerWall, tHeBalloon, tOuterWall, tLongitRib, tVerticalRib,
-           ttLiSc, 1, nx, ny, z1, z2, Zshift, cell_thickness_z0, wallThick,
-           liscThick, liscThick, ribThick);
+  AddBlock(tInnerWall, tHeBalloon, tOuterWall, tLongitRib, tVerticalRib, ttLiSc,
+           1, nx, ny, z1, z2, Zshift, cell_thickness_z0, wallThick, liscThick,
+           liscThick, ribThick);
 
   //******************************** Block2
   //**************************************
@@ -768,9 +774,9 @@ TGeoVolume* veto::MakeSegments() {
 
   Zshift += wz / 2;
 
-  AddBlock(tInnerWall, tHeBalloon, tOuterWall, tLongitRib, tVerticalRib,
-           ttLiSc, 2, nx, ny, z1, z2, Zshift, cell_thickness_z, wallThick,
-           liscThick, liscThick, ribThick);
+  AddBlock(tInnerWall, tHeBalloon, tOuterWall, tLongitRib, tVerticalRib, ttLiSc,
+           2, nx, ny, z1, z2, Zshift, cell_thickness_z, wallThick, liscThick,
+           liscThick, ribThick);
 
   double zi = z2;
 
@@ -890,8 +896,8 @@ void veto::ConstructGeometry() {
       supportMedOut_name);  //! medium of support structure, aluminium, balloon
   decayVolumeMed = gGeoManager->GetMedium(
       decayVolumeMed_name);  // decay volume, air/helium/vacuum
-  f_he_balloon_med = gGeoManager->GetMedium(
-      f_he_balloon_med_name);  // He Balloon medium, pvc
+  f_he_balloon_med =
+      gGeoManager->GetMedium(f_he_balloon_med_name);  // He Balloon medium, pvc
   LOG(info) << "veto: Decay Volume medium set as: " << decayVolumeMed_name;
   TGeoVolume* tDecayVol = new TGeoVolumeAssembly("DecayVolume");
 

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -58,7 +58,9 @@ class veto : public SHiP::Detector<vetoPoint> {
   void ConstructGeometry() override;
 
   void SetVesselStructure(Float_t a, Float_t b, Float_t c, TString d, Float_t l,
-                          TString e, TString f, TString v, Float_t r, Float_t he_balloon_thickness, TString he_balloon_med) {
+                          TString e, TString f, TString v, Float_t r,
+                          Float_t he_balloon_thickness,
+                          TString he_balloon_med) {
     f_InnerSupportThickness = a;
     f_VetoThickness = b;
     f_OuterSupportThickness = c;
@@ -99,7 +101,7 @@ class veto : public SHiP::Detector<vetoPoint> {
   //! Thickness of the liquid scintillator along z(Default = 20cm).
   Float_t f_VetoThickness;
   Float_t f_RibThickness;
-  //! Thickness of the He Balloon 
+  //! Thickness of the He Balloon
   Float_t f_he_balloon_thickness;
 
   //! medium of veto counter, liquid or plastic scintillator
@@ -161,7 +163,7 @@ class veto : public SHiP::Detector<vetoPoint> {
    * distance along z. Ensures consistency in implementation throughout the z.
    */
   void AddBlock(TGeoVolumeAssembly* tInnerWall,
-                TGeoVolumeAssembly* tDecayVacuum,
+                TGeoVolumeAssembly* tdecay_medium,
                 TGeoVolumeAssembly* tOuterWall, TGeoVolumeAssembly* tLongitRib,
                 TGeoVolumeAssembly* tVerticalRib, TGeoVolumeAssembly* ttLiSc,
                 int blockNr, int nx, int ny, double z1, double z2,

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -58,7 +58,7 @@ class veto : public SHiP::Detector<vetoPoint> {
   void ConstructGeometry() override;
 
   void SetVesselStructure(Float_t a, Float_t b, Float_t c, TString d, Float_t l,
-                          TString e, TString f, TString v, Float_t r) {
+                          TString e, TString f, TString v, Float_t r, Float_t he_balloon_thickness, TString he_balloon_med) {
     f_InnerSupportThickness = a;
     f_VetoThickness = b;
     f_OuterSupportThickness = c;
@@ -68,6 +68,8 @@ class veto : public SHiP::Detector<vetoPoint> {
     supportMedOut_name = std::move(f);
     decayVolumeMed_name = std::move(v);
     f_RibThickness = r;
+    f_he_balloon_thickness = he_balloon_thickness;
+    f_he_balloon_med_name = std::move(he_balloon_med);
   }
 
   /** The following methods can be implemented if you need to make
@@ -97,6 +99,8 @@ class veto : public SHiP::Detector<vetoPoint> {
   //! Thickness of the liquid scintillator along z(Default = 20cm).
   Float_t f_VetoThickness;
   Float_t f_RibThickness;
+  //! Thickness of the He Balloon 
+  Float_t f_he_balloon_thickness;
 
   //! medium of veto counter, liquid or plastic scintillator
   TString vetoMed_name;
@@ -106,11 +110,14 @@ class veto : public SHiP::Detector<vetoPoint> {
   TString supportMedOut_name;
   //! medium of decay volume(Default= helium).
   TString decayVolumeMed_name;
+  //! medium of He Balloon(Default= PVC).
+  TString f_he_balloon_med_name;
 
   TGeoMedium* vetoMed;
   TGeoMedium* supportMedIn;
   TGeoMedium* supportMedOut;
   TGeoMedium* decayVolumeMed;
+  TGeoMedium* f_he_balloon_med;
 
   //! Width of the Vessel along X at the start
   Float_t VetoStartInnerX;


### PR DESCRIPTION
## Checklist

- Modified the veto/veto.cxx file to include per block 1 TropezoidHollow(), 1 Tropezoid() made out of 1 mm thick pvc. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helium-balloon assemblies for both detector blocks.
  * Added configurable helium-balloon thickness and material settings.
  * Added PVC shielding with block-specific side walls and front/rear lids.
  * Added support for selecting the 2026 BDF target design and comparing it with the legacy target.
  * Added hidden decay-medium volumes within the detector assembly.

* **Bug Fixes**
  * Updated fiducial-volume and wall-distance checks to recognize revised decay-medium geometry names.

* **Documentation**
  * Updated the changelog with target-design and configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->