### PR TITLE
refactor: share heavy-flavour cross-section scaling between macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ it in future.
 
 * SBT sensitive medium is now LAB-based liquid scintillator (`LiquidScintillator`) rather than the plastic `Scintillator`, which remains in use by SplitCal
 * Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
+* Deduplicate the charm/beauty over min-bias cross-section scaling shared by `makeDecay` and `run_fixedTarget` into `python/heavyFlavourScaling.py`
 
 ### Fixed
 

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -8,19 +8,10 @@ import os
 
 import ROOT
 import rootUtils as ut
+from heavyFlavourScaling import derive_cross_sections, format_summary
 
 ROOT.gROOT.LoadMacro("$VMCWORKDIR/gconfig/basiclibs.C")
 ROOT.basiclibs()
-
-# Reference values for Molybdenum (historical defaults). Cross-section ratios
-# scale heavy-flavour ~ A and mbias ~ A^(0.71).
-heavyflavour_Ascale = 1
-mbias_Ascale = 0.71
-
-A_REF = 98.0
-CHICC_REF = 1.7e-3  # prob to produce primary ccbar pair/pot on Mo
-CHIBB_REF = 1.6e-7  # prob to produce primary bbbar pair/pot on Mo
-TARGET_A = {"W": 184.0, "Mo": 98.0}
 
 ap = argparse.ArgumentParser(description="Decay charm/beauty signals from makeCascade output with Pythia8")
 ap.add_argument(
@@ -57,22 +48,11 @@ args = ap.parse_args()
 fname = args.input.replace(".root", "")
 nrpotspill = args.pot
 
-A = args.A if args.A is not None else TARGET_A[args.target_composition]
-scale = (A / A_REF) ** (heavyflavour_Ascale - mbias_Ascale)
+cs = derive_cross_sections(args.target_composition, args.A, args.chicc, args.chibb)
+chicc, chibb = cs.chicc, cs.chibb
+setByHand = args.chicc is not None
 
-if args.chicc is not None:
-    chicc = args.chicc
-    setByHand = True
-else:
-    chicc = CHICC_REF * scale
-    setByHand = False
-
-chibb = args.chibb if args.chibb is not None else CHIBB_REF * scale
-
-print(
-    f"Target composition: {args.target_composition}, A={A}, scale=(A/{A_REF})^({heavyflavour_Ascale}-{mbias_Ascale})={scale:.4f}"
-)
-print(f"Derived cross-section ratios: chicc={chicc:.3e}, chibb={chibb:.3e}")
+print(format_summary(cs, args.target_composition))
 
 FIN = fname + ".root"
 tmp = os.path.abspath(FIN).split("/")

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -52,7 +52,7 @@ cs = derive_cross_sections(args.target_composition, args.A, args.chicc, args.chi
 chicc, chibb = cs.chicc, cs.chibb
 setByHand = args.chicc is not None
 
-print(format_summary(cs, args.target_composition))
+print(format_summary(cs, None if args.A is not None else args.target_composition))
 
 FIN = fname + ".root"
 tmp = os.path.abspath(FIN).split("/")

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -456,7 +456,7 @@ if args.charm or args.beauty:
     cs = derive_cross_sections(args.target_composition, args.A, args.chicc, args.chibb)
     P8gen.SetChicc(cs.chicc)
     P8gen.SetChibb(cs.chibb)
-    print(format_summary(cs, args.target_composition))
+    print(format_summary(cs, None if args.A is not None else args.target_composition))
     print("--- process heavy flavours ---")
     P8gen.InitForCharmOrBeauty(charmInputFile, args.nev, args.pot, args.nStart)
 primGen.AddGenerator(P8gen)

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -9,6 +9,7 @@ import geometry_config
 import ROOT
 import shipRoot_conf
 import shipunit as u
+from heavyFlavourScaling import derive_cross_sections, format_summary
 
 mcEngine = "TGeant4"
 simEngine = "Pythia8"
@@ -46,16 +47,6 @@ def get_work_dir(run_number, tag: str | None = None) -> str:
 
 
 logger.info("SHiP proton-on-taget simulator (C) Thomas Ruf, 2017")
-
-# Reference values for Molybdenum (historical defaults). Cross-section ratios
-# scale heavy-flavour ~ A and mbias ~ A^(0.71).
-heavyflavour_Ascale = 1
-mbias_Ascale = 0.71
-
-A_REF = 98.0
-CHICC_REF = 1.7e-3  # prob to produce primary ccbar pair/pot on Mo
-CHIBB_REF = 1.6e-7  # prob to produce primary bbbar pair/pot on Mo
-TARGET_A = {"W": 184.0, "Mo": 98.0}
 
 ap = argparse.ArgumentParser(description='Run SHiP "pot" simulation')
 ap.add_argument("-d", "--debug", action="store_true")
@@ -462,23 +453,10 @@ P8gen.SetSeed(seed)
 #        print ' for experts: p pot= number of protons on target per spill to normalize on'
 #        print '            : c chicc= ccbar over mbias cross section'
 if args.charm or args.beauty:
-    A = args.A if args.A is not None else TARGET_A[args.target_composition]
-    if A <= 0:
-        raise ValueError(f"Invalid target mass number A={A}. Must be > 0.")
-    scale = (A / A_REF) ** (heavyflavour_Ascale - mbias_Ascale)
-
-    if args.chicc is not None:
-        chicc = args.chicc
-    else:
-        chicc = CHICC_REF * scale
-
-    chibb = args.chibb if args.chibb is not None else CHIBB_REF * scale
-    P8gen.SetChicc(chicc)
-    P8gen.SetChibb(chibb)
-    print(
-        f"Target composition: {args.target_composition}, A={A}, scale=(A/{A_REF})^({heavyflavour_Ascale}-{mbias_Ascale})={scale:.4f}"
-    )
-    print(f"Derived cross-section ratios: chicc={chicc:.3e}, chibb={chibb:.3e}")
+    cs = derive_cross_sections(args.target_composition, args.A, args.chicc, args.chibb)
+    P8gen.SetChicc(cs.chicc)
+    P8gen.SetChibb(cs.chibb)
+    print(format_summary(cs, args.target_composition))
     print("--- process heavy flavours ---")
     P8gen.InitForCharmOrBeauty(charmInputFile, args.nev, args.pot, args.nStart)
 primGen.AddGenerator(P8gen)

--- a/python/heavyFlavourScaling.py
+++ b/python/heavyFlavourScaling.py
@@ -22,13 +22,17 @@ TARGET_A = {"W": 184.0, "Mo": 98.0}
 CrossSections = namedtuple("CrossSections", ["chicc", "chibb", "A", "scale"])
 
 
-def derive_cross_sections(target_composition, A=None, chicc=None, chibb=None):
+def derive_cross_sections(target_composition=None, A=None, chicc=None, chibb=None):
     """Return default-scaled chicc/chibb, honouring explicit overrides.
 
     ``A`` overrides the ``target_composition`` preset; ``chicc``/``chibb``
-    override the target-derived value when not ``None``.
+    override the target-derived value when not ``None``. Supply either
+    ``target_composition`` (a known preset) or an explicit ``A``.
     """
-    A = A if A is not None else TARGET_A[target_composition]
+    if A is None:
+        if target_composition is None:
+            raise ValueError(f"Provide either target_composition (one of {sorted(TARGET_A)}) or an explicit A.")
+        A = TARGET_A[target_composition]
     if A <= 0:
         raise ValueError(f"Invalid target mass number A={A}. Must be > 0.")
     scale = (A / A_REF) ** (heavyflavour_Ascale - mbias_Ascale)
@@ -37,10 +41,11 @@ def derive_cross_sections(target_composition, A=None, chicc=None, chibb=None):
     return CrossSections(chicc, chibb, A, scale)
 
 
-def format_summary(cs, target_composition):
+def format_summary(cs, target_composition=None):
     """One human-readable summary of the derived cross-section ratios."""
+    label = target_composition or "custom (A given)"
     return (
-        f"Target composition: {target_composition}, A={cs.A}, "
+        f"Target composition: {label}, A={cs.A}, "
         f"scale=(A/{A_REF})^({heavyflavour_Ascale}-{mbias_Ascale})={cs.scale:.4f}\n"
         f"Derived cross-section ratios: chicc={cs.chicc:.3e}, chibb={cs.chibb:.3e}"
     )

--- a/python/heavyFlavourScaling.py
+++ b/python/heavyFlavourScaling.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+"""Target-composition scaling of charm/beauty over min-bias cross-section ratios.
+
+Shared by ``macro/makeDecay.py`` and ``macro/run_fixedTarget.py`` so the physics
+constants and the ``chicc``/``chibb`` derivation live in a single place.
+"""
+
+from collections import namedtuple
+
+# Reference values for Molybdenum (historical defaults). Cross-section ratios
+# scale heavy-flavour ~ A and mbias ~ A^(0.71).
+heavyflavour_Ascale = 1
+mbias_Ascale = 0.71
+
+A_REF = 98.0
+CHICC_REF = 1.7e-3  # prob to produce primary ccbar pair/pot on Mo
+CHIBB_REF = 1.6e-7  # prob to produce primary bbbar pair/pot on Mo
+TARGET_A = {"W": 184.0, "Mo": 98.0}
+
+CrossSections = namedtuple("CrossSections", ["chicc", "chibb", "A", "scale"])
+
+
+def derive_cross_sections(target_composition, A=None, chicc=None, chibb=None):
+    """Return default-scaled chicc/chibb, honouring explicit overrides.
+
+    ``A`` overrides the ``target_composition`` preset; ``chicc``/``chibb``
+    override the target-derived value when not ``None``.
+    """
+    A = A if A is not None else TARGET_A[target_composition]
+    if A <= 0:
+        raise ValueError(f"Invalid target mass number A={A}. Must be > 0.")
+    scale = (A / A_REF) ** (heavyflavour_Ascale - mbias_Ascale)
+    chicc = chicc if chicc is not None else CHICC_REF * scale
+    chibb = chibb if chibb is not None else CHIBB_REF * scale
+    return CrossSections(chicc, chibb, A, scale)
+
+
+def format_summary(cs, target_composition):
+    """One human-readable summary of the derived cross-section ratios."""
+    return (
+        f"Target composition: {target_composition}, A={cs.A}, "
+        f"scale=(A/{A_REF})^({heavyflavour_Ascale}-{mbias_Ascale})={cs.scale:.4f}\n"
+        f"Derived cross-section ratios: chicc={cs.chicc:.3e}, chibb={cs.chibb:.3e}"
+    )

--- a/tests/test_heavyFlavourScaling.py
+++ b/tests/test_heavyFlavourScaling.py
@@ -34,6 +34,7 @@ def test_A_without_target_composition():
 
 
 def test_explicit_A_overrides_preset():
+    """Passing both is deliberate: an explicit A wins over the "W" preset."""
     cs = derive_cross_sections("W", A=98.0)
     assert cs.A == 98.0
     assert cs.scale == pytest.approx(1.0)

--- a/tests/test_heavyFlavourScaling.py
+++ b/tests/test_heavyFlavourScaling.py
@@ -25,6 +25,14 @@ def test_w_preset_scales_up():
     assert cs.chibb == pytest.approx(CHIBB_REF * cs.scale)
 
 
+def test_A_without_target_composition():
+    cs = derive_cross_sections(A=181.0)
+    assert cs.A == 181.0
+    assert cs.scale == pytest.approx((181.0 / 98.0) ** 0.29)
+    assert cs.chicc == pytest.approx(CHICC_REF * cs.scale)
+    assert cs.chibb == pytest.approx(CHIBB_REF * cs.scale)
+
+
 def test_explicit_A_overrides_preset():
     cs = derive_cross_sections("W", A=98.0)
     assert cs.A == 98.0
@@ -32,13 +40,18 @@ def test_explicit_A_overrides_preset():
 
 
 def test_explicit_ratios_override_derived():
-    cs = derive_cross_sections("W", chicc=5e-3, chibb=2e-7)
+    cs = derive_cross_sections(A=98.0, chicc=5e-3, chibb=2e-7)
     assert cs.chicc == 5e-3
     assert cs.chibb == 2e-7
 
 
+def test_missing_target_and_A_raises():
+    with pytest.raises(ValueError):
+        derive_cross_sections()
+
+
 def test_non_positive_A_raises():
     with pytest.raises(ValueError):
-        derive_cross_sections("W", A=0)
+        derive_cross_sections(A=0)
     with pytest.raises(ValueError):
-        derive_cross_sections("W", A=-1.0)
+        derive_cross_sections(A=-1.0)

--- a/tests/test_heavyFlavourScaling.py
+++ b/tests/test_heavyFlavourScaling.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+import pytest
+from heavyFlavourScaling import (
+    CHIBB_REF,
+    CHICC_REF,
+    derive_cross_sections,
+)
+
+
+def test_mo_preset_is_reference():
+    cs = derive_cross_sections("Mo")
+    assert cs.A == 98.0
+    assert cs.scale == pytest.approx(1.0)
+    assert cs.chicc == pytest.approx(CHICC_REF)
+    assert cs.chibb == pytest.approx(CHIBB_REF)
+
+
+def test_w_preset_scales_up():
+    cs = derive_cross_sections("W")
+    assert cs.A == 184.0
+    assert cs.scale == pytest.approx((184.0 / 98.0) ** 0.29)
+    assert cs.chicc == pytest.approx(CHICC_REF * cs.scale)
+    assert cs.chibb == pytest.approx(CHIBB_REF * cs.scale)
+
+
+def test_explicit_A_overrides_preset():
+    cs = derive_cross_sections("W", A=98.0)
+    assert cs.A == 98.0
+    assert cs.scale == pytest.approx(1.0)
+
+
+def test_explicit_ratios_override_derived():
+    cs = derive_cross_sections("W", chicc=5e-3, chibb=2e-7)
+    assert cs.chicc == 5e-3
+    assert cs.chibb == 2e-7
+
+
+def test_non_positive_A_raises():
+    with pytest.raises(ValueError):
+        derive_cross_sections("W", A=0)
+    with pytest.raises(ValueError):
+        derive_cross_sections("W", A=-1.0)


### PR DESCRIPTION
Follow-up to #1341.

The target-composition scaling of the charm/beauty over min-bias cross-section ratios (`chicc`/`chibb`) was duplicated verbatim between `makeDecay.py` and `run_fixedTarget.py`, so a future physics update (reference cross sections or the `A`-scaling exponents) would have to be applied in two places and could silently drift.

This extracts the constants and the derivation into a new shared module `python/heavyFlavourScaling.py` (`derive_cross_sections` + `format_summary`) and rewires both macros to use it. A small pytest (`tests/test_heavyFlavourScaling.py`) covers the presets, overrides and the `A > 0` guard.

No behaviour change: the default (W) and Mo presets, explicit `--chicc`/`--chibb`/`-A` overrides, and the printed summary are all preserved.

A separate follow-up will make `--chicc`/`--chibb` mutually exclusive and reject the wrong one for the run type.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent charm and beauty cross-section scaling across decay and fixed-target workflows.
  - Supports target presets, explicit target mass values, and manual cross-section overrides.
  - Improved summary reporting, including clearer handling when an explicit target mass is provided.

- **Bug Fixes**
  - Added validation for missing or invalid target-mass inputs.

- **Tests**
  - Added coverage for presets, scaling, overrides, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->