### PR TITLE
fix: reject mismatched chicc/chibb overrides in charm/beauty macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ it in future.
 * SBT sensitive medium is now LAB-based liquid scintillator (`LiquidScintillator`) rather than the plastic `Scintillator`, which remains in use by SplitCal
 * Use dense vectors instead of `std::map` for ShipStack track selection and index remapping, roughly halving CPU time and reducing peak memory for high-multiplicity events (e.g. kaon/pion splitting)
 * Deduplicate the charm/beauty over min-bias cross-section scaling shared by `makeDecay` and `run_fixedTarget` into `python/heavyFlavourScaling.py`
+* Make `--chicc` and `--chibb` mutually exclusive in `makeDecay` and `run_fixedTarget`, and raise a clear error when the override does not match the run type (e.g. `--chicc` for a beauty run) instead of silently ignoring it
 
 ### Fixed
 

--- a/macro/makeDecay.py
+++ b/macro/makeDecay.py
@@ -8,7 +8,11 @@ import os
 
 import ROOT
 import rootUtils as ut
-from heavyFlavourScaling import derive_cross_sections, format_summary
+from heavyFlavourScaling import (
+    check_run_type_override,
+    derive_cross_sections,
+    format_summary,
+)
 
 ROOT.gROOT.LoadMacro("$VMCWORKDIR/gconfig/basiclibs.C")
 ROOT.basiclibs()
@@ -21,10 +25,12 @@ ap.add_argument(
     help="input file with charm/beauty hadrons (.root suffix optional)",
 )
 ap.add_argument("-p", "--pot", type=float, default=5.0e13, help="number of protons on target per spill to normalise on")
-ap.add_argument(
+# A run is either charm or beauty, so only one ratio override is ever meaningful.
+cross_section = ap.add_mutually_exclusive_group()
+cross_section.add_argument(
     "-c", "--chicc", type=float, default=None, help="ccbar over mbias cross section (overrides target-derived value)"
 )
-ap.add_argument(
+cross_section.add_argument(
     "--chibb", type=float, default=None, help="bbbar over mbias cross section (overrides target-derived value)"
 )
 ap.add_argument(
@@ -50,7 +56,6 @@ nrpotspill = args.pot
 
 cs = derive_cross_sections(args.target_composition, args.A, args.chicc, args.chibb)
 chicc, chibb = cs.chicc, cs.chibb
-setByHand = args.chicc is not None
 
 print(format_summary(cs, None if args.A is not None else args.target_composition))
 
@@ -128,7 +133,9 @@ for n in range(nEvents):
     rc = sTree.GetEvent(n)
     # check if we deal with charm or beauty:
     if n == 0:
-        if not setByHand and sTree.M > 5:
+        is_beauty = sTree.M > 5
+        check_run_type_override(is_beauty, args.chicc, args.chibb)
+        if is_beauty:
             chicc = chibb
             print("automatic detection of beauty, configured for beauty")
             print("bb cross section / mbias ", chicc)

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -9,7 +9,11 @@ import geometry_config
 import ROOT
 import shipRoot_conf
 import shipunit as u
-from heavyFlavourScaling import derive_cross_sections, format_summary
+from heavyFlavourScaling import (
+    check_run_type_override,
+    derive_cross_sections,
+    format_summary,
+)
 
 mcEngine = "TGeant4"
 simEngine = "Pythia8"
@@ -108,10 +112,12 @@ ap.add_argument(
     help="enable ntuple production",
 )
 # for charm production
-ap.add_argument(
+# A run is either charm or beauty, so only one ratio override is ever meaningful.
+cross_section = ap.add_mutually_exclusive_group()
+cross_section.add_argument(
     "-cc", "--chicc", type=float, default=None, help="ccbar over mbias cross section (overrides target-derived value)"
 )
-ap.add_argument(
+cross_section.add_argument(
     "-bb", "--chibb", type=float, default=None, help="bbbar over mbias cross section (overrides target-derived value)"
 )
 ap.add_argument(
@@ -453,6 +459,7 @@ P8gen.SetSeed(seed)
 #        print ' for experts: p pot= number of protons on target per spill to normalize on'
 #        print '            : c chicc= ccbar over mbias cross section'
 if args.charm or args.beauty:
+    check_run_type_override(args.beauty, args.chicc, args.chibb)
     cs = derive_cross_sections(args.target_composition, args.A, args.chicc, args.chibb)
     P8gen.SetChicc(cs.chicc)
     P8gen.SetChibb(cs.chibb)

--- a/python/heavyFlavourScaling.py
+++ b/python/heavyFlavourScaling.py
@@ -41,6 +41,21 @@ def derive_cross_sections(target_composition=None, A=None, chicc=None, chibb=Non
     return CrossSections(chicc, chibb, A, scale)
 
 
+def check_run_type_override(is_beauty, chicc, chibb):
+    """Reject a cross-section override that does not match the run type.
+
+    A run is either charm or beauty, so at most one of ``chicc``/``chibb`` is
+    meaningful. Passing the wrong one (or both) is a mistake and raises
+    ``ValueError`` with a clear message rather than being silently ignored.
+    """
+    if chicc is not None and chibb is not None:
+        raise ValueError("Set only one of --chicc / --chibb; a run is either charm or beauty.")
+    if is_beauty and chicc is not None:
+        raise ValueError("This is a beauty run: pass --chibb, not --chicc.")
+    if not is_beauty and chibb is not None:
+        raise ValueError("This is a charm run: pass --chicc, not --chibb.")
+
+
 def format_summary(cs, target_composition=None):
     """One human-readable summary of the derived cross-section ratios."""
     label = target_composition or "custom (A given)"

--- a/tests/test_heavyFlavourScaling.py
+++ b/tests/test_heavyFlavourScaling.py
@@ -5,6 +5,7 @@ import pytest
 from heavyFlavourScaling import (
     CHIBB_REF,
     CHICC_REF,
+    check_run_type_override,
     derive_cross_sections,
 )
 
@@ -56,3 +57,22 @@ def test_non_positive_A_raises():
         derive_cross_sections(A=0)
     with pytest.raises(ValueError):
         derive_cross_sections(A=-1.0)
+
+
+def test_override_matching_run_type_is_accepted():
+    # charm run with chicc, beauty run with chibb, and no override at all.
+    check_run_type_override(is_beauty=False, chicc=1e-3, chibb=None)
+    check_run_type_override(is_beauty=True, chicc=None, chibb=1e-7)
+    check_run_type_override(is_beauty=False, chicc=None, chibb=None)
+
+
+def test_override_wrong_run_type_raises():
+    with pytest.raises(ValueError, match="beauty run"):
+        check_run_type_override(is_beauty=True, chicc=1e-3, chibb=None)
+    with pytest.raises(ValueError, match="charm run"):
+        check_run_type_override(is_beauty=False, chicc=None, chibb=1e-7)
+
+
+def test_both_overrides_raise():
+    with pytest.raises(ValueError, match="only one"):
+        check_run_type_override(is_beauty=False, chicc=1e-3, chibb=1e-7)


### PR DESCRIPTION
Follow-up to #1341. **Stacked on #1357** (based on that branch); rebase onto `main` once #1357 merges.

A run is either charm or beauty, so only one of the ccbar/bbbar over min-bias cross-section ratios is ever meaningful. Previously the wrong override was silently ignored:

- in `run_fixedTarget.py`, passing `--chicc` for a beauty run had no effect because `FixedTargetGenerator::InitForCharmOrBeauty` unconditionally sets `chicc = chibb` for beauty;
- in `makeDecay.py`, the `setByHand` flag caused a user-supplied `--chicc` to be used even on a beauty file.

This makes `--chicc`/`--chibb` mutually exclusive (argparse) and adds `check_run_type_override` to the shared `heavyFlavourScaling` module, which raises a clear error when the supplied override does not match the run type:

- `run_fixedTarget.py`: checked against the resolved `--charm`/`--beauty` flag;
- `makeDecay.py`: checked after the input file's charm-vs-beauty type is known (`M > 5`), replacing the silent `setByHand` swap.

Unit tests cover the accepted and rejected combinations.

## Checklist

- [x] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
- [ ] CI checks pass