### PR TITLE
fix: unifying the identical materials Aluminum and aluminium to Aluminium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,7 +355,7 @@ it in future.
 
 * Add access to decoded numbers (stations, views etc.) of strawtubes hits
 * Add enough straws to cover aperture entirely
-* Add SST frame option (4 = aluminium, 10 = steel [default])
+* Add SST frame option (4 = Aluminium, 10 = steel [default])
 * Add z-offset to FixedTargetGenerator
 * Add missing --FixedTarget option to run_simScript.py
 

--- a/geometry/media.geo
+++ b/geometry/media.geo
@@ -6,7 +6,7 @@
 //name	ncomp	aw	an	dens
 //sensflag	fldflag	fld	epsil
 //npckov
-//ncomp: - number of components in the material (ncomp= 1 for a basic material and <1 or >1 for a mixture
+//ncomp: - number of components in the material (ncomp= 1 for a basic material and <1 or >1 for a mixture)
 //aw: 	- atomic weights A for the components
 //an: 	- atomic numbers Z for the components
 //dens:	density DENS in g cm(**-3)
@@ -108,10 +108,7 @@ silicon            1  28.0855 14.0 2.33
 HYPsilicon         1  28.0855 14.0 2.33
                    1  1  20.  .001
                    0
-aluminium          1  26.98 13. 2.7
-                   0  1  20.  .001
-                   0
-Aluminum           1  26.98 13. 2.7
+Aluminium          1  26.98 13. 2.7
                    0  1  20.  .001
                    0
 //  powder of Al to simulate sensitive material with 900cm of radiation length
@@ -216,7 +213,7 @@ SMD               1 26.98 13. 1.41
 PVC               3 1.00794 12.0107 35.453 1. 6. 17. 1.30  0.048380 0.384360 0.567260
                   0 1 20. .001
                   0
-// Polyvinylchloride (PVC2) Heavier definition for MVD containing some aluminum
+// Polyvinylchloride (PVC2) Heavier definition for MVD containing some aluminium
 PVCHEAVY          4 1.00794 12.0107 35.453 26.981539 1. 6. 17. 13. 1.44 0.043542 0.345924 0.510534 0.1
                   0	1	20.	.001
                   0

--- a/geometry/veto_config_helium.yaml
+++ b/geometry/veto_config_helium.yaml
@@ -1,15 +1,15 @@
 # Configuration of Decay Vessel for FairShip ( Naples Design)
 z: 0.0
 innerSupport: 0.8 # cm
-innerSupportMed: "Aluminum"
+innerSupportMed: "Aluminium"
 outerSupport: 0.8 # cm
-outerSupportMed: "Aluminum"
+outerSupportMed: "Aluminium"
 lidThickness: 0.0 # cm
 sensitiveThickness: 20 # cm
 sensitiveMed: "LiquidScintillator"
 decayMed: "helium"
 rib: 1.5 # cm
-ribMed: "Aluminum"
+ribMed: "Aluminium"
 xstartInner: 100.0 # cm
 ystartInner: 270.0 # cm
 xendInner: 400.0 # cm        #FocusLineX at z= target.z0 + 16.8m

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -62,11 +62,10 @@ withMCTracks = True
 #                        muon shield  strawtube                     decay vessel
 transparentMaterials = {
     "iron": 80,
-    "aluminium": 80,
+    "Aluminium": 80,
     "mylar": 60,
     "STTmix9010_2bar": 95,
     "steel": 80,
-    "Aluminum": 80,
     "Scintillator": 80,
     "LiquidScintillator": 80,
     #                        tau nu detector

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -308,7 +308,7 @@ parser.add_argument(
 parser.add_argument("-Y", dest="dy", help="max height of vacuum tank", default=6.0, type=float)
 parser.add_argument(
     "--strawDesign",
-    help="Tracker station frame material: 4=aluminium; 10=steel (default)",
+    help="Tracker station frame material: 4=Aluminium; 10=steel (default)",
     default=10,
     type=int,
     choices=[4, 10],

--- a/muonShieldOptimization/study_GammaConv.py
+++ b/muonShieldOptimization/study_GammaConv.py
@@ -20,9 +20,9 @@ runnr = 1
 nev = 10  # 000000
 
 setup = {}
-setup["10"] = {"thickness": 2 * u.cm, "material": "aluminium", "momentum": 10 * u.GeV}
-setup["100"] = {"thickness": 2 * u.cm, "material": "aluminium", "momentum": 100 * u.GeV}
-setup["200"] = {"thickness": 2 * u.cm, "material": "aluminium", "momentum": 200 * u.GeV}
+setup["10"] = {"thickness": 2 * u.cm, "material": "Aluminium", "momentum": 10 * u.GeV}
+setup["100"] = {"thickness": 2 * u.cm, "material": "Aluminium", "momentum": 100 * u.GeV}
+setup["200"] = {"thickness": 2 * u.cm, "material": "Aluminium", "momentum": 200 * u.GeV}
 
 # 8cm = 0.9X0
 

--- a/passive/ShipMagnet.cxx
+++ b/passive/ShipMagnet.cxx
@@ -101,8 +101,8 @@ void ShipMagnet::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
   ShipGeo::InitMedium("iron");
   TGeoMedium* Fe = gGeoManager->GetMedium("iron");
-  ShipGeo::InitMedium("Aluminum");
-  TGeoMedium* Al = gGeoManager->GetMedium("Aluminum");
+  ShipGeo::InitMedium("Aluminium");
+  TGeoMedium* Al = gGeoManager->GetMedium("Aluminium");
   TGeoVolumeAssembly* tMagnet = new TGeoVolumeAssembly("SHiPMagnet");
   top->AddNode(tMagnet, 1, new TGeoTranslation(0, 0, 0));
 

--- a/python/geometry_config.py
+++ b/python/geometry_config.py
@@ -11,7 +11,7 @@ from ShipGeoConfig import AttrDict, Config
 # nuTargetPassive = 1  #0 = with active layers, 1 = only passive
 
 # targetOpt      = 5  # 0=solid   >0 sliced, 5: 5 pieces of tungsten, 4 air slits, 17: molybdenum tungsten interleaved with H20
-# strawOpt       = 0  # 4=aluminium frame 10=steel frame (default)
+# strawOpt       = 0  # 4=Aluminium frame 10=steel frame (default)
 
 # Here you can select the MS geometry
 # The first row is the length of the magnets
@@ -159,7 +159,7 @@ def create_config(
     Args:
         DecayVolumeMedium: Medium in decay volume ("helium" or "vacuums"), default: "helium"
         Yheight: Height of vacuum tank in meters, default: 6.0
-        strawDesign: Straw tube design (4=aluminium frame, 10=steel frame), default: 10
+        strawDesign: Straw tube design (4=Aluminium frame, 10=steel frame), default: 10
         muShieldGeo: Muon shield geometry file (for experts), default: None
         shieldName: Name of shield configuration, default: "TRY_2025"
         nuTargetPassive: Target type (0=with active layers, 1=only passive), default: 1

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -222,7 +222,7 @@ def configure_strawtubes(yaml_file: str, ship_geo) -> None:
 
     # Choose frame material
     if ship_geo.strawDesign == 4:
-        ship_geo.strawtubes_geo.frame_material = "aluminium"
+        ship_geo.strawtubes_geo.frame_material = "Aluminium"
     elif ship_geo.strawDesign == 10:
         ship_geo.strawtubes_geo.frame_material = "steel"
 

--- a/veto/veto.cxx
+++ b/veto/veto.cxx
@@ -829,7 +829,7 @@ void veto::ConstructGeometry() {
   TGeoVolume* top = gGeoManager->GetTopVolume();
 
   ShipGeo::InitMedium("vacuums");
-  ShipGeo::InitMedium("Aluminum");
+  ShipGeo::InitMedium("Aluminium");
   ShipGeo::InitMedium("helium");
   ShipGeo::InitMedium(vetoMed_name.Data());
   ShipGeo::InitMedium("steel");

--- a/veto/veto.h
+++ b/veto/veto.h
@@ -100,9 +100,9 @@ class veto : public SHiP::Detector<vetoPoint> {
 
   //! medium of veto counter, liquid or plastic scintillator
   TString vetoMed_name;
-  //! medium of internal support structure(Default = Aluminum).
+  //! medium of internal support structure(Default = Aluminium).
   TString supportMedIn_name;
-  //! medium of external support structure(Default = Aluminum).
+  //! medium of external support structure(Default = Aluminium).
   TString supportMedOut_name;
   //! medium of decay volume(Default= helium).
   TString decayVolumeMed_name;


### PR DESCRIPTION
## Checklist

- Erased the Aluminum material from geometry/media.geo
- Change the name of aluminium to Aluminium in geometry/media.geo
- Update the code to match the new material name


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the material name to **“Aluminium”** across geometry configurations, simulation settings, visualisation mappings, and detector components.
  * Preserved existing material properties, defaults, and configuration values while ensuring consistent recognition across workflows.

* **Documentation**
  * Updated changelog entries, help text, and comments to use the consistent **“Aluminium”** spelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->