### PR TITLE
chore: remove CI checks item from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,3 @@
 
 - [ ] Changelog updated (if applicable)
 - [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)
-- [ ] CI checks pass


### PR DESCRIPTION
The GitHub PR interface already surfaces CI status directly (green/red checks), so the self-certified "CI checks pass" checkbox is redundant. This removes it from the checklist.