### PR TITLE
Clean up comments

### DIFF
--- a/field/ShipBFieldMap.cxx
+++ b/field/ShipBFieldMap.cxx
@@ -142,10 +142,8 @@ void ShipBFieldMap::Field(const Double_t* position, Double_t* B) {
   Float_t BzSign = 1;
 
   if (isSymmetric_) {
-    // The field map coordinates only contain x > 0 and y > 0, i.e. we
-    // are using x-y quadrant symmetry. If the local x or y coordinates
-    // are negative we need to change their sign and keep track of the
-    // adjusted sign of Bx which we use as a multiplication factor at the end
+    // The map stores only the x > 0, y > 0 quadrant; fold negative
+    // coordinates in and track the induced signs of Bx and Bz.
     if (x < 0.0) {
       x = -x;
       BxSign *= -1.0;
@@ -520,9 +518,8 @@ Float_t ShipBFieldMap::triLinearInterp(Float_t A, Float_t B, Float_t C,
                                        Float_t xFrac1, Float_t yFrac,
                                        Float_t yFrac1, Float_t zFrac,
                                        Float_t zFrac1) {
-  // Trilinear interpolation of a single component from its eight corner values
-  // A..H (bit-for-bit the arithmetic previously performed per axis by
-  // BInterCalc).
+  // Trilinear interpolation of a single component from its eight corner
+  // values A..H.
   // Linear interpolation along x
   const Float_t F00 = A * xFrac1 + B * xFrac;
   const Float_t F10 = C * xFrac1 + D * xFrac;

--- a/geometry/SiliconTarget_config.yaml
+++ b/geometry/SiliconTarget_config.yaml
@@ -6,7 +6,7 @@ SiliconTarget:
   sensorWidth: 9.8 #Sensor active area -- width (cm)
   sensorLength: 19.52 #Sensor active area -- height (cm)
   nLayers: 120 #Number of tungsten + silicon layers
-  zPosition: auto #Default: auto -- centre of the second to last magnet in z
+  zPosition: auto #Default: auto -- last layer ends one magnet Z-gap upstream of the last muon-shield magnet's entrance (where the MTC starts)
   targetThickness: 0.35 #Tungsten thickness (cm)
   targetSpacing: 1.1 #Spacing between pairs of tungsten layers (cm)
   moduleOffset: 0.1 #Spacing between tungsten surface and first silicon layer (cm)

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -397,9 +397,8 @@ def RedoVertexing(t1, t2):
     LV = {}
     for tr in [t1, t2]:
         mom = reps[tr].getMom(states[tr])
+        # tracks are always fitted under the muon hypothesis (+-13)
         pid = abs(states[tr].getPDG())
-        if pid == 2212:
-            pid = 211
         _pdg_particle = PDG.GetParticle(pid)
         assert _pdg_particle is not None, f"Unknown PDG: {pid}"
         mass = _pdg_particle.Mass()

--- a/macro/ShipReco.py
+++ b/macro/ShipReco.py
@@ -5,7 +5,6 @@
 from argparse import ArgumentParser
 
 withHists = True
-pidProton = False  # if true, take truth, if False fake with pion mass
 
 import resource
 
@@ -162,7 +161,6 @@ if hasattr(ShipGeo.Bfield, "fieldMap"):
 # make global variables
 global_variables.debug = options.Debug
 global_variables.fieldMaker = fieldMaker
-global_variables.pidProton = pidProton
 global_variables.withT0 = options.withT0
 global_variables.patRec = options.patRec
 global_variables.vertexing = vertexing

--- a/macro/eventDisplay.py
+++ b/macro/eventDisplay.py
@@ -398,10 +398,8 @@ class DrawTracks(ROOT.FairTask):
         ntot = 0
         fPos = ROOT.TVector3()
         fMom = ROOT.TVector3()
-        # Build a trackID -> hits map once per event instead of rescanning every
-        # hit collection for every MC track (was O(tracks x hits)). Branch and
-        # in-branch order are preserved, so downstream hitlist building is
-        # unchanged.
+        # Map trackID -> hits once per event, preserving branch and in-branch
+        # order (the hitlist building below relies on it).
         hits_by_track: dict[int, list] = {}
         for P in [
             "vetoPoint",

--- a/macro/run_simScript.py
+++ b/macro/run_simScript.py
@@ -217,7 +217,7 @@ parser.add_argument(
 parser.add_argument("--PaintBeam", dest="PaintBeam", help="Radius of beam painting [cm]", default=5, type=float)
 parser.add_argument(
     "--Cosmics", dest="cosmics", help="Use cosmic generator, argument switch for cosmic generator 0 or 1", default=None
-)  # TODO: Understand integer options, replace with store_true?
+)  # 0/1 selects CosmicsGenerator::Init(largeMom); not store_true, since "0" must enable cosmics with largeMom=False
 parser.add_argument("--MuDIS", dest="mudis", help="Use muon deep inelastic scattering generator", action="store_true")
 parser.add_argument("--RpvSusy", dest="RPVSUSY", help="Generate events based on RPV neutralino", action="store_true")
 parser.add_argument("--FixedTarget", dest="fixedTarget", help="Enable fixed target simulation", action="store_true")

--- a/python/convertToACTS.py
+++ b/python/convertToACTS.py
@@ -260,8 +260,8 @@ def main():
         outcome = ROOT.std.vector("float")()
         particleTree.Branch("outcome", outcome)
 
-        # Seed the RNG once, before the event loop, so digitisation draws a
-        # fresh random sequence per event.
+        # Seed the RNG once, before the event loop: all events draw from a
+        # single deterministic stream.
         ROOT.gRandom.SetSeed(13)
 
         for ievent, event in enumerate(sTree):

--- a/python/convertToACTS.py
+++ b/python/convertToACTS.py
@@ -261,16 +261,15 @@ def main():
         particleTree.Branch("outcome", outcome)
 
         # Seed the RNG once, before the event loop, so digitisation draws a
-        # fresh random sequence per event instead of repeating the same one.
+        # fresh random sequence per event.
         ROOT.gRandom.SetSeed(13)
 
         for ievent, event in enumerate(sTree):
             motherMap = defaultdict(list)
             motherMapVal = defaultdict(list)
             detHitMap = defaultdict(list)
-            # Hits already accounted for that will be discarded from detHitMap
-            # before the per-particle hit count is taken (e.g. SND SiliconTarget
-            # hits, which are cleared before the MTC block reuses detHitMap).
+            # Per-track counts of hits dropped from detHitMap before the
+            # per-particle hit count is taken.
             extraHitCount = defaultdict(int)
             detHitArray = []
             strawHitArr = []
@@ -340,8 +339,8 @@ def main():
             if global_variables.detector == "MTC" or global_variables.detector == "SND":
                 detHitArray.clear()
                 trID.clear()
-                # For SND the SiliconTarget hits were stored in detHitMap above;
-                # preserve their per-track counts before reusing the map for MTC.
+                # Preserve SiliconTarget per-track counts before reusing
+                # detHitMap for MTC.
                 for trackID in detHitMap:
                     extraHitCount[trackID] += len(detHitMap[trackID])
                 detHitMap.clear()
@@ -563,8 +562,8 @@ def main():
                 if len(particleCodes) < 2:
                     continue
                 event_id_vertex[0] = ievent
-                # Encode the per-event vertex index so each vertex gets a distinct
-                # id (previously constant, so every vertex shared the same value).
+                # Encode the per-event vertex index so each vertex gets a
+                # distinct id.
                 vertexVal = acts.Barcode(primaryVertex=1, secondaryVertex=0, part=c, gen=0, subpart=0).value
                 vertex_id.push_back(vertexVal)
                 particle_0ID = motherMap[str(i)]

--- a/python/detectors/MTCDetector.py
+++ b/python/detectors/MTCDetector.py
@@ -63,7 +63,6 @@ class MTCDetector(BaseDetector):
                     norm[global_channel] = 0
 
                 weight = 1
-                # Append (energy_loss, weight) instead of (mc_point, weight)
                 hit_container[global_channel].append([mc_point, weight])
                 d_e = energy_loss * weight
                 mc_points[global_channel][k] = d_e

--- a/python/detectors/strawtubesDetector.py
+++ b/python/detectors/strawtubesDetector.py
@@ -81,7 +81,6 @@ class strawtubesDetector(BaseDetector):
         stop = ROOT.TVector3()
         start = ROOT.TVector3()
         v_drift = global_variables.modules["strawtubes"].StrawVdrift()
-        global_variables.modules["strawtubes"].StrawEndPoints(1002001, start, stop)
         for aDigi in self.det:
             key += 1
             if not aDigi.isValid():

--- a/python/detectors/strawtubesDetector.py
+++ b/python/detectors/strawtubesDetector.py
@@ -30,7 +30,7 @@ class strawtubesDetector(BaseDetector):
                 else:
                     earliest_per_det_id[detector_id] = index
 
-    def withT0Estimate(self) -> list[dict[str, int]]:
+    def withT0Estimate(self) -> list[dict[str, float | int]]:
         # loop over all straw tdcs and make average, correct for ToF
         n = 0
         t0 = 0.0
@@ -74,7 +74,7 @@ class strawtubesDetector(BaseDetector):
             s["dist"] = (s["dist"] - delt1 - t0) * v_drift
         return SmearedHits
 
-    def smearHits(self, no_amb=None) -> list[dict[str, int]]:
+    def smearHits(self, no_amb=None) -> list[dict[str, float | int]]:
         # smear strawtube points
         SmearedHits = []
         key = -1

--- a/python/detectors/strawtubesDetector.py
+++ b/python/detectors/strawtubesDetector.py
@@ -39,6 +39,8 @@ class strawtubesDetector(BaseDetector):
         start = ROOT.TVector3()
         SmearedHits = []
         v_drift = global_variables.modules["strawtubes"].StrawVdrift()
+        # straw 1002001 (first straw of station 1) defines the z reference
+        # plane for the time-of-flight correction
         global_variables.modules["strawtubes"].StrawEndPoints(1002001, start, stop)
         z1 = stop.z()
         for aDigi in self.det:
@@ -63,6 +65,9 @@ class strawtubesDetector(BaseDetector):
             )
             n += 1
         if n > 0:
+            # 73.2 ns: empirical offset aligning the averaged, ToF-corrected
+            # TDC times with the event t0.
+            # TODO(olantwin, 2026-08-12): document its derivation
             t0 = t0 / n - 73.2 * u.ns
         for s in SmearedHits:
             delt1 = (s["z"] - z1) / u.speedOfLight

--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -132,9 +132,8 @@ def printWF(vl, alreadyPrinted, onlyWithField: bool = True):
 
 
 def nextLevel(lv, magnetMass, onlyWithField, exclude, alreadyPrinted):
-    # Accumulate the magnet mass of every leaf volume in the subtree. A single
-    # running total is threaded through the recursion so that leaves at any
-    # depth (and direct leaf daughters of the top level) are all counted.
+    # Recursively accumulate the magnet mass of every leaf volume in the
+    # subtree.
     for da in range(lv.GetNoDaughters()):
         lvn = lv.GetDaughter(da)
         name = lvn.GetName().c_str()

--- a/python/geomGeant4.py
+++ b/python/geomGeant4.py
@@ -132,8 +132,8 @@ def printWF(vl, alreadyPrinted, onlyWithField: bool = True):
 
 
 def nextLevel(lv, magnetMass, onlyWithField, exclude, alreadyPrinted):
-    # Recursively accumulate the magnet mass of every leaf volume in the
-    # subtree.
+    # Recursively accumulate the magnet mass over the subtree's leaf volumes;
+    # printWF counts only the first leaf per unique volume name.
     for da in range(lv.GetNoDaughters()):
         lvn = lv.GetDaughter(da)
         name = lvn.GetName().c_str()

--- a/python/hnl.py
+++ b/python/hnl.py
@@ -133,8 +133,9 @@ class HNLbranchings:
         self.U2 = couplings
         self.U = [math.sqrt(ui) for ui in self.U2]
         self.MN = mass * u.GeV
-        # Cached total width and integrand TF1; both constant for fixed
-        # mass/couplings, and binding a Python callable into a TF1 is expensive.
+        # Cache the total width (constant for fixed mass/couplings) and a
+        # reusable TF1 whose parameters are set per integral() call; binding a
+        # Python callable into a TF1 is expensive.
         self._totalWidth = None
         self._integrand_tf1 = None
         self.CKM = CKMmatrix()

--- a/python/hnl.py
+++ b/python/hnl.py
@@ -133,11 +133,9 @@ class HNLbranchings:
         self.U2 = couplings
         self.U = [math.sqrt(ui) for ui in self.U2]
         self.MN = mass * u.GeV
-        # Cached total decay width; constant for fixed mass/couplings, which are
-        # never mutated after construction.
+        # Cached total width and integrand TF1; both constant for fixed
+        # mass/couplings, and binding a Python callable into a TF1 is expensive.
         self._totalWidth = None
-        # Reused TF1 wrapping the (Python) integrand; rebuilding it per call is
-        # expensive because of the PyROOT callable binding.
         self._integrand_tf1 = None
         self.CKM = CKMmatrix()
         self.CKMelemSq = {
@@ -331,9 +329,8 @@ class HNLbranchings:
         xi = mi/MN
         """
         if self._integrand_tf1 is None:
-            # ROOT registers TF1s globally by name and WrappedTF1 resolves them
-            # by that name, so give each instance a unique name to avoid
-            # collisions when several HNLbranchings objects are alive at once.
+            # ROOT registers TF1s globally by name, so make it unique per
+            # instance to avoid collisions between HNLbranchings objects.
             self._integrand_tf1 = ROOT.TF1(f"hnl_integrand_{id(self):x}", self.Integrand, 0, 1, 3)
         func = self._integrand_tf1
         func.SetParameters(x1, x2, x3)

--- a/python/shipDet_conf.py
+++ b/python/shipDet_conf.py
@@ -156,9 +156,9 @@ def configure_snd_siliconTarget(yaml_file: str, ship_geo) -> None:
     ship_geo.SiliconTarget_geo = AttrDict(config["SiliconTarget"])
     # Initialize detector
     if ship_geo.SiliconTarget_geo.zPosition == "auto":
-        # Get the the center of the next to last magnet (temporary placement)
-        # Offset placement of detector by 140 cm, magnet is 2* 212.54 cm,
-        # 120 layers at 132 cm will fit, with 140 cm offset final layer within 10 cm of MTC.
+        # auto: centre the target so its last layer ends one magnet Z-gap
+        # upstream of the last muon-shield magnet's entrance (where the MTC
+        # starts).
         SiliconTarget_total_length = ship_geo.SiliconTarget_geo.targetSpacing * ship_geo.SiliconTarget_geo.nLayers
         ship_geo.SiliconTarget_geo.zPosition = (
             ship_geo.muShield.Entrance[-1] - ship_geo.muShield.Zgap[-1] - SiliconTarget_total_length / 2

--- a/python/shipDigiReco.py
+++ b/python/shipDigiReco.py
@@ -261,7 +261,7 @@ class ShipDigiReco:
                 self.validation_stats["candidate_stations_count"] += 1
             if nM < 13:
                 n_too_few_hits += 1
-                continue  # not enough hits to make a good trackfit
+                continue  # not enough hits for a good trackfit (threshold tuned to the 1-plane-per-view geometry, #552)
             if n_stations_crossed < 3:
                 n_too_few_stations += 1
                 continue  # not enough stations crossed to make a good trackfit
@@ -284,6 +284,8 @@ class ShipDigiReco:
                     resolution *= 1.4  # worse resolution due to t0 estimate
                 for i in range(3):
                     covM[i][i] = resolution * resolution
+                # x is only measured by the small-angle stereo views, so give
+                # the seed a ~10x larger x uncertainty than y
                 covM[0][0] = resolution * resolution * 100.0
                 for i in range(3, 6):
                     covM[i][i] = ROOT.TMath.Power(resolution / nM / ROOT.TMath.Sqrt(3), 2)

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -621,7 +621,7 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     ----------
     iEvent : int
         Event id.
-    sTree : root file
+    sTree : ROOT.TTree or ROOT.TChain
         Events in raw format.
     sGeo : object
         Contains SHiP detector geometry.
@@ -806,8 +806,9 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     for item in MCTrackIDs:
         atrack = sTree.MCTrack.At(item)
         motherId = atrack.GetMotherId()
-        # keep only daughters of the signal particle, assumed to be MCTrack 2
-        # (HNLPythia8Generator with external input file; it is 1 without one)
+        # keep only daughters of the signal particle; assumes the standard HNL
+        # production chain (external charm file), where the signal is MCTrack 2.
+        # Other generator configurations are not supported here.
         if motherId != 2:
             itemstoremove.append(item)
 

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -550,6 +550,8 @@ def extrapolateToPlane(fT, z):
                 fstate = fstate1
             zs = z
             NewPosition = ROOT.TVector3(0.0, 0.0, zs)
+            # muon hypothesis (+-13), keeping the sign of the fitted PDG code
+            # (the PDG-code sign is opposite to the muon's charge sign)
             rep = ROOT.genfit.RKTrackRep(13 * cmp(fstate.getPDG(), 0))
             state = ROOT.genfit.StateOnPlane(rep)
             pos, mom = fstate.getPos(), fstate.getMom()
@@ -631,6 +633,9 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
         List of reconstructible track ids.
     """
 
+    # z extent of the tracker: station z is the centre of its 4 views (2 layers
+    # each), so the first straw layer sits 1.5 view spacings + 0.5 layer
+    # spacings away, plus one straw radius to the straw edge
     TStationz = ShipGeo.TrackStation1.z
     Zpos = (
         TStationz - 3.0 / 2.0 * ShipGeo.strawtubes_geo.delta_z_view - 1.0 / 2.0 * ShipGeo.strawtubes_geo.delta_z_layer
@@ -801,7 +806,9 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     for item in MCTrackIDs:
         atrack = sTree.MCTrack.At(item)
         motherId = atrack.GetMotherId()
-        if motherId != 2:  #!!!!
+        # keep only daughters of the signal particle, assumed to be MCTrack 2
+        # (HNLPythia8Generator with external input file; it is 1 without one)
+        if motherId != 2:
             itemstoremove.append(item)
 
     for item in itemstoremove:

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -619,9 +619,9 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     ----------
     iEvent : int
         Event id.
-    stree : root file
+    sTree : root file
         Events in raw format.
-    fGeo : object
+    sGeo : object
         Contains SHiP detector geometry.
     ShipGeo : object
         Contains SHiP detector geometry.

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -222,11 +222,9 @@ class Task:
                 # print "DEBUG",HNLPos[0],HNLPos[1],HNLPos[2],dist,covX[0][0],covX[1][1],covX[2][2]
                 # print "     ",mctrack.GetStartX(),mctrack.GetStartY(),mctrack.GetStartZ()
 
-                # Copy the fitted states: getFittedState() returns a reference to
-                # the state cached in the track's KalmanFitterInfo, and the
-                # stepwise extrapolation below would otherwise mutate the stored
-                # genfit::Track in place (affecting later pairs / getFittedState
-                # calls, making results depend on pair-processing order).
+                # Copy the fitted states: getFittedState() returns a reference
+                # cached in the track, and extrapolating it in place would make
+                # results depend on the pair-processing order.
                 st1 = ROOT.genfit.MeasuredStateOnPlane(fittedTracks[t1].getFittedState())
                 st2 = ROOT.genfit.MeasuredStateOnPlane(fittedTracks[t2].getFittedState())
                 # Extrapolate to the vertex Z-plane stepwise to avoid

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -112,12 +112,9 @@ class Task:
         for tr in goodTracks:
             fittedTracks[tr].getFitStatus()
             xx = fittedTracks[tr].getFittedState()
+            # shipDigiReco fits every track under the muon hypothesis (+-13)
             pid = xx.getPDG()
-            # without proton PID, refit protons under the pion mass
-            # hypothesis, keeping the charge
-            if not global_variables.pidProton and abs(pid) == 2212:
-                pid = int(math.copysign(211, pid))
-            rep = ROOT.genfit.RKTrackRep(xx.getPDG())
+            rep = ROOT.genfit.RKTrackRep(pid)
             state = ROOT.genfit.StateOnPlane(rep)
             rep.setPosMom(state, xx.getPos(), xx.getMom())
             PosDirCharge[tr] = {

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -53,17 +53,22 @@ class Task:
         self.TwoTrackVertex()
 
     # define global data and functions for vertex fit with TMinuit
+    # y_data packs the two 5D genfit track states (q/p, dx/dz, dy/dz, x, y)
+    # on the plane at z0; Vy is their joint 10x10 inverse covariance, flattened
     y_data = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     z0 = 0
     Vy = np.zeros(100)
 
     def chi2(self, res, Vy) -> int:
+        # res^T V^-1 res, with the flat index i -> (row i//10, column i%10)
         s = 0
         for i in range(100):
             s += Vy[i] * res[i // 10] * res[i % 10]
         return s
 
     def residuals(self, y_data, a, z0: int):
+        # fit parameters a: 0-2 vertex (x, y, z), 3-5 track 1 (dx/dz, dy/dz,
+        # |q/p|), 6-8 track 2; positions are propagated from the vertex to z0
         res = np.zeros(10)
         res[0] = abs(y_data[0]) - a[5]
         res[1] = y_data[1] - a[3]
@@ -106,6 +111,8 @@ class Task:
             fittedTracks[tr].getFitStatus()
             xx = fittedTracks[tr].getFittedState()
             pid = xx.getPDG()
+            # without proton PID, refit protons under the pion mass
+            # hypothesis, keeping the charge
             if not global_variables.pidProton and abs(pid) == 2212:
                 pid = int(math.copysign(211, pid))
             rep = ROOT.genfit.RKTrackRep(xx.getPDG())
@@ -253,6 +260,8 @@ class Task:
                 covInv = ROOT.TMatrixDSym()
                 ROOT.genfit.tools.invertMatrix(cov, covInv)
 
+                # pack both 5D states (and their inverse covariance below) as
+                # expected by fcn/residuals
                 self.y_data = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
                 stVal1 = st1.getState()
                 stVal2 = st2.getState()
@@ -443,8 +452,10 @@ class Task:
                         for j in range(6):
                             MT_AtoP[j][i] = M_AtoP[i][j]
 
+                    # extract the 6x6 block of parameters 3-8 (slopes and
+                    # 1/|p|) from the flat, row-major 9x9 fit covariance
                     for i in range(36):
-                        covA[i // 6][i % 6] = cov[i // 6 + 3 + (i % 6 + 3) * 9]
+                        covA[i // 6][i % 6] = cov[(i // 6 + 3) * 9 + (i % 6 + 3)]
 
                     tmp = ROOT.TMatrixD(4, 6)
                     tmp.Mult(M_AtoP, covA)

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -68,7 +68,9 @@ class Task:
 
     def residuals(self, y_data, a, z0: float):
         # fit parameters a: 0-2 vertex (x, y, z), 3-5 track 1 (dx/dz, dy/dz,
-        # |q/p|), 6-8 track 2; positions are propagated from the vertex to z0
+        # 1/|p|), 6-8 track 2; positions are propagated from the vertex to z0.
+        # The q/p state component is compared via abs(), which equals 1/|p|
+        # for unit-charge tracks.
         res = np.zeros(10)
         res[0] = abs(y_data[0]) - a[5]
         res[1] = y_data[1] - a[3]
@@ -261,7 +263,8 @@ class Task:
                 ROOT.genfit.tools.invertMatrix(cov, covInv)
 
                 # pack both 5D states (and their inverse covariance below) as
-                # expected by fcn/residuals
+                # expected by fcn/residuals; the covariance is block-diagonal,
+                # i.e. the fit treats the two track states as independent
                 self.y_data = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
                 stVal1 = st1.getState()
                 stVal2 = st2.getState()

--- a/python/shipVertex.py
+++ b/python/shipVertex.py
@@ -59,14 +59,14 @@ class Task:
     z0 = 0
     Vy = np.zeros(100)
 
-    def chi2(self, res, Vy) -> int:
+    def chi2(self, res, Vy) -> float:
         # res^T V^-1 res, with the flat index i -> (row i//10, column i%10)
         s = 0
         for i in range(100):
             s += Vy[i] * res[i // 10] * res[i % 10]
         return s
 
-    def residuals(self, y_data, a, z0: int):
+    def residuals(self, y_data, a, z0: float):
         # fit parameters a: 0-2 vertex (x, y, z), 3-5 track 1 (dx/dz, dy/dz,
         # |q/p|), 6-8 track 2; positions are propagated from the vertex to z0
         res = np.zeros(10)

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -428,9 +428,8 @@ void ShipStack::SelectTracks() {
     // generator if (iMother == iMother2) {fStoreMap[i] = kTRUE;}
   }
   // --> If flag is set, flag recursively mothers of selected tracks.
-  // A mother always has a smaller index than its daughters and every walk
-  // continues to the root, so an already-flagged mother implies its whole
-  // ancestor chain is flagged and the walk can stop early.
+  // An already-flagged mother implies its whole ancestor chain is flagged,
+  // so the walk can stop there.
   if (fStoreMothers) {
     for (Int_t i = 0; i < fNParticles; i++) {
       if (fStoreFlags[i]) {

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -420,12 +420,6 @@ void ShipStack::SelectTracks() {
     }
     // --> Set storage flag
     fStoreFlags[i] = store;
-    // special case for Ship generators, want to keep all original particles
-    // with their mother daughter relationship independent if tracked or not.
-    // apply a dirty trick and use second mother to identify original generator
-    // particles. doesn't work, always true: Int_t iMother2 =
-    // GetParticle(i)->GetMother(1); maybe should set Mother2 to -1 in the
-    // generator if (iMother == iMother2) {fStoreMap[i] = kTRUE;}
   }
   // --> If flag is set, flag recursively mothers of selected tracks.
   // An already-flagged mother implies its whole ancestor chain is flagged,

--- a/shipgen/DPPythia8Generator.cxx
+++ b/shipgen/DPPythia8Generator.cxx
@@ -245,8 +245,7 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
 
           cpg->AddTrack((Int_t)fPythia->event[1].id(), pxN, pyN, pzN,
                         xN * mm + dx, yN * mm + dy, zN * mm, -1, false, eN,
-                        tN * mm / c_light,
-                        w);  // event[0] is the root of the exported chain
+                        tN * mm / c_light, w);
 
           dec_chain.push_back(1);
 
@@ -267,7 +266,7 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
         em = fPythia->event[im].e();
         tm = fPythia->event[im].tProd();
 
-        // mother points to track 0 (event[1]) in the exported chain
+        // mother of the meson is track 0 (the beam nucleon)
         imout = 0;
 
         cpg->AddTrack(
@@ -275,8 +274,7 @@ Bool_t DPPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
             ym * mm + dy, zm * mm, imout, false, em, tm * mm / c_light,
             w);  // convert pythia's (x,y,z[mm], t[mm/c]) to ([cm], [s])
 
-        // DP points to the direct mother in the exported chain, which is track
-        // 1
+        // mother of the DP is track 1 (the meson)
         cpg->AddTrack(fDP, px, py, pz, xp * mm + dx, yp * mm + dy, zp * mm, 1,
                       false, e, tp * mm / c_light, w);
 

--- a/shipgen/FixedTargetGenerator.cxx
+++ b/shipgen/FixedTargetGenerator.cxx
@@ -54,8 +54,9 @@ FixedTargetGenerator::FixedTargetGenerator() {
   fBoost = 1.;
   withEvtGen = kFALSE;
   withNtuple = kFALSE;
-  chicc = 1.7e-3;      // prob to produce primary ccbar pair/pot
-  chibb = 1.6e-7;      // prob to produce primary bbbar pair/pot
+  chicc = 1.7e-3;      // prob to produce primary ccbar pair/pot on Mo
+                       // (cf. python/heavyFlavourScaling.py)
+  chibb = 1.6e-7;      // prob to produce primary bbbar pair/pot on Mo
   nrpotspill = 5.E13;  // nr of protons / spill
   setByHand = kFALSE;
   Debug = kFALSE;

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -172,6 +172,8 @@ Bool_t GenieGenerator::ReadEventGeometryDriver(FairPrimaryGenerator* cpg) {
   if (!fNuOnly) {
     // Add final state lepton to the MCTrack stack:
     int outgoing_lepton_pdg = neu;
+    // CC: lepton PDG = neutrino PDG - 1 (12->11, 14->13, 16->15),
+    // antineutrinos keep the negative sign
     if (cc) outgoing_lepton_pdg = copysign(TMath::Abs(neu) - 1, neu);
     if (nuel) outgoing_lepton_pdg = 11;
 

--- a/shipgen/GenieGenerator.cxx
+++ b/shipgen/GenieGenerator.cxx
@@ -172,8 +172,8 @@ Bool_t GenieGenerator::ReadEventGeometryDriver(FairPrimaryGenerator* cpg) {
   if (!fNuOnly) {
     // Add final state lepton to the MCTrack stack:
     int outgoing_lepton_pdg = neu;
-    // CC: lepton PDG = neutrino PDG - 1 (12->11, 14->13, 16->15),
-    // antineutrinos keep the negative sign
+    // CC: |lepton PDG| = |neutrino PDG| - 1, sign preserved
+    // (14 -> 13, -14 -> -13)
     if (cc) outgoing_lepton_pdg = copysign(TMath::Abs(neu) - 1, neu);
     if (nuel) outgoing_lepton_pdg = 11;
 

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -24,8 +24,10 @@ HNLPythia8Generator::HNLPythia8Generator() {
   fId = 2212;           // proton
   fMom = 400;           // proton
   fHNL = 9900015;       // HNL  pdg code
-  fLmin = 5000. * cm;   // mm minimum  decay position z  ROOT units !
-  fLmax = 12000. * cm;  // mm maximum decay position z
+  fLmin = 5000. * cm;   // min decay length along the HNL flight direction
+                        // (50 m, stored in Pythia units, mm)
+  fLmax = 12000. * cm;  // max decay length along the HNL flight direction
+                        // (120 m, stored in Pythia units, mm)
   fFDs = 7.7 / 10.4;  // correction for Pythia6 to match measured Ds production
   fsmearBeam = 8 * mm;  // default value for smearing beam (8 mm)
   fPaintBeam = 5 * cm;  // default value for painting beam (5 cm)
@@ -242,10 +244,8 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       zS = zp + lam * pz;
       Double_t gam = e / TMath::Sqrt(e * e - p * p);
       Double_t beta = p / e;
-      tS = tp + LS / beta;  // units ? [mm/c] + [mm/beta] (beta is dimensionless
-                            // speed, and c=1 here) if one would use [s], then
-                            // tS = tp/(cm*c_light) + (LS/cm)/(beta*c_light) =
-                            // tS/(cm*c_light) i.e. units look consistent
+      tS = tp + LS / beta;  // decay time in Pythia units (mm/c): flight
+                            // distance over dimensionless beta
       w = TMath::Exp(-LS / (beta * gam * fctau)) *
           ((fLmax - fLmin) / (beta * gam * fctau));
       im = (Int_t)fPythia->event[i].mother1();

--- a/shipgen/HNLPythia8Generator.cxx
+++ b/shipgen/HNLPythia8Generator.cxx
@@ -28,7 +28,9 @@ HNLPythia8Generator::HNLPythia8Generator() {
                         // (50 m, stored in Pythia units, mm)
   fLmax = 12000. * cm;  // max decay length along the HNL flight direction
                         // (120 m, stored in Pythia units, mm)
-  fFDs = 7.7 / 10.4;  // correction for Pythia6 to match measured Ds production
+  fFDs = 7.7 / 10.4;    // correction for Pythia6 to match measured Ds
+                        // production.
+                        // TODO(olantwin, 2026-08-12): cite source of 7.7/10.4
   fsmearBeam = 8 * mm;  // default value for smearing beam (8 mm)
   fPaintBeam = 5 * cm;  // default value for painting beam (5 cm)
   fInputFile = nullptr;
@@ -246,6 +248,8 @@ Bool_t HNLPythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
       Double_t beta = p / e;
       tS = tp + LS / beta;  // decay time in Pythia units (mm/c): flight
                             // distance over dimensionless beta
+      // decay probability density at LS, normalised for the uniform sampling
+      // of LS over [fLmin, fLmax]
       w = TMath::Exp(-LS / (beta * gam * fctau)) *
           ((fLmax - fLmin) / (beta * gam * fctau));
       im = (Int_t)fPythia->event[i].mother1();

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -104,7 +104,8 @@ class HNLPythia8Generator : public SHiP::Generator {
   Double_t fLmin;   // min decay length along the HNL flight direction (mm)
   Double_t fLmax;   // max decay length along the HNL flight direction (mm)
   Int_t fnRetries;  // retries: no HNL produced
-  Double_t fctau;   // hnl lifetime
+  Double_t fctau;   // Pythia nominal proper lifetime tau0 = proper decay
+                    // length c*tau (mm)
   Double_t fFDs;    // correction for Pythia6 to match measured Ds production
   Double_t fsmearBeam;  // finite beam size
   Double_t fPaintBeam;  // beam painting radius

--- a/shipgen/HNLPythia8Generator.h
+++ b/shipgen/HNLPythia8Generator.h
@@ -101,11 +101,11 @@ class HNLPythia8Generator : public SHiP::Generator {
   Int_t fId;                   // target type
   Bool_t fUseRandom1{kFALSE};  // flag to use TRandom1
   Bool_t fUseRandom3{kTRUE};   // flag to use TRandom3 (default)
-  Double_t fLmin;              // m minimum  decay position z
-  Double_t fLmax;              // m maximum decay position z
-  Int_t fnRetries;             // retries: no HNL produced
-  Double_t fctau;              // hnl lifetime
-  Double_t fFDs;  // correction for Pythia6 to match measured Ds production
+  Double_t fLmin;   // min decay length along the HNL flight direction (mm)
+  Double_t fLmax;   // max decay length along the HNL flight direction (mm)
+  Int_t fnRetries;  // retries: no HNL produced
+  Double_t fctau;   // hnl lifetime
+  Double_t fFDs;    // correction for Pythia6 to match measured Ds production
   Double_t fsmearBeam;  // finite beam size
   Double_t fPaintBeam;  // beam painting radius
   TFile* fInputFile;    //! pointer to a file

--- a/shipgen/MuDISGenerator.cxx
+++ b/shipgen/MuDISGenerator.cxx
@@ -114,7 +114,9 @@ Bool_t MuDISGenerator::ReadEvent(FairPrimaryGenerator* cpg) {
   Double_t start[3] = {0., 0., startZ};
   Double_t end[3] = {0., 0., endZ};
 
-  // incoming muon  array('d',[pid,px,py,pz,E,x,y,z,w,t])
+  // incoming muon
+  // array('d',[pid,px,py,pz,E,x,y,z,w,isProton,xsec,t,nDIS,nmuons]); entries
+  // 10-12 hold cross-section, time and nDIS (see below)
   TVectorD* mu = dynamic_cast<TVectorD*>(iMuon->AddrAt(0));
   LOG(debug) << "muon DIS Generator in muon " << int((*mu)[0]);
   Double_t x = (*mu)[5] * 100.;  // come in m -> cm

--- a/shipgen/Pythia8Generator.cxx
+++ b/shipgen/Pythia8Generator.cxx
@@ -187,10 +187,6 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg) {
   Double_t x, y, z, px, py, pz, dl, e, tof;
   Int_t im, id, key;
   fnRetries = 0;
-  // ReadEvent only supports the external-file mode (charm/beauty hadrons read
-  // from fTree). The standalone (no external file) branch in Init() has no
-  // corresponding event path here, so guard against dereferencing a null fTree
-  // instead of crashing on an uninitialized pointer.
   if (!fTree) {
     LOG(fatal) << "Pythia8Generator::ReadEvent: no external input tree is set; "
                   "standalone generation is not implemented. Call "

--- a/shipgen/TTreeGenerator.cxx
+++ b/shipgen/TTreeGenerator.cxx
@@ -104,9 +104,8 @@ Bool_t TTreeGenerator::ReadEvent(FairPrimaryGenerator* primGen) {
     return kFALSE;
   }
 
-  // Position in cm, momentum in GeV/c. Pass e < 0 (-9e9) so
-  // FairPrimaryGenerator computes the energy from the momentum and PDG mass
-  // instead of storing E = 0.
+  // Position in cm, momentum in GeV/c. e < 0 makes FairPrimaryGenerator
+  // compute the energy from the momentum and PDG mass.
   primGen->AddTrack(fPdgId, fPx, fPy, fPz, fX, fY, fZ, -1, true, -9e9, 0.,
                     fWeight);
 

--- a/splitcal/splitcalHit.cxx
+++ b/splitcal/splitcalHit.cxx
@@ -72,8 +72,8 @@ splitcalHit::splitcalHit(const std::vector<splitcalPoint>& points, Double_t t0)
 
   SetIDs(isPrec, nL, nMx, nMy, nS);
 
-  // GetNode(name) is a linear scan over all strip nodes (up to O(10^5)); the
-  // geometry is fixed, so cache the node pointer per strip name.
+  // The geometry is fixed, so cache the node per strip name; GetNode(name)
+  // is a linear scan over all strip nodes.
   static std::unordered_map<std::string, TGeoNode*> stripNodeCache;
   TGeoNode* strip = nullptr;
   if (auto it = stripNodeCache.find(stripName); it != stripNodeCache.end()) {

--- a/strawtubes/strawtubes.cxx
+++ b/strawtubes/strawtubes.cxx
@@ -61,10 +61,8 @@ Bool_t strawtubes::ProcessHits(FairVolume* vol) {
     fLength = gMC->TrackLength();
     gMC->TrackPosition(fPos);
     gMC->TrackMomentum(fMom);
-    // Clear the "already recorded" marker on every fresh entry so that a later
-    // traversal of the same straw (curling track, delta ray, next track or
-    // event) is not silently dropped. The marker only exists to deduplicate
-    // repeated exit signals at the same boundary crossing.
+    // Reset the "already recorded" marker so a later traversal of the same
+    // straw (curling track, next track/event) is not silently dropped.
     fVolumeID = -1;
   }
   // Sum energy loss for all steps in the active volume
@@ -451,9 +449,8 @@ void strawtubes::StrawEndPoints(Int_t fDetectorID, TVector3& vbot,
                                 TVector3& vtop)
 // method to get end points from TGeoNavigator
 {
-  // The endpoints depend only on the (fixed) geometry, so cache them per detID:
-  // rebuilding the volume path and re-navigating on every hit is a significant
-  // cost in the stepping and digitisation hot paths.
+  // The geometry is fixed, so cache the endpoints per detID; TGeo navigation
+  // is expensive in the stepping and digitisation hot paths.
   static std::unordered_map<Int_t, std::pair<TVector3, TVector3>> endPointCache;
   if (auto it = endPointCache.find(fDetectorID); it != endPointCache.end()) {
     vbot = it->second.first;


### PR DESCRIPTION
This PR addresses several issues with comments in FairShip:

1. (first commit): Claude tends to be too wordy and includes too much historical narrative in comments. A good comment should explain *why* something non-obvious was done that way, not *how* it ended up that way. This commit trims this narration and distills the comments to the important points.
2. (second commit): Some comments by Thomas, me and others are no longer up-to-date or plain wrong. This commit tries to correct/remove/update where possible)
3. (third commit): we have significant gaps where non-trivial/non-obvious code is not commented and magic numbers are not documented. This commit tries to deal with some instances and adds comments where I could not figure out where things came from.

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation across simulation, detector, tracking, vertexing, geometry, and event-display workflows.
  * Improved explanations for particle relationships, timing and decay parameters, detector positioning, interpolation, covariance handling, and track-to-hit mappings.
  * Documented cosmic-mode argument values and heavy-flavor production assumptions.
* **Bug Fixes**
  * Preserved fitted particle hypotheses during vertex reconstruction.
  * Corrected covariance block extraction and numeric type handling for fitted track results.
  * Removed obsolete proton-to-pion reassignment during track representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->