### PR TITLE
Fix signal track lookup

### DIFF
--- a/.github/workflows/pixi-build.yml
+++ b/.github/workflows/pixi-build.yml
@@ -41,6 +41,8 @@ jobs:
         run: pixi run --locked build
       - name: Test
         run: pixi run --locked test
+      - name: Python unit tests
+        run: pixi run --locked ci-pytest
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:

--- a/examples/analysis_example.py
+++ b/examples/analysis_example.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser
 import ROOT
 import rootUtils as ut
 from experimental import analysis_toolkit
+from mc_truth import signal_weight
 
 
 def main() -> None:
@@ -99,7 +100,7 @@ def main() -> None:
         print(f"Event{event_nr}:")
         inspector.dump_event(event, mom_threshold=0.5)  # in GeV
 
-        event_weight = event.MCTrack[2].GetWeight()
+        event_weight = signal_weight(event.MCTrack)
 
         hist_dict["event_weight"].Fill(event_weight)
 

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -9,6 +9,7 @@ import ROOT
 import rootUtils as ut
 import shipRoot_conf
 import shipunit as u
+from mc_truth import find_signal_track, signal_weight
 from ShipGeoConfig import load_from_root_file
 
 shipRoot_conf.configure()
@@ -436,17 +437,20 @@ def fitSingleGauss(x: str, ba: float | None = None, be: float | None = None) -> 
 
 def match2HNL(p) -> bool:
     matched = False
+    signalId = find_signal_track(sTree.MCTrack)
+    if signalId is None:
+        return matched
     hnlKey = []
     for t in [p.GetDaughter(0), p.GetDaughter(1)]:
         mcp = sTree.fitTrack2MC[t]
+        # Walk up the MC mother chain looking for the signal particle.
         while mcp > -0.5:
             if mcp >= len(sTree.MCTrack):
                 break
-            mo = sTree.MCTrack[mcp]
-            if abs(mo.GetPdgCode()) == 9900015:
+            if mcp == signalId:
                 hnlKey.append(mcp)
                 break
-            mcp = mo.GetMotherId()
+            mcp = sTree.MCTrack[mcp].GetMotherId()
     if len(hnlKey) == 2 and hnlKey[0] == hnlKey[1]:
         matched = True
     return matched
@@ -554,14 +558,9 @@ def myEventLoop(n: int) -> None:
         sTree.Particles = sTree.Particles_PR
     if not checkHNLorigin(sTree):
         return
-    if not len(sTree.MCTrack) > 1:
-        wg = 1.0
-    else:
-        wg = sTree.MCTrack[1].GetWeight()
-    if not wg > 0.0:
-        wg = 1.0
+    wg = signal_weight(sTree.MCTrack)
 
-        # make some straw hit analysis
+    # make some straw hit analysis
     hitlist = {}
     for ahit in sTree.strawtubesPoint:
         detID = ahit.GetDetectorID()

--- a/macro/ShipAna.py
+++ b/macro/ShipAna.py
@@ -435,10 +435,9 @@ def fitSingleGauss(x: str, ba: float | None = None, be: float | None = None) -> 
         h[x].Fit(myGauss, "", "", ba, be)
 
 
-def match2HNL(p) -> bool:
+def match2HNL(p, signal_id) -> bool:
     matched = False
-    signalId = find_signal_track(sTree.MCTrack)
-    if signalId is None:
+    if signal_id is None:
         return matched
     hnlKey = []
     for t in [p.GetDaughter(0), p.GetDaughter(1)]:
@@ -447,7 +446,7 @@ def match2HNL(p) -> bool:
         while mcp > -0.5:
             if mcp >= len(sTree.MCTrack):
                 break
-            if mcp == signalId:
+            if mcp == signal_id:
                 hnlKey.append(mcp)
                 break
             mcp = sTree.MCTrack[mcp].GetMotherId()
@@ -559,6 +558,7 @@ def myEventLoop(n: int) -> None:
     if not checkHNLorigin(sTree):
         return
     wg = signal_weight(sTree.MCTrack)
+    signal_id = find_signal_track(sTree.MCTrack)
 
     # make some straw hit analysis
     hitlist = {}
@@ -667,7 +667,7 @@ def myEventLoop(n: int) -> None:
         if not checkMeasurements:
             continue
             # check mc matching
-        if not match2HNL(HNL):
+        if not match2HNL(HNL, signal_id):
             continue
         HNLPos = ROOT.TLorentzVector()
         HNL.ProductionVertex(HNLPos)

--- a/pixi.toml
+++ b/pixi.toml
@@ -78,6 +78,11 @@ build = { cmd = "cmake --build build -j$(nproc)", depends-on = ["configure"] }
 install = { cmd = "cmake --install build", depends-on = ["build"] }
 test = { cmd = "ctest --test-dir build --output-on-failure", depends-on = ["build"] }
 
+# Python unit tests. Separate from `test` so they run without a build: they
+# only need `python/` on PYTHONPATH, which activate.sh provides.
+[tasks.ci-pytest]
+cmd = "pytest tests/"
+
 # --- CI sim-chain tasks ---
 # Mirror the per-step commands in .github/workflows/build-run.yml so the
 # whole sim/reco/ana/benchmark chain is reproducible locally via `pixi run`.

--- a/python/mc_truth.py
+++ b/python/mc_truth.py
@@ -52,16 +52,13 @@ def find_signal_track(mc_tracks, pdg=None):
 
     n_tracks = len(mc_tracks)
     stack = {i for i in range(n_tracks) if mc_tracks[i].GetProcName() == PRIMARY_PROCESS}
+    mothers = {i: mc_tracks[i].GetMotherId() for i in stack}
 
-    def mother_on_stack(i):
-        mother = mc_tracks[i].GetMotherId()
-        return mother if mother in stack else None
-
-    roots = [i for i in stack if mother_on_stack(i) is None]
+    roots = [i for i in stack if mothers[i] not in stack]
     if len(roots) != 1:
         return None
 
-    with_daughters = {mother_on_stack(i) for i in stack if mother_on_stack(i) is not None}
+    with_daughters = {mothers[i] for i in stack if mothers[i] in stack}
     return max(with_daughters) if with_daughters else None
 
 

--- a/python/mc_truth.py
+++ b/python/mc_truth.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+"""Helpers for locating particles of interest in the MC truth record.
+
+Shared by the analysis macros so the conventions live in a single place rather
+than being rediscovered (and hardcoded) at every call site.
+"""
+
+# Process name FairShip gives to tracks put on the stack by the generator, as
+# opposed to those created by Geant during transport.
+PRIMARY_PROCESS = "Primary particle emission"
+
+
+def find_signal_track(mc_tracks, pdg=None):
+    """Return the index of the signal particle in ``mc_tracks``, or ``None``.
+
+    The signal (HNL, dark photon, dark scalar, ...) does not sit at a fixed
+    position: the generators store a variable amount of the production chain
+    ahead of it, so it can be track 0, 1 or 2 depending on the configuration.
+    Its PDG code is not a reliable handle either, since external-input
+    generators use placeholders. Hence this lookup.
+
+    Parameters
+    ----------
+    mc_tracks : sequence
+        The ``MCTrack`` branch. Indexing and ``len()`` are used rather than
+        ``At()``/``GetEntriesFast()`` so that both ``std::vector<ShipMCTrack>``
+        and ``TClonesArray`` work.
+    pdg : int, optional
+        The signal PDG code, when the caller knows it. Otherwise the signal is
+        inferred from the shape of the generator record, as described below.
+        Pass ``pdg`` where it is available.
+
+    Notes
+    -----
+    A signal event is generated as a single production chain -- optionally a
+    grandmother and a mother, then the signal -- followed by the signal's decay
+    products. So among the tracks the generator put on the stack there is
+    exactly one root, and the signal is the deepest one that has a daughter
+    also on the stack.
+
+    Requiring a single root is what keeps this honest on background samples,
+    where the generator stack is a branching cascade with several roots: those
+    give ``None`` rather than an arbitrary resonance decay.
+    """
+    if pdg is not None:
+        for i in range(len(mc_tracks)):
+            if abs(mc_tracks[i].GetPdgCode()) == abs(pdg):
+                return i
+        return None
+
+    n_tracks = len(mc_tracks)
+    stack = {i for i in range(n_tracks) if mc_tracks[i].GetProcName() == PRIMARY_PROCESS}
+
+    def mother_on_stack(i):
+        mother = mc_tracks[i].GetMotherId()
+        return mother if mother in stack else None
+
+    roots = [i for i in stack if mother_on_stack(i) is None]
+    if len(roots) != 1:
+        return None
+
+    with_daughters = {mother_on_stack(i) for i in stack if mother_on_stack(i) is not None}
+    return max(with_daughters) if with_daughters else None
+
+
+def signal_weight(mc_tracks, pdg=None, default=1.0):
+    """Return the event weight carried by the signal track.
+
+    Every generator stores the per-event weight on the signal, so this is the
+    robust way to read it. Falls back to ``default`` when no signal is found.
+    """
+    signal_id = find_signal_track(mc_tracks, pdg)
+    if signal_id is None:
+        return default
+    weight = mc_tracks[signal_id].GetWeight()
+    return weight if weight > 0.0 else default

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -204,7 +204,7 @@ def run_track_pattern_recognition(input_file, geo_file, output_file, method, dy=
 
         ########################################## Recognized tracks ###################################################
 
-        nTracklets = sTree.Tracklets.GetEntriesFast()
+        nTracklets = len(sTree.Tracklets)
 
         for i_track in range(nTracklets):
             atracklet = sTree.Tracklets[i_track]
@@ -654,16 +654,16 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     # call this routine once for each event before smearing
     MCTrackIDs = []
     sTree.GetEvent(iEvent)
-    nMCTracks = sTree.MCTrack.GetEntriesFast()
+    nMCTracks = len(sTree.MCTrack)
 
     # 1. MCTrackIDs: list of tracks decaying after the last tstation and originating before the first
     for i in reversed(range(nMCTracks)):
-        atrack = sTree.MCTrack.At(i)
+        atrack = sTree.MCTrack[i]
         # track endpoint after tstations?
         if atrack.GetStartZ() > TStation4EndZ:
             motherId = atrack.GetMotherId()
             if motherId > -1:
-                mothertrack = sTree.MCTrack.At(motherId)
+                mothertrack = sTree.MCTrack[motherId]
                 mothertrackZ = mothertrack.GetStartZ()
                 # this mother track is a HNL decay
                 # track starts inside the decay volume? (before 1 st tstation)
@@ -674,10 +674,10 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
         return MCTrackIDs
 
     # 2. hitsinTimeDet: list of tracks with hits in TimeDet
-    # nVetoHits = sTree.vetoPoint.GetEntriesFast()
+    # nVetoHits = len(sTree.vetoPoint)
     # hitsinTimeDet=[]
     # for i in range(nVetoHits):
-    #    avetohit = sTree.vetoPoint.At(i)
+    #    avetohit = sTree.vetoPoint[i]
     #    #hit in TimeDet?
     #    if sGeo.FindNode(avetohit.GetX(), avetohit.GetY(), avetohit.GetZ()).GetName() == 'TimeDet_1':
     #        if avetohit.GetTrackID() not in hitsinTimeDet:
@@ -695,7 +695,7 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     #    return MCTrackIDs
 
     # 4. Find straws that have multiple hits
-    nHits = sTree.strawtubesPoint.GetEntriesFast()
+    nHits = len(sTree.strawtubesPoint)
     hitstraws = {}
     duplicatestrawhit = set()
 
@@ -804,7 +804,7 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     itemstoremove = []
 
     for item in MCTrackIDs:
-        atrack = sTree.MCTrack.At(item)
+        atrack = sTree.MCTrack[item]
         motherId = atrack.GetMotherId()
         # keep only daughters of the signal particle; assumes the standard HNL
         # production chain (external charm file), where the signal is MCTrack 2.

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -806,10 +806,13 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     # reaches the tracker is a Geant secondary (delta ray, bremsstrahlung).
     signalId = find_signal_track(sTree.MCTrack)
 
-    itemstoremove = [item for item in MCTrackIDs if sTree.MCTrack[item].GetMotherId() != signalId]
+    if signalId is None:
+        print(f"Warning: no signal track found in event {iEvent}, skipping the signal-daughter filter.")
+    else:
+        itemstoremove = [item for item in MCTrackIDs if sTree.MCTrack[item].GetMotherId() != signalId]
 
-    for item in itemstoremove:
-        MCTrackIDs.remove(item)
+        for item in itemstoremove:
+            MCTrackIDs.remove(item)
 
     return MCTrackIDs
 

--- a/python/shipStrawTracking.py
+++ b/python/shipStrawTracking.py
@@ -14,6 +14,7 @@ import ROOT
 # For modules
 import shipDet_conf
 import shipunit as u
+from mc_truth import find_signal_track
 
 # For ShipGeo
 from ShipGeoConfig import load_from_root_file
@@ -801,16 +802,11 @@ def getReconstructibleTracks(iEvent: int, sTree, sGeo, ShipGeo):
     if len(MCTrackIDs) == 0:
         return MCTrackIDs
 
-    itemstoremove = []
+    # 8. Keep only the daughters of the signal particle. Everything else that
+    # reaches the tracker is a Geant secondary (delta ray, bremsstrahlung).
+    signalId = find_signal_track(sTree.MCTrack)
 
-    for item in MCTrackIDs:
-        atrack = sTree.MCTrack[item]
-        motherId = atrack.GetMotherId()
-        # keep only daughters of the signal particle; assumes the standard HNL
-        # production chain (external charm file), where the signal is MCTrack 2.
-        # Other generator configurations are not supported here.
-        if motherId != 2:
-            itemstoremove.append(item)
+    itemstoremove = [item for item in MCTrackIDs if sTree.MCTrack[item].GetMotherId() != signalId]
 
     for item in itemstoremove:
         MCTrackIDs.remove(item)

--- a/tests/test_signal_particle.py
+++ b/tests/test_signal_particle.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright CERN for the benefit of the SHiP Collaboration
+
+import pytest
+from mc_truth import PRIMARY_PROCESS, find_signal_track, signal_weight
+
+
+class FakeTrack:
+    """Minimal stand-in for ShipMCTrack, so the tests need no ROOT."""
+
+    def __init__(self, pdg, mother, process=PRIMARY_PROCESS, weight=1.0):
+        self.pdg = pdg
+        self.mother = mother
+        self.process = process
+        self.weight = weight
+
+    def GetPdgCode(self):
+        return self.pdg
+
+    def GetMotherId(self):
+        return self.mother
+
+    def GetProcName(self):
+        return self.process
+
+    def GetWeight(self):
+        return self.weight
+
+
+# The five MCTrack layouts the SHiP generators produce. Each is (tracks,
+# expected signal index); see shipgen/HNLPythia8Generator.cxx:269-283,
+# shipgen/DPPythia8Generator.cxx:246-298 and shipgen/EvtCalcGenerator.cxx:205.
+LAYOUTS = {
+    "hnl_external_charm_file": (
+        [
+            FakeTrack(2212, -1),  # grand mother from the input file
+            FakeTrack(431, 0),  # charm hadron
+            FakeTrack(9900015, 1),  # signal
+            FakeTrack(13, 2),
+            FakeTrack(-211, 2),
+        ],
+        2,
+    ),
+    "hnl_no_input_file": (
+        [
+            FakeTrack(431, -1),  # charm hadron
+            FakeTrack(9900015, 0),  # signal
+            FakeTrack(13, 1),
+            FakeTrack(-211, 1),
+        ],
+        1,
+    ),
+    "dark_photon_meson_production": (
+        [
+            FakeTrack(2212, -1),
+            FakeTrack(111, 0),
+            FakeTrack(4900023, 1),  # signal
+            FakeTrack(13, 2),
+            FakeTrack(-13, 2),
+        ],
+        2,
+    ),
+    "dark_photon_proton_bremsstrahlung": (
+        [
+            FakeTrack(9900015, -1),  # signal, no mother stored
+            FakeTrack(11, 0),
+            FakeTrack(-11, 0),
+        ],
+        0,
+    ),
+    "evtcalc_external_llp_file": (
+        [
+            FakeTrack(999, -1),  # signal, geantino placeholder PDG
+            FakeTrack(13, 0),
+            FakeTrack(-13, 0),
+        ],
+        0,
+    ),
+}
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_signal_found_in_every_generator_layout(layout):
+    tracks, expected = LAYOUTS[layout]
+    assert find_signal_track(tracks) == expected
+
+
+def test_geant_secondaries_are_ignored():
+    """A delta ray crossing the tracker must not be mistaken for a daughter."""
+    tracks = [
+        FakeTrack(12345678, -1),  # signal from an external file
+        FakeTrack(-13, 0),
+        FakeTrack(13, 0),
+        FakeTrack(11, 2, process="Delta ray"),
+        FakeTrack(22, 2, process="Bremstrahlung"),
+    ]
+    assert find_signal_track(tracks) == 0
+
+
+def test_explicit_pdg_takes_precedence():
+    tracks, _ = LAYOUTS["hnl_external_charm_file"]
+    assert find_signal_track(tracks, pdg=9900015) == 2
+    # Sign is irrelevant, as elsewhere in the analysis code.
+    assert find_signal_track(tracks, pdg=-9900015) == 2
+
+
+def test_explicit_pdg_absent_returns_none():
+    tracks, _ = LAYOUTS["hnl_external_charm_file"]
+    assert find_signal_track(tracks, pdg=4900023) is None
+
+
+def test_single_stored_daughter_still_finds_the_signal():
+    """Not every decay product is kept; one daughter must be enough.
+
+    Seen in 7 of 2000 events of the issue-1371 dark-scalar sample.
+    """
+    tracks = [
+        FakeTrack(12345678, -1),  # signal
+        FakeTrack(13, 0),  # the only decay product stored
+        FakeTrack(11, 1, process="Delta ray"),
+    ]
+    assert find_signal_track(tracks) == 0
+
+
+def test_background_cascade_returns_none():
+    """A muon-background stack is a branching cascade with several roots."""
+    tracks = [
+        FakeTrack(2212, -1),
+        FakeTrack(2112, -1),  # second root: not a single production chain
+        FakeTrack(1, 1),
+        FakeTrack(1, 2),
+        FakeTrack(213, 3),
+        FakeTrack(211, 4),
+    ]
+    assert find_signal_track(tracks) is None
+
+
+def test_lone_primary_returns_none():
+    """A single generator track with no daughters is not a signal decay."""
+    assert find_signal_track([FakeTrack(2212, -1)]) is None
+
+
+def test_empty_event_returns_none():
+    assert find_signal_track([]) is None
+
+
+def test_signal_weight_reads_the_signal_track():
+    tracks = [
+        FakeTrack(2212, -1, weight=1.0),  # grandmother, weight hardcoded to 1
+        FakeTrack(431, 0, weight=0.25),
+        FakeTrack(9900015, 1, weight=0.25),  # signal
+        FakeTrack(13, 2, weight=0.25),
+        FakeTrack(-211, 2, weight=0.25),
+    ]
+    assert signal_weight(tracks) == pytest.approx(0.25)
+
+
+def test_signal_weight_falls_back_when_no_signal():
+    tracks = [FakeTrack(2212, -1, weight=0.5), FakeTrack(2112, -1, weight=0.5)]
+    assert signal_weight(tracks) == pytest.approx(1.0)
+
+
+def test_signal_weight_falls_back_on_nonpositive_weight():
+    tracks = [
+        FakeTrack(9900015, -1, weight=0.0),
+        FakeTrack(13, 0),
+        FakeTrack(-13, 0),
+    ]
+    assert signal_weight(tracks) == pytest.approx(1.0)


### PR DESCRIPTION
This fixes #1378.

In many places we rely on generator internals (and several different ways!) to find the HNL or signal.

This PR aims to replace them (in all actively used places) with a single helper `mc_truth.find_signal_track` that checks the creation process (or PDG if available) to find the signal.
 
A helper `mc_truth.signal_weight` is also available to read its weight.

Some broken or very HNL specific code has not (yet) been updated.

## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared signal-particle detection and event-weight handling across analysis workflows.
  * Improved support for HNL, dark-photon, and EvtCalc generator layouts.
  * Added fallback handling for missing or invalid event weights.

* **Bug Fixes**
  * Improved signal-track matching and reconstructible-track selection.
  * Replaced fixed track assumptions with dynamic event-based identification.

* **Tests**
  * Added comprehensive coverage for signal detection, weighting, background events, and incomplete decays.
  * Added a dedicated locked Python test task to build checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->