### PR TITLE
fix(muonDIS): replace removed TDirectory attribute access

### DIFF
--- a/muonDIS/add_muonresponse.py
+++ b/muonDIS/add_muonresponse.py
@@ -43,10 +43,10 @@ headers = [
 def inspect_file(inputfile, muonfile, print_table=False) -> bool:
     """Inspecting the produced file for successfully added muon veto points."""
     input_file = r.TFile.Open(inputfile, "read")
-    input_tree = input_file.cbmsim
+    input_tree = input_file["cbmsim"]
 
     muon_file = r.TFile.Open(muonfile, "read")
-    muon_tree = muon_file.DIS
+    muon_tree = muon_file["DIS"]
 
     muons_found = False
 
@@ -99,7 +99,7 @@ def modify_file(inputfile, muonfile) -> None:
 
     input_file = r.TFile.Open(inputfile, "read")
     try:
-        input_tree = input_file.cbmsim
+        input_tree = input_file["cbmsim"]
     except Exception as e:
         print(f"Error: {e}")
         input_file.Close()
@@ -108,7 +108,7 @@ def modify_file(inputfile, muonfile) -> None:
     # Open the external file with additional vetoPoints
     muon_file = r.TFile.Open(muonfile, "read")
     try:
-        muon_tree = muon_file.DIS
+        muon_tree = muon_file["DIS"]
     except Exception as e:
         print(f"Error: {e}")
         muon_file.Close()

--- a/muonDIS/makeMuonDIS.py
+++ b/muonDIS/makeMuonDIS.py
@@ -73,7 +73,7 @@ def update_file(filename: str, final_xsec) -> None:
     """Update the DIS cross section of the muon to the converged value from Pythia."""
     file = r.TFile.Open(filename, "read")
 
-    original_tree = file.DIS
+    original_tree = file["DIS"]
 
     temp_filename = filename + ".tmp"
     temp_file = r.TFile.Open(temp_filename, "recreate")
@@ -112,7 +112,7 @@ Fixtarget = {1: "p+", 0: "n0"}
 def inspect_file(filename: str) -> None:
     """Inspect the contents of muonDis file."""
     file = r.TFile.Open(filename, "READ")
-    tree = file.DIS
+    tree = file["DIS"]
 
     table_rows = []
 
@@ -141,7 +141,7 @@ def makeMuonDIS() -> None:
     muonFile = r.TFile.Open(args.inputFile, "read")
 
     try:
-        muon_tree = muonFile.MuonAndSoftInteractions
+        muon_tree = muonFile["MuonAndSoftInteractions"]
     except Exception as e:
         logging.error(e)
         muonFile.Close()

--- a/muonDIS/make_nTuple_SBT.py
+++ b/muonDIS/make_nTuple_SBT.py
@@ -223,7 +223,7 @@ for inputFolder in os.listdir(path):
             os.path.join(path, inputFolder, "ship.conical.MuonBack-TGeant4.root"),
             "read",
         )
-        tree = f.cbmsim
+        tree = f["cbmsim"]
     except Exception as e:
         logging.debug(f"Error :{e}")
 
@@ -384,7 +384,7 @@ print(
 event_data = []
 with r.TFile.Open(args.outputfile, "read") as file:
     try:
-        tree = file.MuonAndSoftInteractions
+        tree = file["MuonAndSoftInteractions"]
     except Exception as e:
         print(f"Error: {e}")
         exit(1)

--- a/muonDIS/make_nTuple_Tr.py
+++ b/muonDIS/make_nTuple_Tr.py
@@ -222,7 +222,7 @@ for inputFolder in os.listdir(path):
             os.path.join(path, inputFolder, "ship.conical.MuonBack-TGeant4.root"),
             "read",
         )
-        tree = f.cbmsim
+        tree = f["cbmsim"]
     except Exception as e:
         print(f"Error :{e}")
 
@@ -392,7 +392,7 @@ print(
 event_data = []
 with r.TFile.Open(args.outputfile, "read") as file:
     try:
-        tree = file.MuonAndSoftInteractions
+        tree = file["MuonAndSoftInteractions"]
     except Exception as e:
         print(f"Error: {e}")
         exit(1)


### PR DESCRIPTION
Follow-up to #1316

ROOT 6.38 removed the deprecated TDirectory attribute style lookup, while the muonDIS scripts still contain accesses such as `file.DIS` and `file.cbmsim`

This replaces the remaining attribute accesses in `muonDIS/` with the item syntax

Tested locally with ROOT 6.40.02:
- static checks pass
- `makeMuonDIS.py` completes on a controlled 1-muon input with 2 DIS events
- the generated sample runs successfully through a short Geant4 smoke test

AI assistance: ChatGPT (GPT-5.6 Sol) was used during debugging, testing, and review of this change. 
I reviewed and applied the submitted changes manually

## Checklist

- [ ] Changelog updated (if applicable)
- [x] Commit message follows [conventional commits (https://www.conventionalcommits.org/)
