### PR TITLE
Intermediate nsplits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ it in future.
 ### Fixed
 
 * `veto` now registers the configured `sensitiveMed` instead of a hardcoded medium name; previously any other value resolved to a null `TGeoMedium`
-* Kaon/pion splitting no longer silently loses the whole clone set when the first track after the decay falls below the energy cut (the buffered clones were discarded by the stack popper's reset before ever being tracked). This removed ~17% of muons from charged-kaon decay in flight (−2.8% of the total muon rate) in split productions; pions were unaffected only because their soft decay muons imply equally soft, unobservable clones. The clone buffer is now flushed only into tracks that survive the cut, and a warning is emitted if an event ends with clones still buffered. Note that `--multiple-kpi-splits` was only computationally viable because of this loss (it silently killed ~99.9% of the per-step clone flushes); with the fix it exhausts memory within a few events and must not be used until the clone cascade is bounded
+* Kaon/pion splitting no longer silently loses the whole clone set when the first track after the decay falls below the energy cut (the buffered clones were discarded by the stack popper's reset before being tracked). This removed ~17% of muons from charged-kaon decay in flight (−2.8% of the total muon rate) in split productions; pions were unaffected because their soft decay muons imply equally soft, unobservable clones. The clone buffer is now flushed only into tracks that survive the cut, and a warning is emitted if an event ends with clones still buffered. To avoid memory issues, a specific number is set for the splits per GEANT4 step
 
 ### Removed
 

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -87,16 +87,20 @@ ap.add_argument(
     "--kaon-pion-splits",
     type=int,
     default=0,
-    help="splitting factor for kaons and pions, in order to boost the number of muons stemming from their decays",
+    help="splitting factor for kaons and pions when they decay, in order to boost the number of muons stemming from their decays",
+)
+ap.add_argument(
+    "--intermediate-kaon-pion-splits",
+    type=int,
+    default=2,
+    help="EXPERTS ONLY: intermediate splitting factor for kaons and pions for each GEANT4 step before they decay, "
+          "in order to boost the number of muons stemming from forced decays. "
+          "EXPERTS ONLY: risk of very large memory usage if the number is set without proper testing",
 )
 ap.add_argument(
     "--multiple-kpi-splits",
     action="store_true",
-    help="split kaons and pions multiple times along the track path. "
-    "WARNING: computationally unbounded — every step spawns N clones and clone "
-    "daughters are split recursively, which exhausts memory within a few "
-    "events now that buffered clones are reliably tracked; needs a cascade "
-    "guard before production use",
+    help="split kaons and pions multiple times along the track path",
 )
 
 ap.add_argument("-C", "--charm", action=argparse.BooleanOptionalAction, default=False, help="generate charm decays")
@@ -231,8 +235,8 @@ if args.debug:
 
 if args.kaon_pion_splits < 0:
     ap.error("--kaon-pion-splits must be >= 0")
-if args.multiple_kpi_splits and args.kaon_pion_splits == 0:
-    ap.error("--multiple-kpi-splits requires --kaon-pion-splits > 0")
+if args.multiple_kpi_splits and args.intermediate_kaon_pion_splits <= 1:
+    ap.error("--multiple-kpi-splits requires --intermediate-kaon-pion-splits > 1")
 
 
 if args.G4only:
@@ -400,6 +404,7 @@ sensPlaneHA = ROOT.exitHadronAbsorber()
 sensPlaneHA.SetNSplits(args.kaon_pion_splits)  # type: ignore[missing-attribute]
 if args.multiple_kpi_splits:
     sensPlaneHA.SetSplitMultipleTimes()  # type: ignore[missing-attribute]
+    sensPlaneHA.SetIntermediateNSplits(args.intermediate_kaon_pion_splits)  # type: ignore[missing-attribute]
 sensPlaneHA.SetEnergyCut(args.ecut * u.GeV)
 sensPlaneHA.SetVetoPointName("PlaneHA")
 

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -50,6 +50,7 @@ exitHadronAbsorber::exitHadronAbsorber(const char* Name, Bool_t Active)
       fCylindricalPlane(kFALSE),
       fUseCaveCoordinates(kFALSE),
       fNsplits(0),
+      fIntermediateNsplits(2),
       fCurrentSurvivalFactor(1) {}
 
 exitHadronAbsorber::exitHadronAbsorber()
@@ -63,6 +64,7 @@ exitHadronAbsorber::exitHadronAbsorber()
       fCylindricalPlane(kFALSE),
       fUseCaveCoordinates(kFALSE),
       fNsplits(0),
+      fIntermediateNsplits(2),
       fCurrentSurvivalFactor(1) {}
 
 Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
@@ -100,7 +102,7 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
     }
   }
 
-  if (fNsplits > 0 && (!fSplitOnce)) {
+  if (fIntermediateNsplits > 0 && (!fSplitOnce)) {
     Int_t currentTrackId = gMC->GetStack()->GetCurrentTrackNumber();
 
     if (fCloneTracks.count(currentTrackId) > 0 ||
@@ -141,8 +143,8 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
           Int_t trueParentId = part->GetFirstMother();
 
           Double_t decayBranchWeight = fCurrentSurvivalFactor * P_decay;
-          Double_t cloneWeight = decayBranchWeight / fNsplits;
-          for (int i = 0; i < fNsplits; ++i) {
+          Double_t cloneWeight = decayBranchWeight / fIntermediateNsplits;
+          for (int i = 0; i < fIntermediateNsplits; ++i) {
             TrackBuffer clone;
             clone.pdg = track_pid;
             clone.px = mom.Px();
@@ -562,7 +564,7 @@ void exitHadronAbsorber::ConstructGeometry() {
                                                 new TGeoTranslation(0, 0, 0));
     AddSensitiveVolume(sensPlaneCyl);
   }
-  if ((fNsplits > 0) && (!fSplitOnce)) {
+  if ((fIntermediateNsplits > 0) && (!fSplitOnce)) {
     TString parentVolumeName = "/target_vacuum_box_1";
     nav->cd(parentVolumeName.Data());
     TGeoVolume* vol = nav->GetCurrentNode()->GetVolume();

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -44,6 +44,7 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   // void FinishEvent();
 
   void SetNSplits(Int_t n) { fNsplits = n; }
+  void SetIntermediateNSplits(Int_t n) { fIntermediateNsplits = n; }
   void SetSplitMultipleTimes() { fSplitOnce = kFALSE; }
 
   inline void SetEnergyCut(Float_t emax) { EMax = emax; }
@@ -68,6 +69,7 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   Bool_t fUseCaveCoordinates = kFALSE;  //! set position from cave
 
   int32_t fNsplits;
+  int32_t fIntermediateNsplits;  // intermediate splits to use at each step before the particle decays
   Double_t fCurrentSurvivalFactor;  // survival factor at every step, if we
                                     // choose to split at every step
   Bool_t fSplitOnce =


### PR DESCRIPTION
Added intermediate splitting number (set to 2 by default) to avoid memory issues. Changed `CHANGELOG.md` accordingly, rather than adding an extra entry (since the fix is not merged yet).

I wonder if the `CHANGELOG.md` entry is still too long or if it doesn't matter.


## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to configure the number of intermediate kaon/pion splits per simulation step.
  - Updated multiple-splitting configuration so it uses the intermediate split factor when generating particle clones.

- **Bug Fixes**
  - Kaon/pion splitting now limits clone generation at each GEANT4 step, helping prevent excessive memory usage during simulations.

- **Documentation**
  - Updated the changelog and command-line help to describe the revised splitting behavior and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->