### PR TITLE
Fix residual kaon/pion splitting clone loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ it in future.
 * `veto` now registers the configured `sensitiveMed` instead of a hardcoded medium name; previously any other value resolved to a null `TGeoMedium`
 * Kaon/pion splitting no longer discards the whole clone set when the first track after the decay falls below the energy cut. This cost ~17% of the muons from charged-kaon decay in flight (−2.8% of the total muon rate) in split productions; pions were unaffected. Clones are now flushed only into tracks that survive the cut, and a warning is emitted if an event ends with clones still buffered
 * Split clones are no longer subject to the transport energy cut. A clone is the parent re-injected at its decay point, so re-applying the cut there discarded clone sets that an unsplit run keeps
+* The first track after a splitting decay now carries the buffered clones to the stack popper and is exempt from the energy and neutrino cuts, so a clone set can no longer be stranded in the buffer
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ it in future.
 * 2026 BDF target design (33 pure tungsten disks with a larger rear block, steel core with serpentine He cooling grooves, jacket tube, flanges, upstream beam window and cover plate, and domed rear endcap), extracted from CATIA model ST1A07710_01_AB.02. Select with `--target-yaml geometry/target_config_2026.yaml`; the legacy design remains the default. Downstream elements are positioned using the nominal legacy target length so both designs can be compared directly.
 * `--intermediate-kaon-pion-splits` (default 2): splitting factor applied to kaons and pions at each GEANT4 step before they decay, separate from the `--kaon-pion-splits` factor applied at the decay itself
 * `--max-split-buffer` (default 25000): hard bound on the split clones buffered per track. Per-step splitting stops once the cap is reached, reducing the statistical boost but conserving weight
+* `exitHadronAbsorber` reports the split-clone balance (decays split, clones created, clones never tracked and their weight) at the end of the run, including the final event's leftover buffer
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ it in future.
 
 * `veto` now registers the configured `sensitiveMed` instead of a hardcoded medium name; previously any other value resolved to a null `TGeoMedium`
 * Kaon/pion splitting no longer discards the whole clone set when the first track after the decay falls below the energy cut. This cost ~17% of the muons from charged-kaon decay in flight (−2.8% of the total muon rate) in split productions; pions were unaffected. Clones are now flushed only into tracks that survive the cut, and a warning is emitted if an event ends with clones still buffered
+* Split clones are no longer subject to the transport energy cut. A clone is the parent re-injected at its decay point, so re-applying the cut there discarded clone sets that an unsplit run keeps
 
 ### Removed
 

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -398,11 +398,23 @@ void exitHadronAbsorber::PreTrack() {
   fCurrentSurvivalFactor = 1.0;
 
   gMC->TrackMomentum(fMom);
-  if ((fMom.E() - fMom.M()) < EMax) {
+  TParticle* p = gMC->GetStack()->GetCurrentTrack();
+  Int_t currentID = gMC->GetStack()->GetCurrentTrackNumber();
+  Bool_t isClone = (fCloneTracks.find(currentID) != fCloneTracks.end());
+
+  if (!isClone && (fMom.E() - fMom.M()) < EMax) {
     // Do NOT flush the clone buffer into this track: it is stopped before its
     // first step, so the stack popper would never run for it and the pending
     // clones would be silently discarded at the next track's popper reset.
     // Keep the buffer for the next track that survives the cut.
+    //
+    // Clones are exempt from the cut. They are a bookkeeping device that has
+    // to decay immediately (ForceDecayTime(0)) so that the decay can be
+    // re-sampled, and their parent already passed the cut at the start of its
+    // own track. Applying the cut again at the decay point would drop decay
+    // products which an unsplit run keeps, because there the cut acts on the
+    // (possibly much harder) decay muon rather than on the parent. The decay
+    // products of the clones are cut as usual.
     gMC->StopTrack();
     return;
   }
@@ -419,10 +431,8 @@ void exitHadronAbsorber::PreTrack() {
     // Clear the buffer so we don't duplicate them for the next track
     fSecondaryBuffer.clear();
   }
-  TParticle* p = gMC->GetStack()->GetCurrentTrack();
-  Int_t currentID = gMC->GetStack()->GetCurrentTrackNumber();
 
-  if (fCloneTracks.find(currentID) != fCloneTracks.end()) {
+  if (isClone) {
     //  Force the decay time to 0
     gMC->ForceDecayTime(0);
   }

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -208,6 +208,8 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
             fSecondaryBuffer.push_back(clone);
           }
           fCurrentSurvivalFactor *= (1.0 - P_decay);
+          fSplitDecays++;
+          fClonesBuffered += fIntermediateNsplits;
           RequestCloneCarrier();
         }
       }
@@ -295,24 +297,32 @@ void exitHadronAbsorber::Initialize() {
 }
 
 void exitHadronAbsorber::BeginEvent() {
-  if (!fSecondaryBuffer.empty()) {
-    // No track surviving the energy cut followed the last splitting decay of
-    // the previous event, so its clones could not be handed to the stack
-    // popper and their weight is lost.
-    Double_t lostWeight = 0;
-    for (const auto& trk : fSecondaryBuffer) {
-      lostWeight += trk.weight;
-    }
-    LOG(warning) << "exitHadronAbsorber: discarding " << fSecondaryBuffer.size()
-                 << " buffered split clones (summed weight " << lostWeight
-                 << ") left over from the previous event";
-  }
+  DiscardBufferedClones();
   fCloneTracks.clear();
   fContinuationTracks.clear();
   fDecayedParentIDs.clear();
   fSecondaryBuffer.clear();
   fSplitBufferLimitWarned = kFALSE;
   fgCarrierTrackID = kNoCarrier;
+}
+
+void exitHadronAbsorber::DiscardBufferedClones() {
+  if (fSecondaryBuffer.empty()) {
+    return;
+  }
+  // No track carried these clones to the stack popper before the event
+  // ended, so their weight never made it into the simulation.
+  Double_t lostWeight = 0;
+  for (const auto& trk : fSecondaryBuffer) {
+    lostWeight += trk.weight;
+  }
+  fLostBufferEvents++;
+  fLostCloneTracks += static_cast<Int_t>(fSecondaryBuffer.size());
+  fLostCloneWeight += lostWeight;
+  LOG(warning) << "exitHadronAbsorber: discarding " << fSecondaryBuffer.size()
+               << " buffered split clones (summed weight " << lostWeight
+               << ") which no track handed to the stack popper";
+  fSecondaryBuffer.clear();
 }
 
 void exitHadronAbsorber::PostTrack() {
@@ -380,6 +390,8 @@ void exitHadronAbsorber::PostTrack() {
       }
       fCurrentSurvivalFactor = 0.0;
       fDecayedParentIDs.insert(currentTrackId);
+      fSplitDecays++;
+      fClonesBuffered += fNsplits;
       RequestCloneCarrier();
     }
 
@@ -512,6 +524,21 @@ void exitHadronAbsorber::PreTrack() {
 }
 
 void exitHadronAbsorber::FinishRun() {
+  // BeginEvent only sees the buffer of the previous event, so the last event
+  // of the run has to be checked here.
+  DiscardBufferedClones();
+  if (fNsplits > 0) {
+    LOG(info) << "exitHadronAbsorber: split " << fSplitDecays
+              << " times, creating " << fClonesBuffered << " clones";
+    if (fLostBufferEvents > 0) {
+      LOG(warning) << "exitHadronAbsorber: " << fLostBufferEvents
+                   << " event(s) ended with buffered split clones, losing "
+                   << fLostCloneTracks << " clones of summed weight "
+                   << fLostCloneWeight;
+    } else {
+      LOG(info) << "exitHadronAbsorber: every buffered split clone was tracked";
+    }
+  }
   for (Int_t idnu = 11; idnu < 23; idnu += 1) {
     // nu or anti-nu
     for (Int_t idadd = -1; idadd < 3; idadd += 2) {

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -41,6 +41,8 @@ constexpr Double_t cm = 1;         // cm
 constexpr Double_t m = 100 * cm;   //  m
 constexpr Double_t mm = 0.1 * cm;  //  mm
 
+Int_t exitHadronAbsorber::fgCarrierTrackID = exitHadronAbsorber::kNoCarrier;
+
 exitHadronAbsorber::exitHadronAbsorber(const char* Name, Bool_t Active)
     : Detector(Name, Active, kVETO),
       fOnlyMuons(kFALSE),
@@ -206,6 +208,7 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
             fSecondaryBuffer.push_back(clone);
           }
           fCurrentSurvivalFactor *= (1.0 - P_decay);
+          RequestCloneCarrier();
         }
       }
     }
@@ -309,6 +312,7 @@ void exitHadronAbsorber::BeginEvent() {
   fDecayedParentIDs.clear();
   fSecondaryBuffer.clear();
   fSplitBufferLimitWarned = kFALSE;
+  fgCarrierTrackID = kNoCarrier;
 }
 
 void exitHadronAbsorber::PostTrack() {
@@ -376,6 +380,7 @@ void exitHadronAbsorber::PostTrack() {
       }
       fCurrentSurvivalFactor = 0.0;
       fDecayedParentIDs.insert(currentTrackId);
+      RequestCloneCarrier();
     }
 
     // tracks which do not decay are stopped with stoptrack and added back with
@@ -402,11 +407,27 @@ void exitHadronAbsorber::PreTrack() {
   Int_t currentID = gMC->GetStack()->GetCurrentTrackNumber();
   Bool_t isClone = (fCloneTracks.find(currentID) != fCloneTracks.end());
 
-  if (!isClone && (fMom.E() - fMom.M()) < EMax) {
+  // Claim the carrier for the clones buffered by the last splitting decay. A
+  // decay always puts its daughters on the stack, so some track always follows
+  // it; only the cuts below can strand the buffer until the event ends.
+  Bool_t isCarrier =
+      (fgCarrierTrackID == kCarrierRequested || fgCarrierTrackID == currentID);
+  if (fgCarrierTrackID == kCarrierRequested) {
+    fgCarrierTrackID = currentID;
+  }
+
+  Bool_t belowCut = (fMom.E() - fMom.M()) < EMax;
+
+  if (!isClone && !isCarrier && belowCut) {
     // Do NOT flush the clone buffer into this track: it is stopped before its
     // first step, so the stack popper would never run for it and the pending
     // clones would be silently discarded at the next track's popper reset.
-    // Keep the buffer for the next track that survives the cut.
+    // The designated carrier is exempt so that it does step, and is dropped
+    // from the scoring below instead. ProcessHits does not score it either: it
+    // is a daughter of a split decay, which fDecayedParentIDs excludes. Its
+    // secondaries are still transported and can be scored if they pass the
+    // cut, which costs one sub-threshold track's worth of extra physics per
+    // splitting decay.
     //
     // Clones are exempt from the cut. They are a bookkeeping device that has
     // to decay immediately (ForceDecayTime(0)) so that the decay can be
@@ -435,6 +456,13 @@ void exitHadronAbsorber::PreTrack() {
   if (isClone) {
     //  Force the decay time to 0
     gMC->ForceDecayTime(0);
+  }
+
+  if (!isClone && belowCut) {
+    // Only a carrier gets here: it has handed the clones over and still has to
+    // step so the stack popper runs, but an unsplit run would have stopped it
+    // above, so it must not reach the histograms or the ntuple.
+    return;
   }
 
   Int_t pdgCode = p->GetPdgCode();
@@ -476,7 +504,8 @@ void exitHadronAbsorber::PreTrack() {
       fNtuple->Fill(pdgCode, fMom.Px(), fMom.Py(), fMom.Pz(), fPos.X(),
                     fPos.Y(), fPos.Z());
     }
-    if (fSkipNeutrinos && (idabs == 12 || idabs == 14 || idabs == 16)) {
+    if (fSkipNeutrinos && !isCarrier &&
+        (idabs == 12 || idabs == 14 || idabs == 16)) {
       gMC->StopTrack();
     }
   }

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -72,6 +72,10 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   // Ask for the next track to carry the clones just added to the buffer.
   static void RequestCloneCarrier() { fgCarrierTrackID = kCarrierRequested; }
 
+  // Drop the clones still buffered at the end of an event or run, keeping
+  // track of how much weight was never simulated.
+  void DiscardBufferedClones();
+
   Int_t fUniqueID = 0;
   Bool_t fOnlyMuons;         //! flag if only muons should be stored
   Bool_t fSkipNeutrinos;     //! flag if neutrinos should be ignored
@@ -108,6 +112,12 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   std::set<Int_t> fCloneTracks;
   std::set<Int_t> fContinuationTracks;
   std::set<Int_t> fDecayedParentIDs;
+
+  Int_t fSplitDecays = 0;          //! decays replaced by clones
+  Int_t fClonesBuffered = 0;       //! clones created for those decays
+  Int_t fLostBufferEvents = 0;     //! events ending with unflushed clones
+  Int_t fLostCloneTracks = 0;      //! clones which were never tracked
+  Double_t fLostCloneWeight = 0.;  //! summed weight of those clones
 
   TFile* fout;               //!
   TClonesArray* fElectrons;  //!

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -59,6 +59,19 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   inline void SetUseCaveCoordinates() { fUseCaveCoordinates = kTRUE; }
 
  private:
+  // Hand the buffered clones of a splitting decay to the stack popper. They
+  // can only be popped during a step, so the first track after the decay is
+  // designated as their carrier and must not be stopped before it steps.
+  // The designation is shared by all instances: run_fixedTarget can add
+  // several sensitive planes and whichever is polled first would otherwise
+  // stop the carrier before the splitting instance ever sees it.
+  static constexpr Int_t kNoCarrier = -1;
+  static constexpr Int_t kCarrierRequested = -2;
+  static Int_t fgCarrierTrackID;  //!
+
+  // Ask for the next track to carry the clones just added to the buffer.
+  static void RequestCloneCarrier() { fgCarrierTrackID = kCarrierRequested; }
+
   Int_t fUniqueID = 0;
   Bool_t fOnlyMuons;         //! flag if only muons should be stored
   Bool_t fSkipNeutrinos;     //! flag if neutrinos should be ignored


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Stacked on #1389 — please review/merge that one first; the base of this PR is `fix-splitting-clone-loss`.

#1389 removes the dominant clone-loss channel, but instrumented runs afterwards still showed whole clone sets going missing for roughly 6 % of splitting decays. Two independent channels are responsible, and this PR closes both.

### 1. The energy cut was applied to the clones themselves

A clone is the parent kaon or pion re-injected at its decay point so the decay can be re-sampled. Its own `PreTrack` applied the `EMax` kinetic-energy cut a second time, although the parent had already passed that cut at the start of its own track. A parent that dropped below the cut before decaying therefore had every clone stopped before `ForceDecayTime(0)` could fire — while an unsplit run keeps such a decay and applies the cut to the decay muon instead, which for K → μν can be much harder than the parent.

Instrumented runs reproduce this deterministically: of 40 splitting decays in a 10k-event run, the 3 with a sub-threshold parent lost every clone and all 37 others were fine.

### 2. The clone buffer could be stranded until the end of the event

Clones are buffered at the decay and handed to the VMC stack in a later track's `PreTrack`, because `TG4StackPopper` only drains the stack during a step. If every track after the decay was stopped before its first step — by the energy cut, or by `SkipNeutrinos` — the buffer survived to the end of the event and was dropped in `ShipStack::Reset`.

A decay always puts its daughters on the stack, so a track always follows it. The first such track is now designated as the carrier and exempted from both stops so that it does step. This costs at most one sub-threshold track transported per splitting decay and cannot change the output: `ProcessHits` only scores crossings above the same cut, and no secondary of a sub-threshold track exceeds it. The designation is shared between instances because `run_fixedTarget` can add up to three sensitive planes and modules are polled in `AddModule` order, so a sibling plane would otherwise stop the carrier before the splitting instance sees it.

A third hypothesis — that a flushed buffer can go unpopped when the carrier takes a zero-length step — was checked and **refuted**: of 14 zero-length π⁰/η/Σ⁰ carriers in the instrumented logs, 12 delivered all 100 clones, and the 2 that did not are exactly the sub-threshold-parent events above. `TG4SteppingAction`'s exclusive-step rescue covers that case, so no retry machinery is needed.

### 3. The loss is now visible in production logs

The per-event warning could only see the buffer left by the *previous* event, so a clone set stranded in the last event of a run went unreported, and nothing summarised the total. `FinishRun` now inspects the buffer once more and reports how many times the splitting fired, how many clones it produced, and how many were never tracked. A production which reports a non-zero loss undercounts the corresponding decay channel.

## Verification

Runs use `run_fixedTarget` with `-e 5`, `--AddHadronAbsorberOnly`, and a scaled K± lifetime to turn decay-in-flight from a rare process into a common one (kaon gun for the loss counting, Pythia for the weighted comparison).

**Loss regression**

| | splitting decays | clone sets lost |
|---|---|---|
| before | ~36 600 | **544** |
| after | 36 622 | **0** |

The "before" figure counts only the stranded-buffer channel, since the sub-threshold-clone channel is silent without the fix, so it is a lower bound.

**Closure at the scoring plane**, split100 vs unsplit (18k vs 90k events): all muons **1.0096 ± 0.0247**, muons from charged-kaon decay **1.0132 ± 0.0248**, with the momentum spectrum agreeing bin by bin up to 160 GeV/c.

Two things worth flagging honestly:

- This configuration cannot resolve the *rate* impact of the fix (a paired comparison of the split runs before/after gives −6.3 % ± 3.5 %, i.e. 1.8σ). The per-event weighted sum is dominated by rare weight-≈1 decays, so the ×100 boost buys tail coverage rather than rate precision. The case for the fix rests on the direct clone-set accounting; the closure test's value here is confirming that the new carrier exemption introduces no bias.
- With `--multiple-kpi-splits` and the buffer cap from #1389, a 300-event run performs 297 137 splits producing 623 674 clones and loses none, so the mode is exercised too — but no physics closure is claimed for it.

Each commit builds on its own. `ci-fixed-target` is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kaon and pion splitting so buffered clone tracks are reliably processed after splitting.
  * Prevented clone and carrier tracks from being incorrectly stopped by energy or neutrino-selection cuts.
  * Added safeguards for buffered clones remaining at event or run completion.

* **Configuration**
  * Increased the maximum supported split-buffer capacity and documented its hard limit.

* **Monitoring**
  * Added reporting for split decays, buffered clones, lost clone events, untracked clone tracks, and untracked clone weight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->