### PR TITLE
fix(ci): give clang-tidy the conda include path

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -151,8 +151,11 @@ cmd = "ship-metrics-compare {{ reference }} {{ new }} --config .github/scripts/m
 # so the workflow can pass them in without fighting pixi's positional-args
 # expansion.
 
+# CMake leaves -I$CONDA_PREFIX/include out of compile_commands.json because it
+# is already in the conda gcc's implicit include path. It is not in clang's, so
+# clang-tidy fails to find the FairRoot headers when it replays those commands.
 [tasks.ci-clang-tidy]
-cmd = "bash -c 'set -o pipefail; echo $CPP_FILES | xargs -P $(nproc) -n 4 clang-tidy -p build/ 2>&1 | python .github/scripts/annotate_build.py'"
+cmd = "bash -c 'set -o pipefail; echo $CPP_FILES | xargs -P $(nproc) -n 4 clang-tidy -p build/ --extra-arg=-isystem$CONDA_PREFIX/include 2>&1 | python .github/scripts/annotate_build.py'"
 
 [tasks.ci-pyrefly]
 cmd = "pyrefly check --output-format=github $PY_FILES"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

CMake leaves `-I$CONDA_PREFIX/include` out of `compile_commands.json` — it is already in the implicit include path of the conda gcc the records were generated with, but not in clang's. clang-tidy replays those commands with clang, so every translation unit that reaches a FairRoot header fails to parse:

```
Detector/DetectorPoint.h:10:10: error: 'FairMCPoint.h' file not found
```

clang-tidy then exits non-zero and, under `set -o pipefail`, takes **Static analysis (PR diff)** down with it on every pull request that touches C++ — currently #1389, but it reproduces on any file that pulls in `DetectorPoint.h` (e.g. `veto/veto.cxx`, untouched by any open PR).

This is the next layer of the same problem as c0bdf35e9: with `stddef.h` resolved, the parse now gets far enough to reach the FairRoot includes. As that commit noted, diagnostics from the broken parse were unreliable — a `modernize-use-equals-default` warning reported against `exitHadronAbsorber` disappears once the translation unit parses properly.

Passing the directory as a *system* include keeps warnings from those headers suppressed.

Verified locally: `CPP_FILES="veto/veto.cxx muonShieldOptimization/exitHadronAbsorber.cxx" pixi run ci-clang-tidy` exits 0 with Errors 0 / Warnings 0; without the flag it exits 123.

## Checklist

- [ ] Changelog updated (if applicable) — CI-only, not applicable
- [x] Commit message follows [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `ci-clang-tidy` task so clang-tidy can locate FairRoot headers during static analysis.
- **Documentation**
  - Added an explanatory comment describing the required include path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->