### PR TITLE
feat(splitting): Add a cap on the size of the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ it in future.
 * 2026 BDF target design (33 pure tungsten disks with a larger rear block, steel core with serpentine He cooling grooves, jacket tube, flanges, upstream beam window and cover plate, and domed rear endcap), extracted from CATIA model ST1A07710_01_AB.02. Select with `--target-yaml geometry/target_config_2026.yaml`; the legacy design remains the default. Downstream elements are positioned using the nominal legacy target length so both designs can be compared directly.
 * `--intermediate-kaon-pion-splits` (default 2): splitting factor applied to kaons and pions at each GEANT4 step before they decay, separate from the `--kaon-pion-splits` factor applied at the decay itself
 * `--max-split-buffer` (default 25000): hard bound on the split clones buffered per track. Per-step splitting stops once the cap is reached, reducing the statistical boost but conserving weight
+* `--max-event-size` (default 5000000): hard bound on the event size, with the per-step splitting stopping once the cap is reached
 
 ### Changed
 

--- a/macro/run_fixedTarget.py
+++ b/macro/run_fixedTarget.py
@@ -106,6 +106,15 @@ ap.add_argument(
     "conserves weight",
 )
 ap.add_argument(
+    "--max-event-size",
+    type=int,
+    default=5_000_000,
+    help="EXPERTS ONLY: maximum size of the event (accounting for an extra safety factor  before further"
+         " per-step splitting is skipped. Memory safety valve for --multiple-kpi-splits;"
+         "lowering it reduces the statistical boost but conserves weight",
+)
+
+ap.add_argument(
     "--multiple-kpi-splits",
     action="store_true",
     help="split kaons and pions multiple times along the track path",
@@ -247,11 +256,19 @@ if args.multiple_kpi_splits and (args.kaon_pion_splits <= 0 or args.intermediate
     ap.error("--multiple-kpi-splits requires --kaon-pion-splits > 0 and --intermediate-kaon-pion-splits > 1")
 if args.max_split_buffer < 1:
     ap.error("--max-split-buffer must be >= 1")
+if args.max_event_size < 1:
+    ap.error("--max-event-size must be >= 1")
+
 if args.max_split_buffer < args.kaon_pion_splits:
     ap.error(
         "--max-split-buffer must be >= --kaon-pion-splits: the clones buffered when the parent "
         "decays have to fit under the cap"
     )
+if args.max_event_size < args.kaon_pion_splits:
+    ap.error(
+        "--max-event-size must be >= --kaon-pion-splits: the event size has to fit under the cap"
+    )
+
 
 
 if args.G4only:
@@ -418,6 +435,7 @@ if args.AddMuonShield or args.AddHadronAbsorberOnly:
 sensPlaneHA = ROOT.exitHadronAbsorber()
 sensPlaneHA.SetNSplits(args.kaon_pion_splits)
 sensPlaneHA.SetMaxSplitBuffer(args.max_split_buffer)
+sensPlaneHA.SetMaxEventSize(args.max_event_size)
 if args.multiple_kpi_splits:
     sensPlaneHA.SetSplitMultipleTimes()
     sensPlaneHA.SetIntermediateNSplits(args.intermediate_kaon_pion_splits)

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -79,6 +79,16 @@ void exitHadronAbsorber::SetMaxSplitBuffer(Int_t n) {
   fMaxSplitBuffer = static_cast<std::size_t>(n);
 }
 
+void exitHadronAbsorber::SetMaxEventSize(Int_t n) {
+  if (n < 1) {
+    LOG(error) << "exitHadronAbsorber: max event size must be >= 1, ignoring "
+               << n;
+    return;
+  }
+  fMaxEventSize = static_cast<std::size_t>(n);
+}
+
+
 Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
   /** This method is called from the MC stepping */
   TString volName = gMC->CurrentVolName();
@@ -162,10 +172,18 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
           // when the parent finally decays, so the buffer never exceeds
           // fMaxSplitBuffer. All terms are on the left to keep the unsigned
           // arithmetic from wrapping.
-          if (fSecondaryBuffer.size() +
-                  static_cast<std::size_t>(fIntermediateNsplits) +
-                  static_cast<std::size_t>(fNsplits) >
-              fMaxSplitBuffer) {
+          std::size_t secondaryBufferSize = fSecondaryBuffer.size();
+          std::size_t event_size = gMC->GetStack()->GetNtrack();
+
+          const std::size_t pending = secondaryBufferSize +
+                             static_cast<std::size_t>(fIntermediateNsplits) +
+                             static_cast<std::size_t>(fNsplits);
+          const bool bufferFull = pending > fMaxSplitBuffer;
+
+          // multiplying pending tracks by factor to account for showers
+          const int32_t shower_safety_factor = 500;
+          const bool eventFull  = event_size + pending * shower_safety_factor > fMaxEventSize;
+          if (bufferFull || eventFull) {
             // Skip the split for this step instead of truncating the buffer.
             // fCurrentSurvivalFactor is the weight ledger: leaving it untouched
             // means the weight we did not split off is still carried by the
@@ -173,16 +191,25 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
             // continuation track in PostTrack(). No weight is lost, only the
             // statistical boost is reduced.
             if (!fSplitBufferLimitWarned) {
-              LOG(warning) << "exitHadronAbsorber: intermediate split buffer "
-                              "reached "
-                           << fMaxSplitBuffer
-                           << " entries; skipping further per-step splitting "
-                              "for this track. Consider lowering "
-                              "--intermediate-kaon-pion-splits or raising "
-                              "--max-split-buffer.";
-              fSplitBufferLimitWarned = kTRUE;
+              if (bufferFull) {
+                 LOG(warning) << "exitHadronAbsorber: intermediate split buffer "
+                                 "reached "
+                              << secondaryBufferSize
+                              << " entries; skipping further per-step splitting "
+                                 "for this track. Consider lowering "
+                                 "--intermediate-kaon-pion-splits or raising "
+                                 "--max-split-buffer.";
+              } else {  // that means the event is full
+                 LOG(warning) << "exitHadronAbsorber: event size reached "
+                              << event_size
+                              << " entries; skipping further per-step splitting "
+                                 "for this track. Consider lowering "
+                                 "--intermediate-kaon-pion-splits or raising "
+                                 " --max-event-size.";
+              }
+            fSplitBufferLimitWarned = kTRUE;
             }
-            return kTRUE;
+          return kTRUE;
           }
 
           Double_t decayBranchWeight = fCurrentSurvivalFactor * P_decay;

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -47,6 +47,7 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   void SetNSplits(Int_t n) { fNsplits = n; }
   void SetIntermediateNSplits(Int_t n) { fIntermediateNsplits = n; }
   void SetMaxSplitBuffer(Int_t n);
+  void SetMaxEventSize(Int_t n);
   void SetSplitMultipleTimes() { fSplitOnce = kFALSE; }
 
   inline void SetEnergyCut(Float_t emax) { EMax = emax; }
@@ -83,6 +84,7 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
   // enough to leave room for the fNsplits endpoint clones PostTrack() appends,
   // and Initialize() rejects a cap that fNsplits alone would exceed.
   std::size_t fMaxSplitBuffer = 25000;
+  std::size_t fMaxEventSize = 5000000;
   // latch so the split-buffer cap is reported at most once per event
   Bool_t fSplitBufferLimitWarned = kFALSE;  //!
   Double_t fCurrentSurvivalFactor;  // survival factor at every step, if we


### PR DESCRIPTION
Added a cap on the stack size to avoid memory issues for large number of intermediate splits


## Checklist

- [ ] Changelog updated (if applicable)
- [ ] Commit message follows [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--max-event-size` command-line option, defaulting to 5,000,000.
  - Event processing now enforces a hard limit on event size during kaon and pion splitting.
  - The configured limit must be positive and at least as large as the split count.
  - Clear warnings indicate when event-size or buffering limits prevent further splitting.

- **Documentation**
  - Documented the new command-line option in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->