### PR TITLE
Keep the split parent's weight in step with the survival ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ it in future.
 
 * `veto` now registers the configured `sensitiveMed` instead of a hardcoded medium name; previously any other value resolved to a null `TGeoMedium`
 * Kaon/pion splitting no longer discards the whole clone set when the track that follows the decay is stopped before it takes a step. The energy cut cost ~17% of the muons from charged-kaon decay in flight (−2.8% of the total muon rate) in split productions; pions were unaffected. `--skipNeutrinos` was a second route into the same loss, and left nothing in the log. Clones are now handed only to tracks that are still alive at the end of `PreTrack`, and a warning is emitted if an event ends with clones still buffered
+* Per-step kaon/pion splitting now lowers the weight of the parent kaon or pion as weight is split off into clones. The survival factor was only kept internally before, so a parent that ended by interacting rather than decaying still contributed its own hit at the sensitive plane, and the secondaries of that interaction, at full weight. Only `--multiple-kpi-splits` runs are affected; with `--kaon-pion-splits` alone no weight is split off before the decay
 
 ### Removed
 

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -114,10 +114,9 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
     }
   }
 
-  // Both counts have to be positive: PostTrack() only stops the parent and
-  // hands on the remaining weight when fNsplits > 0, so buffering per-step
-  // clones with fNsplits == 0 would leave the parent carrying its full weight
-  // alongside the clones.
+  // Both counts have to be positive: PostTrack() only terminates the ledger,
+  // handing what is left of it to the endpoint clones, when fNsplits > 0.
+  // run_fixedTarget.py pairs the two options for the same reason.
   if (fNsplits > 0 && fIntermediateNsplits > 0 && (!fSplitOnce)) {
     Int_t currentTrackId = gMC->GetStack()->GetCurrentTrackNumber();
 
@@ -204,7 +203,20 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
             clone.parentID = trueParentId;
             fSecondaryBuffer.push_back(clone);
           }
+          // The clone weights above are relative to trueParentId, because
+          // ShipStack::PushTrack multiplies a pushed weight by the weight of
+          // the track it names as parent. The parent's own weight, relative
+          // to that same track, has to follow the ledger down from 1 to
+          // fCurrentSurvivalFactor, otherwise everything it goes on to do
+          // still counts at full weight: its hit at the sensitive plane, and
+          // the secondaries it makes if it ends by interacting rather than
+          // decaying. Scaling it here keeps parent + clones equal to the
+          // weight the parent started with at every step. Geant4 pushes a
+          // secondary onto the VMC stack when that secondary starts tracking,
+          // which is after the parent is done, so the secondaries pick this
+          // up on their own.
           fCurrentSurvivalFactor *= (1.0 - P_decay);
+          part->SetWeight(part->GetWeight() * (1.0 - P_decay));
         }
       }
     }

--- a/muonShieldOptimization/exitHadronAbsorber.cxx
+++ b/muonShieldOptimization/exitHadronAbsorber.cxx
@@ -121,8 +121,7 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
   if (fNsplits > 0 && fIntermediateNsplits > 0 && (!fSplitOnce)) {
     Int_t currentTrackId = gMC->GetStack()->GetCurrentTrackNumber();
 
-    if (fCloneTracks.count(currentTrackId) > 0 ||
-        fContinuationTracks.count(currentTrackId) > 0) {
+    if (fCloneTracks.count(currentTrackId) > 0) {
       return kTRUE;
     }
 
@@ -169,9 +168,9 @@ Bool_t exitHadronAbsorber::ProcessHits(FairVolume* vol) {
             // Skip the split for this step instead of truncating the buffer.
             // fCurrentSurvivalFactor is the weight ledger: leaving it untouched
             // means the weight we did not split off is still carried by the
-            // track and is handed to the natural-decay clones or the
-            // continuation track in PostTrack(). No weight is lost, only the
-            // statistical boost is reduced.
+            // track, and reaches the natural-decay clones in PostTrack() if
+            // the track ends in a decay. The total weight the track
+            // contributes is unchanged, only the statistical boost is reduced.
             if (!fSplitBufferLimitWarned) {
               LOG(warning) << "exitHadronAbsorber: intermediate split buffer "
                               "reached "
@@ -305,7 +304,6 @@ void exitHadronAbsorber::BeginEvent() {
                  << ") left over from the previous event";
   }
   fCloneTracks.clear();
-  fContinuationTracks.clear();
   fDecayedParentIDs.clear();
   fSecondaryBuffer.clear();
   fSplitBufferLimitWarned = kFALSE;
@@ -314,8 +312,7 @@ void exitHadronAbsorber::BeginEvent() {
 void exitHadronAbsorber::PostTrack() {
   Int_t currentTrackId = gMC->GetStack()->GetCurrentTrackNumber();
 
-  if (fCloneTracks.count(currentTrackId) > 0 ||
-      fContinuationTracks.count(currentTrackId) > 0) {
+  if (fCloneTracks.count(currentTrackId) > 0) {
     return;
   }
 
@@ -325,7 +322,6 @@ void exitHadronAbsorber::PostTrack() {
 
   if (fNsplits > 0 && kaon_or_pion) {
     bool isNaturalDecay = false;
-    bool isParticleDestroyed = gMC->IsTrackStop() || gMC->IsTrackDisappeared();
     TArrayI processes;
     gMC->StepProcesses(processes);
     for (int i = 0; i < processes.GetSize(); i++) {
@@ -349,8 +345,6 @@ void exitHadronAbsorber::PostTrack() {
     polY = polVector.Y();
     polZ = polVector.Z();
     Int_t trueParentId = part->GetFirstMother();
-
-    auto* stack = dynamic_cast<ShipStack*>(gMC->GetStack());
 
     // All remaining weight used if cloning happens at point where original
     // particle decays
@@ -378,17 +372,13 @@ void exitHadronAbsorber::PostTrack() {
       fDecayedParentIDs.insert(currentTrackId);
     }
 
-    // tracks which do not decay are stopped with stoptrack and added back with
-    // a given weight
-    if (!isNaturalDecay && !isParticleDestroyed && stack) {
-      Int_t ntr;
-      stack->PushTrack(1, trueParentId, track_pid, finalMom.Px(), finalMom.Py(),
-                       finalMom.Pz(), finalMom.E(), finalPos.X(), finalPos.Y(),
-                       finalPos.Z(), finalPos.T(), polX, polY, polZ,
-                       kPNoProcess, ntr, fCurrentSurvivalFactor, 999);
-      fContinuationTracks.insert(ntr);
-    }
-
+    // A track that ends any other way keeps the remaining weight itself, so
+    // there is nothing to hand on. Geant4 never gives us a track that is
+    // still going: G4TrackingManager steps while the status is fAlive or
+    // fStopButAlive, TG4TrackingAction::PostUserTrackingAction skips
+    // PostTrack for fSuspend, and IsTrackStop() covers every status that is
+    // left. StopTrack() stays because it is the one call here that can still
+    // matter for a status other than fStopAndKill.
     gMC->StopTrack();
   }
 }

--- a/muonShieldOptimization/exitHadronAbsorber.h
+++ b/muonShieldOptimization/exitHadronAbsorber.h
@@ -93,7 +93,6 @@ class exitHadronAbsorber : public SHiP::Detector<vetoPoint> {
 
   std::vector<TrackBuffer> fSecondaryBuffer;
   std::set<Int_t> fCloneTracks;
-  std::set<Int_t> fContinuationTracks;
   std::set<Int_t> fDecayedParentIDs;
 
   TFile* fout;               //!


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Stacked on #1389.

`PostTrack()` had a branch for a kaon or pion whose transport was not over yet, which pushed a continuation track carrying the remaining weight. Geant4 never hands us such a track:

* `G4TrackingManager::ProcessOneTrack` steps while the status is `fAlive` or `fStopButAlive`, so the loop exits only for `fStopAndKill`, `fKillTrackAndSecondaries`, `fSuspend` or `fPostponeToNextEvent`.
* `TG4TrackingAction::PostUserTrackingAction` calls `PostTrack()` only when the status is not `fSuspend` and the track was not interrupted.
* `TG4StepManager::IsTrackStop()` is true for every status that is left.

So `isParticleDestroyed` was always true, the branch never ran, and `fContinuationTracks` stayed empty. The first commit removes it together with the set and its two lookups, and corrects the buffer cap comment that described the weight going to a continuation track. Behaviour is unchanged.

That exposes the bug the branch could never have fixed. Per-step splitting moves weight `S*P` into clones at every step and reduces the survival factor `S`, but `S` was only a bookkeeping variable: the parent's own weight stayed where it started. Everything the parent went on to do therefore counted at full weight, in particular its hit at the sensitive plane and the secondaries it made when it ended by interacting instead of decaying, overcounting that branch by `1/S`. The second commit scales the parent's weight by the same `1 - P` factor.

The clone weights need no change, since `ShipStack::PushTrack` multiplies a pushed weight by the weight of the track named as its parent, and a clone names the split parent's mother. Geant4 pushes a secondary onto the VMC stack once that secondary starts tracking, which is after the parent is done, so the secondaries pick up the reduced weight on their own. Runs with `--kaon-pion-splits` alone are unaffected: the per-step block is guarded by `!fSplitOnce`, so `S` stays 1 there.

### Checks

15 events with `--kaon-pion-splits 5 --multiple-kpi-splits --intermediate-kaon-pion-splits 2`. For 135 of the 157 split parents that can be reconstructed from the output, the residual `|parent + clones - initial|` is well below the summed clone weight, with a median of 2.4% of it. Before this change that ratio is 1 by construction. The other 22 parents, and the floor at about 1e-7, come from the reconstruction rather than from the physics: `ShipStack` drops and remaps tracks so some clones land under the wrong mother, and `fW` is a `Double32_t` stored as a float.

Left alone: the daughters of a natural decay still carry `W*S` in the track array and are kept out of the sensitive plane only by `fDecayedParentIDs`. #1398 will need a one line merge where `fContinuationTracks.clear()` disappears from `BeginEvent()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected particle-weight handling for per-step kaon/pion splitting.
  - In runs using `--multiple-kpi-splits`, the parent particle’s weight is now reduced as weight is distributed among clones.
  - Ensured the parent and its clones collectively retain the original weight, with resulting secondary particles receiving the appropriate reduced weight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->